### PR TITLE
Add metaaddress encoder and parser commands

### DIFF
--- a/cmd/provenanced/cmd/addresses.go
+++ b/cmd/provenanced/cmd/addresses.go
@@ -1,0 +1,141 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/provenance-io/provenance/x/metadata/types"
+	"github.com/spf13/cobra"
+)
+
+// AddMetaAddressParser returns metadata address parser cobra Command.
+func AddMetaAddressParser() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "metaaddress parse [metaaddress]",
+		Short: "Parse MetaAddress and display associate IDs and types",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			addr, parseErr := types.MetadataAddressFromBech32(args[1])
+			if parseErr != nil {
+				return parseErr
+			}
+			if addr.IsScopeAddress() {
+				scopeUUID, err := addr.ScopeUUID()
+				if err != nil {
+					return err
+				}
+
+				fmt.Fprintf(cmd.OutOrStdout(), `Type: Scope
+
+Scope UUID: %s
+`, scopeUUID)
+			}
+			if addr.IsSessionAddress() {
+				scopeUUID, err := addr.ScopeUUID()
+				if err != nil {
+					return err
+				}
+				scopeID := types.ScopeMetadataAddress(scopeUUID)
+				sessionUUID, err := addr.SessionUUID()
+				if err != nil {
+					return err
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), `Type: Session
+
+Scope Id: %s
+Scope UUID: %s
+Session UUID: %s
+`, scopeID, scopeUUID, sessionUUID)
+			}
+			if addr.IsRecordAddress() {
+				scopeUUID, _ := addr.ScopeUUID()
+				scopeID := types.ScopeMetadataAddress(scopeUUID)
+				fmt.Fprintf(cmd.OutOrStdout(), `Type: Record
+
+Scope Id: %s
+Scope UUID: %s
+`, scopeID, scopeUUID.String())
+			}
+			if addr.IsContractSpecificationAddress() {
+				contractSpecUUID, err := addr.ContractSpecUUID()
+				if err != nil {
+					return err
+				}
+
+				fmt.Fprintf(cmd.OutOrStdout(), `Type: Contract Specification
+
+Contract Specification UUID: %s
+`, contractSpecUUID)
+			}
+			if addr.IsScopeSpecificationAddress() {
+				scopeSpecUUID, err := addr.PrimaryUUID()
+				if err != nil {
+					return err
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), `Type: Scope Specification
+
+Scope Specification UUID: %s
+`, scopeSpecUUID)
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+// AddMetaAddressEncoder returns metadata address encoder cobra Command.
+func AddMetaAddressEncoder() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "metaaddress encode [type] [uuid] [uuid|name]",
+		Short: "Encodes metadata uuids to bech32 address for specific type",
+		Long: `Encodes metadata uuids to bech32 address for specific type. 
+		Types: scope,session,record,contract-specification,scope-specification`,
+		Args: cobra.RangeArgs(3, 4),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			primaryUUID, err := uuid.Parse(args[2])
+			if err != nil {
+				return err
+			}
+			switch addrType := args[1]; addrType {
+			case "scope":
+				if len(args) != 3 {
+					return fmt.Errorf("too many arguments for %s address encoder", addrType)
+				}
+				scopeAddr := types.ScopeMetadataAddress(primaryUUID)
+				fmt.Fprint(cmd.OutOrStdout(), scopeAddr.String())
+			case "session":
+				if len(args) != 4 {
+					return fmt.Errorf("missing secondary uuid for type session")
+				}
+				secondaryUUID, err := uuid.Parse(args[3])
+				if err != nil {
+					return err
+				}
+				sessionAddr := types.SessionMetadataAddress(primaryUUID, secondaryUUID)
+				fmt.Fprint(cmd.OutOrStdout(), sessionAddr.String())
+			case "record":
+				if len(args) != 4 {
+					return fmt.Errorf("missing name for type record")
+				}
+				recordAddr := types.RecordMetadataAddress(primaryUUID, args[3])
+				fmt.Fprint(cmd.OutOrStdout(), recordAddr.String())
+			case "contract-specification":
+				if len(args) != 3 {
+					return fmt.Errorf("too many arguments for %s address encoder", addrType)
+				}
+				contractSpecAddr := types.ContractSpecMetadataAddress(primaryUUID)
+				fmt.Fprint(cmd.OutOrStdout(), contractSpecAddr.String())
+			case "scope-specification":
+				if len(args) != 3 {
+					return fmt.Errorf("too many arguments for %s address encoder", addrType)
+				}
+				scopeSpecAddr := types.ScopeSpecMetadataAddress(primaryUUID)
+				fmt.Fprint(cmd.OutOrStdout(), scopeSpecAddr.String())
+			default:
+				return fmt.Errorf("unknown type: %s, Supported types: scope, session, record, contract-specification, scope-specification", addrType)
+			}
+			return nil
+		},
+	}
+	return cmd
+}

--- a/cmd/provenanced/cmd/addresses_test.go
+++ b/cmd/provenanced/cmd/addresses_test.go
@@ -1,0 +1,241 @@
+package cmd_test
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/provenance-io/provenance/cmd/provenanced/cmd"
+	"github.com/provenance-io/provenance/x/metadata/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddMetaAddressParser(t *testing.T) {
+	scopeUUID := uuid.New()
+	scopeID := types.ScopeMetadataAddress(scopeUUID)
+	sessionUUID := uuid.New()
+	sessionID := types.SessionMetadataAddress(scopeUUID, sessionUUID)
+	recordID := types.RecordMetadataAddress(scopeUUID, "this is a name")
+	contractSpecUUID := uuid.New()
+	contractSpecID := types.ContractSpecMetadataAddress(contractSpecUUID)
+	scopeSpecUUID := uuid.New()
+	scopeSpecID := types.ScopeSpecMetadataAddress(scopeSpecUUID)
+
+	tests := []struct {
+		name      string
+		addr      string
+		expected  string
+		expectErr bool
+	}{
+		{
+			name:      "test not an address",
+			addr:      "not an id",
+			expected:  "",
+			expectErr: true,
+		},
+		{
+			name:      "test scope address",
+			addr:      scopeID.String(),
+			expected:  fmt.Sprintf("Type: Scope\n\nScope UUID: %s\n", scopeUUID),
+			expectErr: false,
+		},
+		{
+			name:      "test session address",
+			addr:      sessionID.String(),
+			expected:  fmt.Sprintf("Type: Session\n\nScope Id: %s\nScope UUID: %s\nSession UUID: %s\n", scopeID, scopeUUID, sessionUUID),
+			expectErr: false,
+		},
+		{
+			name:      "test record address",
+			addr:      recordID.String(),
+			expected:  fmt.Sprintf("Type: Record\n\nScope Id: %s\nScope UUID: %s\n", scopeID, scopeUUID),
+			expectErr: false,
+		},
+		{
+			name:      "test contract spec id",
+			addr:      contractSpecID.String(),
+			expected:  fmt.Sprintf("Type: Contract Specification\n\nContract Specification UUID: %s\n", contractSpecUUID),
+			expectErr: false,
+		},
+		{
+			name:      "test scope specification address",
+			addr:      scopeSpecID.String(),
+			expected:  fmt.Sprintf("Type: Scope Specification\n\nScope Specification UUID: %s\n", scopeSpecUUID),
+			expectErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			command := cmd.AddMetaAddressParser()
+			command.SetArgs([]string{
+				"parse", tc.addr})
+			b := bytes.NewBufferString("")
+			command.SetOut(b)
+			if tc.expectErr {
+				require.Error(t, command.Execute())
+			} else {
+				require.NoError(t, command.Execute())
+				out, err := ioutil.ReadAll(b)
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, string(out))
+			}
+		})
+	}
+}
+
+func TestAddMetaAddressEncoder(t *testing.T) {
+	scopeUUID := uuid.New()
+	scopeID := types.ScopeMetadataAddress(scopeUUID)
+	sessionUUID := uuid.New()
+	sessionID := types.SessionMetadataAddress(scopeUUID, sessionUUID)
+	recordName := "this is a name"
+	recordID := types.RecordMetadataAddress(scopeUUID, recordName)
+	contractSpecUUID := uuid.New()
+	contractSpecID := types.ContractSpecMetadataAddress(contractSpecUUID)
+	scopeSpecUUID := uuid.New()
+	scopeSpecID := types.ScopeSpecMetadataAddress(scopeSpecUUID)
+
+	tests := []struct {
+		name      string
+		args      []string
+		expected  string
+		expectErr bool
+	}{
+		{
+			name:      "test scope address",
+			args:      []string{"encode", "scope", scopeUUID.String()},
+			expected:  scopeID.String(),
+			expectErr: false,
+		},
+		{
+			name:      "test scope address too many args",
+			args:      []string{"encode", "scope", scopeUUID.String(), scopeUUID.String()},
+			expected:  "",
+			expectErr: true,
+		},
+		{
+			name:      "test scope address invalid uuid",
+			args:      []string{"encode", "scope", "not an id"},
+			expected:  "",
+			expectErr: true,
+		},
+		{
+			name:      "test session address",
+			args:      []string{"encode", "session", scopeUUID.String(), sessionUUID.String()},
+			expected:  sessionID.String(),
+			expectErr: false,
+		},
+		{
+			name:      "test session address too few args",
+			args:      []string{"encode", "session", scopeUUID.String()},
+			expected:  "",
+			expectErr: true,
+		},
+		{
+			name:      "test session address too many args",
+			args:      []string{"encode", "session", scopeUUID.String(), sessionUUID.String(), sessionUUID.String()},
+			expected:  "",
+			expectErr: true,
+		},
+		{
+			name:      "test session address invalid first uuid",
+			args:      []string{"encode", "session", "not a uuid", sessionUUID.String()},
+			expected:  "",
+			expectErr: true,
+		},
+		{
+			name:      "test session address invalid second uuid",
+			args:      []string{"encode", "session", scopeUUID.String(), "not a uuid"},
+			expected:  "",
+			expectErr: true,
+		},
+		{
+			name:      "test record address",
+			args:      []string{"encode", "record", scopeUUID.String(), recordName},
+			expected:  recordID.String(),
+			expectErr: false,
+		},
+		{
+			name:      "test record address too few args",
+			args:      []string{"encode", "record", scopeUUID.String()},
+			expected:  "",
+			expectErr: true,
+		},
+		{
+			name:      "test record address too many args",
+			args:      []string{"encode", "record", scopeUUID.String(), recordName, recordName},
+			expected:  "",
+			expectErr: true,
+		},
+		{
+			name:      "test record address invalid uuid",
+			args:      []string{"encode", "record", "not a uuid", recordName},
+			expected:  "",
+			expectErr: true,
+		},
+		{
+			name:      "test contract spec id",
+			args:      []string{"encode", "contract-specification", contractSpecUUID.String()},
+			expected:  contractSpecID.String(),
+			expectErr: false,
+		},
+		{
+			name:      "test contract spec id too many args",
+			args:      []string{"encode", "contract-specification", contractSpecUUID.String(), contractSpecUUID.String()},
+			expected:  "",
+			expectErr: true,
+		},
+		{
+			name:      "test contract spec id invalid uuid",
+			args:      []string{"encode", "contract-specification", "not a uuid"},
+			expected:  "",
+			expectErr: true,
+		},
+		{
+			name:      "test scope specification address",
+			args:      []string{"encode", "scope-specification", scopeSpecUUID.String()},
+			expected:  scopeSpecID.String(),
+			expectErr: false,
+		},
+		{
+			name:      "test scope specification address too many args",
+			args:      []string{"encode", "scope-specification", scopeSpecUUID.String(), scopeSpecUUID.String()},
+			expected:  "",
+			expectErr: true,
+		},
+		{
+			name:      "test scope specification address invalid uuid",
+			args:      []string{"encode", "scope-specification", "not a uuid"},
+			expected:  "",
+			expectErr: true,
+		},
+		{
+			name:      "test scope invalid type",
+			args:      []string{"encode", "invalid type", scopeUUID.String()},
+			expected:  "",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			command := cmd.AddMetaAddressEncoder()
+			command.SetArgs(tc.args)
+			b := bytes.NewBufferString("")
+			command.SetOut(b)
+			if tc.expectErr {
+				require.Error(t, command.Execute())
+			} else {
+				require.NoError(t, command.Execute())
+				out, err := ioutil.ReadAll(b)
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, string(out))
+			}
+		})
+	}
+}

--- a/cmd/provenanced/cmd/root.go
+++ b/cmd/provenanced/cmd/root.go
@@ -121,6 +121,8 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 		tmcli.NewCompletionCmd(rootCmd, true),
 		testnetCmd(app.ModuleBasics, banktypes.GenesisBalancesIterator{}),
 		debug.Cmd(),
+		AddMetaAddressParser(),
+		AddMetaAddressEncoder(),
 	)
 
 	server.AddCommands(rootCmd, app.DefaultNodeHome(appName), newApp, createSimappAndExport, addModuleInitFlags)


### PR DESCRIPTION
## Description

Added a command to parse and encode meta addresses between uuids and bech32 addresses.

closes: #136

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
