### PR TITLE
[v0.1.5] - Add custom bank send encoder for provwasm

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -112,6 +112,7 @@ import (
 	wasmclient "github.com/CosmWasm/wasmd/x/wasm/client"
 
 	"github.com/provenance-io/provenance/internal/provwasm"
+	provwasmbank "github.com/provenance-io/provenance/internal/provwasm/custom/bank"
 )
 
 const (
@@ -367,6 +368,7 @@ func New(
 	encoderRegistry.RegisterEncoder(nametypes.RouterKey, namewasm.Encoder)
 	encoderRegistry.RegisterEncoder(attributetypes.RouterKey, attributewasm.Encoder)
 	encoderRegistry.RegisterEncoder(markertypes.RouterKey, markerwasm.Encoder)
+	encoderRegistry.RegisterEncoder(provwasmbank.RouterKey, provwasmbank.Encoder)
 
 	// Init CosmWasm query integrations
 	querierRegistry := provwasm.NewQuerierRegistry()

--- a/internal/provwasm/custom/bank/encode.go
+++ b/internal/provwasm/custom/bank/encode.go
@@ -1,0 +1,71 @@
+package bank
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/provenance-io/provenance/internal/provwasm"
+
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// RouterKey is the registry key for the provwasm custom bank encoder
+const RouterKey = "bank"
+
+// Compile time interface check
+var _ provwasm.Encoder = Encoder
+
+// CustomBankMsgParams are params for wrapping bank []sdk.Msg types.
+type CustomBankMsgParams struct {
+	// Encode a bank send message
+	Send *SendParams `json:"send,omitempty"`
+}
+
+// SendParams are params for encoding a MsgSend.
+type SendParams struct {
+	// The sender
+	To string `json:"to"`
+	// The recipient
+	From string `json:"from"`
+	// The funds to send
+	Coins sdk.Coins `json:"coins"`
+}
+
+// Encoder returns a smart contract message encoder for bank sends.
+func Encoder(contract sdk.AccAddress, msg json.RawMessage, version string) ([]sdk.Msg, error) {
+	wrapper := struct {
+		Params *CustomBankMsgParams `json:"bank"`
+	}{}
+	if err := json.Unmarshal(msg, &wrapper); err != nil {
+		return nil, fmt.Errorf("wasm: failed to unmarshal bank encode params: %w", err)
+	}
+	params := wrapper.Params
+	if params == nil {
+		return nil, fmt.Errorf("wasm: nil bank encode params")
+	}
+	switch {
+	case params.Send != nil:
+		return params.Send.Encode(contract)
+	default:
+		return nil, fmt.Errorf("wasm: invalid bank encode request: %s", string(msg))
+	}
+}
+
+// Encode creates a MsgSend.
+func (params *SendParams) Encode(contract sdk.AccAddress) ([]sdk.Msg, error) {
+	from, err := sdk.AccAddressFromBech32(params.From)
+	if err != nil {
+		return nil, fmt.Errorf("wasm: invalid from address: %w", err)
+	}
+	to, err := sdk.AccAddressFromBech32(params.To)
+	if err != nil {
+		return nil, fmt.Errorf("wasm: invalid to address: %w", err)
+	}
+	if err := params.Coins.Validate(); err != nil {
+		return nil, fmt.Errorf("wasm: invalid coins: %w", err)
+	}
+	msg := banktypes.NewMsgSend(from, to, params.Coins)
+	return []sdk.Msg{msg}, nil
+}


### PR DESCRIPTION
This PR adds a custom bank send encoder for provwasm smart contracts.  This enables marker transfers and bank sends to be used from the same `handle` or `init` function.  The Rust bindings and `marker` smart contract were extended to integration test this integration successfully.

closes #98 

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
