### PR TITLE
Use no-op upgrade handlers for testnet releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,5 +73,5 @@ into new 0.40.x base.  Minimal unit test coverage and features in place to begin
 * Test tag prior to initial testnet release.
 
 The Provenance Blockchain was started by Figure Technologies in 2018 using a Hyperledger Fabric derived private network.
-A subsequent migration was made to a new internal private network based on the 0.38-0.39 series of Cosmos SDK and 
-Tendermint.  The Provence-IO/Provenance Cosmos SDK derived public network is the 
+A subsequent migration was made to a new internal private network based on the 0.38-0.39 series of Cosmos SDK and
+Tendermint.  The Provence-IO/Provenance Cosmos SDK derived public network is the

--- a/app/app.go
+++ b/app/app.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -562,6 +563,35 @@ func New(
 		),
 	)
 	app.SetEndBlocker(app.EndBlocker)
+
+	// A data structure for setting upgrade plans that need to actually do something.
+	// WARNING: Once deployed to a network, NEVER change or remove these handlers.
+	explicitUpgradePlans := map[string]upgradetypes.UpgradeHandler{
+		"v0.6.9": func(ctx sdk.Context, plan upgradetypes.Plan) {
+			// Also a no-op, but here's where developers can do something specific for a release.
+		},
+	}
+
+	// The max major/minor/patch release versions
+	// TODO: Expand version range and make dynamic (build tags would be ideal).
+	majorVersion, maxMinorVersion, maxPatchVersion := 0, 10, 100
+
+	// For testnet release v0.1.1 through v0.10.100, set a no-op handler unless explicitly set above.
+	// This is here so developers don't need to do anything for frequent testnet releases and, in theory,
+	// cosmovisor upgrades should just work.
+	for i := 1; i <= maxMinorVersion; i++ {
+		for j := 1; j <= maxPatchVersion; j++ {
+			name := fmt.Sprintf("v%d.%d.%d", majorVersion, i, j)
+			if handler, ok := explicitUpgradePlans[name]; ok {
+				logger.Info("Setting explicit upgrade handler", "name", name)
+				app.UpgradeKeeper.SetUpgradeHandler(name, handler)
+			} else {
+				app.UpgradeKeeper.SetUpgradeHandler(name, func(ctx sdk.Context, plan upgradetypes.Plan) {
+					logger.Info("Executing no-op update plan", "name", name)
+				})
+			}
+		}
+	}
 
 	if loadLatest {
 		if err := app.LoadLatestVersion(); err != nil {


### PR DESCRIPTION
This PR adds no-op upgrade handlers for a range of testnet release versions to make cosmovisor happy.
This addresses only one of a set of changes required for #30 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
