### PR TITLE
remove todo comments for marker value owner

### DIFF
--- a/x/marker/keeper/marker.go
+++ b/x/marker/keeper/marker.go
@@ -529,7 +529,6 @@ func (k Keeper) DeleteMarker(ctx sdk.Context, caller sdk.AccAddress, denom strin
 	if err != nil {
 		return fmt.Errorf("could not decrease marker supply %s: %s", denom, err)
 	}
-	// TODO: check metadata module for scopes with this marker assigned, if found this delete call fails
 
 	// get the updated state of the marker afer supply burn...
 	m, err = k.GetMarkerByDenom(ctx, denom)

--- a/x/marker/keeper/querier.go
+++ b/x/marker/keeper/querier.go
@@ -41,7 +41,6 @@ func queryMarker(ctx sdk.Context, path []string, _ abci.RequestQuery, keeper Kee
 		return nil, err
 	}
 
-	// TODO : insufficient as it will not return a list of the assets within the acccount without a separate query.
 	res, err := codec.MarshalJSONIndent(legacyQuerierCdc, account)
 	if err != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Removes todo comments for this feature and closes #45.  This feature can not be implemented in the metadata module without adding a dependency on the metadata module (not a great idea).  The ValueOwner query support is implemented in metadata already (https://github.com/provenance-io/provenance/blob/82469ece04db9c03f84266c7bd023c3d4fddd82a/x/metadata/keeper/query_server.go#L169)

The Delete method of the Marker only assigns the Destroyed status to a marker (it does not fully remove it) so references can be maintained to existing scopes via value-ownership.

closes: #45 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
