### PR TITLE
Stop custom store loader from loading everytime

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -576,7 +576,7 @@ func New(
 		panic(err)
 	}
 	// Currently in an upgrade hold for this block.
-	if upgradeInfo.Name != "" && upgradeInfo.Height == app.LastBlockHeight() + 1 {
+	if upgradeInfo.Name != "" && upgradeInfo.Height == app.LastBlockHeight()+1 {
 		app.Logger().Info("Managing upgrade",
 			"plan", upgradeInfo.Name,
 			"upgradeHeight", upgradeInfo.Height,

--- a/app/app.go
+++ b/app/app.go
@@ -569,7 +569,7 @@ func New(
 	// * https://pkg.go.dev/github.com/cosmos/cosmos-sdk@v0.40.0-rc6/x/upgrade#hdr-Performing_Upgrades
 	// * https://github.com/cosmos/cosmos-sdk/issues/8265
 	InstallCustomUpgradeHandlers(app)
-	// Use the dump of $home/data/upgrade.info:{"name":"$plan","height":321654} to determine
+	// Use the dump of $home/data/upgrade-info.json:{"name":"$plan","height":321654} to determine
 	// if we load a store upgrade from the handlers. No file == no error from read func.
 	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
 	if err != nil {

--- a/app/app.go
+++ b/app/app.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -573,9 +574,13 @@ func New(
 		panic(err)
 	}
 
-	storeLoader := CustomUpgradeStoreLoader(app, upgradeInfo)
-	if storeLoader != nil {
-		app.SetStoreLoader(storeLoader)
+	InstallCustomUpgradeHandlers(app)
+	fmt.Printf("name:%s height:%d current:%d", upgradeInfo.Name, upgradeInfo.Height, app.LastBlockHeight())
+	if upgradeInfo.Name != "" && upgradeInfo.Height == app.LastBlockHeight() + 1 {
+		storeLoader := CustomUpgradeStoreLoader(app, upgradeInfo)
+		if storeLoader != nil {
+			app.SetStoreLoader(storeLoader)
+		}
 	}
 	// --
 

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -54,20 +54,29 @@ func InstallCustomUpgradeHandlers(app *App) {
 
 // CustomUpgradeStoreLoader provides upgrade handlers for store and application module upgrades at specified versions
 func CustomUpgradeStoreLoader(app *App, info storetypes.UpgradeInfo) baseapp.StoreLoader {
-	// Current upgrade info is empty. Skip any possible store upgrades.
-	if info.Name == "" {
+	// Current upgrade info is empty or we are at the wrong height, skip this.
+	if info.Name == "" || info.Height - 1 != app.LastBlockHeight() {
 		return nil
 	}
 	// Find the upgrade handler that matches this currently executing upgrade.
 	for name, upgrade := range handlers {
 		// If the plan is executing this block, set the store locator to create any
 		// missing modules, delete unused modules, or rename any keys required in the plan.
-		if info.Name == name && info.Height - 1 == app.LastBlockHeight() && !app.UpgradeKeeper.IsSkipHeight(info.Height) {
+		if info.Name == name && !app.UpgradeKeeper.IsSkipHeight(info.Height) {
 			storeUpgrades := storetypes.StoreUpgrades{
 				Added:   upgrade.Added,
 				Renamed: upgrade.Renamed,
 				Deleted: upgrade.Deleted,
 			}
+
+			if isEmptyUpgrade(storeUpgrades) {
+				app.Logger().Info("No store upgrades required",
+					"plan", name,
+					"height", info.Height,
+				)
+				return nil
+			}
+
 			app.Logger().Info("Store upgrades",
 				"plan", name,
 				"height", info.Height,
@@ -79,4 +88,8 @@ func CustomUpgradeStoreLoader(app *App, info storetypes.UpgradeInfo) baseapp.Sto
 		}
 	}
 	return nil
+}
+
+func isEmptyUpgrade(upgrades storetypes.StoreUpgrades) bool {
+	return len(upgrades.Renamed) == 0 && len(upgrades.Deleted) == 0 && len(upgrades.Added) == 0
 }

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -55,7 +55,7 @@ func InstallCustomUpgradeHandlers(app *App) {
 // CustomUpgradeStoreLoader provides upgrade handlers for store and application module upgrades at specified versions
 func CustomUpgradeStoreLoader(app *App, info storetypes.UpgradeInfo) baseapp.StoreLoader {
 	// Current upgrade info is empty or we are at the wrong height, skip this.
-	if info.Name == "" || info.Height - 1 != app.LastBlockHeight() {
+	if info.Name == "" || info.Height-1 != app.LastBlockHeight() {
 		return nil
 	}
 	// Find the upgrade handler that matches this currently executing upgrade.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Currently, the store loader will load every run. This PR assures that the customStoreLoader only runs during upgrades detected and driven by the 'upgrade-info.json' file.

IMPACT: Since no upgrade handler defined any store upgrades, there is no negative impact as long as this is fixed before an upgrade is added that mutates the kvstore list.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
