### PR TITLE
update for provenance key command using wrong default coin type

### DIFF
--- a/cmd/provenanced/cmd/root.go
+++ b/cmd/provenanced/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -41,8 +42,12 @@ import (
 	"github.com/provenance-io/provenance/app"
 )
 
-// EnvTypeFlag is a flag for indicating a testnet
-const EnvTypeFlag = "testnet"
+const (
+	// EnvTypeFlag is a flag for indicating a testnet
+	EnvTypeFlag = "testnet"
+	// Flag used to indicate coin type.
+	CoinTypeFlag = "coin-type"
+)
 
 // ChainID is the id of the running chain
 var ChainID string
@@ -81,6 +86,8 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 	overwriteFlagDefaults(rootCmd, map[string]string{
 		flags.FlagChainID:        ChainID,
 		flags.FlagKeyringBackend: "test",
+		// Override default value for coin-type to match our mainnet value.
+		CoinTypeFlag: fmt.Sprint(app.CoinTypeMainNet),
 	})
 
 	return rootCmd, encodingConfig


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Currently the `keys` sub command of `provenance` uses the default flag value of 118 which matches cosmos.  Due to the way this default is setup it is not overridden properly with the `-t` flag that switches to testnet/mainnet.  Because of this the default value should at least always match a Provenance network
closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
