### PR TITLE
Add support for uuid names

### DIFF
--- a/x/name/keeper/keeper.go
+++ b/x/name/keeper/keeper.go
@@ -244,10 +244,11 @@ func (keeper Keeper) Normalize(ctx sdk.Context, name string) (string, error) {
 	for _, comp := range strings.Split(name, ".") {
 		comp = strings.ToLower(strings.TrimSpace(comp))
 		lenComp := uint32(len(comp))
+		isUUID := isValidUUID(comp)
 		if lenComp < keeper.GetMinSegmentLength(ctx) {
 			return "", types.ErrNameSegmentTooShort
 		}
-		if lenComp > keeper.GetMaxSegmentLength(ctx) {
+		if lenComp > keeper.GetMaxSegmentLength(ctx) && !isUUID {
 			return "", types.ErrNameSegmentTooLong
 		}
 		if !isValid(comp) {

--- a/x/name/keeper/keeper_test.go
+++ b/x/name/keeper/keeper_test.go
@@ -43,9 +43,8 @@ func normalizeName(t *testing.T, ctx sdk.Context, keeper keeper.Keeper) {
 		{"allow single dash per comp", args{name: "test-field.my-service.pio"}, "test-field.my-service.pio", false},
 		{"allow digits", args{name: "test.normalize.v1.pio"}, "test.normalize.v1.pio", false},
 		{"allow unicode chars", args{name: "tœst.nørmålize.v1.pio"}, "tœst.nørmålize.v1.pio", false},
-		// TODO -- this uuid is rejected due to name length constraints, need to resolve.
-		// {"allow uuid as comp", args{name: "6443a1e8-ec9b-4ff1-b200-d639424bcba4.service.pb"},
-		// 	"6443a1e8-ec9b-4ff1-b200-d639424bcba4.service.pb", false},
+		{"allow uuid as comp", args{name: "6443a1e8-ec9b-4ff1-b200-d639424bcba4.service.pb"},
+			"6443a1e8-ec9b-4ff1-b200-d639424bcba4.service.pb", false},
 		// Invalid names / components
 		{"fail on empty name", args{name: ""}, "", true},
 		{"fail when too short", args{name: "z"}, "", true},


### PR DESCRIPTION
Change check to only enforce size constraint if it isn't a valid UUID.