### PR TITLE
Update upgrade handler to avoid unset param

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -26,11 +26,10 @@ type appUpgrade struct {
 
 var handlers = map[string]appUpgrade{
 	"v0.2.0": {},
-	"v0.2.1": {
+	"v0.2.1": {},
+	"v0.2.2": {
 		Handler: func(app *App, ctx sdk.Context, plan upgradetypes.Plan) {
-			existing := app.MarkerKeeper.GetParams(ctx)
-			existing.UnrestrictedDenomRegex = markertypes.DefaultUnrestrictedDenomRegex
-			app.MarkerKeeper.SetParams(ctx, existing)
+			app.MarkerKeeper.SetParams(ctx, markertypes.DefaultParams())
 		},
 	},
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

0.2.1 upgrade handler pulled existing parameters for marker module which fails due to new parameter that is missing.  This update changes behavior such that params are set directly to the defaults to avoid this read error.

closes: #155 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
