### PR TITLE
Add provenance denom metadata to testnet

### DIFF
--- a/cmd/provenanced/cmd/testnet.go
+++ b/cmd/provenanced/cmd/testnet.go
@@ -305,15 +305,36 @@ func initGenFiles(
 	authGenState.Accounts = accounts
 	appGenState[authtypes.ModuleName] = clientCtx.JSONMarshaler.MustMarshalJSON(&authGenState)
 
+	// PROVENANCE SPECIFIC CONFIG
+	// ----------------------------------------
+
 	// set the balances in the genesis state
 	var bankGenState banktypes.GenesisState
 	clientCtx.JSONMarshaler.MustUnmarshalJSON(appGenState[banktypes.ModuleName], &bankGenState)
 
 	bankGenState.Balances = genBalances
+	nhashDenomUnit := banktypes.DenomUnit{
+		Exponent: 0,
+		Denom:    "nhash",
+		Aliases:  []string{"nanohash"},
+	}
+	hashDenomUnit := banktypes.DenomUnit{
+		Exponent: 9,
+		Denom:    "hash",
+	}
+	denomUnits := []*banktypes.DenomUnit{
+		&hashDenomUnit,
+		&nhashDenomUnit,
+	}
+	bankGenState.DenomMetadata = []banktypes.Metadata{
+		banktypes.Metadata{
+			Description: "The native staking token of the Provenance Blockchain.",
+			Display:     "hash",
+			Base:        "nhash",
+			DenomUnits:  denomUnits,
+		},
+	}
 	appGenState[banktypes.ModuleName] = clientCtx.JSONMarshaler.MustMarshalJSON(&bankGenState)
-
-	// PROVENANCE SPECIFIC CONFIG
-	// ----------------------------------------
 
 	// Set the staking denom
 	var stakeGenState stakingtypes.GenesisState

--- a/cmd/provenanced/cmd/testnet.go
+++ b/cmd/provenanced/cmd/testnet.go
@@ -326,14 +326,13 @@ func initGenFiles(
 		&hashDenomUnit,
 		&nhashDenomUnit,
 	}
-	bankGenState.DenomMetadata = []banktypes.Metadata{
-		banktypes.Metadata{
-			Description: "The native staking token of the Provenance Blockchain.",
-			Display:     "hash",
-			Base:        "nhash",
-			DenomUnits:  denomUnits,
-		},
+	denomMetadata := banktypes.Metadata{
+		Description: "The native staking token of the Provenance Blockchain.",
+		Display:     "hash",
+		Base:        "nhash",
+		DenomUnits:  denomUnits,
 	}
+	bankGenState.DenomMetadata = []banktypes.Metadata{denomMetadata}
 	appGenState[banktypes.ModuleName] = clientCtx.JSONMarshaler.MustMarshalJSON(&bankGenState)
 
 	// Set the staking denom


### PR DESCRIPTION
This adds the provenance specific denomination metadata to the genesis file for the testnet.