### PR TITLE
Refactor attribute validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,13 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Features
 
 * Governance proposal support for marker module
+* Add `AddP8eContractSpec` endpoint to convert v39 contract spec into v40 contract specification  #167
+* Refactor `Attribute` validate to sdk standard validate basic #175
+
 ### Bug Fixes
 
 * Gov module route added for name module root name proposal
 
-* Add `AddP8eContractSpec` endpoint to convert v39 contract spec into v40 contract specification  #167
 
 ## [v0.2.1](https://github.com/provenance-io/provenance/releases/tag/v0.2.1) - 2021-03-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * Governance proposal support for marker module
 * Add `AddP8eContractSpec` endpoint to convert v39 contract spec into v40 contract specification  #167
-* Refactor `Attribute` validate to sdk standard validate basic #175
+* Refactor `Attribute` validate to sdk standard validate basic and validate size of attribute value #175
 
 ### Bug Fixes
 

--- a/x/attribute/client/cli/cli_test.go
+++ b/x/attribute/client/cli/cli_test.go
@@ -268,12 +268,12 @@ func (s *IntegrationTestSuite) TestGetAttributeParamsCmd() {
 		{
 			"json output",
 			[]string{fmt.Sprintf("--%s=json", tmcli.OutputFlag)},
-			"{\"max_value_length\":32}",
+			"{\"max_value_length\":128}",
 		},
 		{
 			"text output",
 			[]string{fmt.Sprintf("--%s=text", tmcli.OutputFlag)},
-			"max_value_length: 32",
+			"max_value_length: 128",
 		},
 	}
 

--- a/x/attribute/client/cli/cli_test.go
+++ b/x/attribute/client/cli/cli_test.go
@@ -86,7 +86,7 @@ func (s *IntegrationTestSuite) SetupSuite() {
 			s.accountAddr,
 			attributetypes.AttributeType_Int,
 			[]byte("2")))
-	attributeData.Params.MaxValueLength = 32
+	attributeData.Params.MaxValueLength = 128
 	attributeDataBz, err := cfg.Codec.MarshalJSON(&attributeData)
 	s.Require().NoError(err)
 	genesisState[attributetypes.ModuleName] = attributeDataBz
@@ -520,6 +520,21 @@ func (s *IntegrationTestSuite) TestAttributeTxCommands() {
 		},
 		{
 			"set attribute, unknown type",
+			cli.NewAddAccountAttributeCmd(),
+			[]string{
+				"txtest.attribute",
+				s.testnet.Validators[0].Address.String(),
+				"notdog",
+				"toomanycharstoomanycharstoomanycharstoomanycharstoomanycharstoomanycharstoomanycharstoomanycharstoomanycharstoomanycharstoomanychars",
+				fmt.Sprintf("--%s=%s", flags.FlagFrom, s.testnet.Validators[0].Address.String()),
+				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
+			},
+			true, &sdk.TxResponse{}, 1,
+		},
+		{
+			"set attribute, exceeds max length",
 			cli.NewAddAccountAttributeCmd(),
 			[]string{
 				"txtest.attribute",

--- a/x/attribute/keeper/genesis.go
+++ b/x/attribute/keeper/genesis.go
@@ -9,7 +9,7 @@ import (
 // InitGenesis creates the initial genesis state for the attribute module.
 func (k Keeper) InitGenesis(ctx sdk.Context, data *types.GenesisState) {
 	k.SetParams(ctx, data.Params)
-	if err := data.Validate(); err != nil {
+	if err := data.ValidateBasic(); err != nil {
 		panic(err)
 	}
 	for _, attr := range data.Attributes {

--- a/x/attribute/keeper/keeper.go
+++ b/x/attribute/keeper/keeper.go
@@ -104,7 +104,7 @@ func (k Keeper) SetAttribute(
 	ctx sdk.Context, acc sdk.AccAddress, attr types.Attribute, owner sdk.AccAddress,
 ) error {
 	// Ensure attribute is valid
-	if err := attr.Validate(); err != nil {
+	if err := attr.ValidateBasic(); err != nil {
 		return err
 	}
 	// Ensure name is stored in normalized format.
@@ -186,7 +186,7 @@ func (k Keeper) prefixScan(ctx sdk.Context, prefix []byte, f namePred) (attrs []
 // A genesis helper that imports attribute state without owner checks.
 func (k Keeper) importAttribute(ctx sdk.Context, attr types.Attribute) error {
 	// Ensure attribute is valid
-	if err := attr.Validate(); err != nil {
+	if err := attr.ValidateBasic(); err != nil {
 		return err
 	}
 	// Attribute must have a valid, non-empty address to import

--- a/x/attribute/keeper/keeper.go
+++ b/x/attribute/keeper/keeper.go
@@ -107,11 +107,20 @@ func (k Keeper) SetAttribute(
 	if err := attr.ValidateBasic(); err != nil {
 		return err
 	}
+
+	// Ensure attribute value length does not exceed max length value
+	maxLength := k.GetMaxValueLength(ctx)
+	if int(maxLength) < len(attr.Value) {
+		return fmt.Errorf("attribute value length of %v exceeds max length %v", len(attr.Value), maxLength)
+	}
+
 	// Ensure name is stored in normalized format.
 	var err error
-	if attr.Name, err = k.nameKeeper.Normalize(ctx, attr.Name); err != nil {
+	normalizedName, err := k.nameKeeper.Normalize(ctx, attr.Name)
+	if err != nil {
 		return fmt.Errorf("unable to normalize attribute name \"%s\": %w", attr.Name, err)
 	}
+	attr.Name = normalizedName
 	// Verify an account exists for the given owner address
 	if ownerAcc := k.authKeeper.GetAccount(ctx, owner); ownerAcc == nil {
 		return fmt.Errorf("no account found for owner address \"%s\"", owner.String())

--- a/x/attribute/keeper/keeper_test.go
+++ b/x/attribute/keeper/keeper_test.go
@@ -180,7 +180,30 @@ func (s *KeeperTestSuite) TestGetAllAttributes() {
 
 	attributes, err = s.app.AttributeKeeper.GetAllAttributes(s.ctx, s.user1Addr)
 	s.NoError(err)
+	s.Equal(attr.Name, attributes[0].Name)
+	s.Equal(attr.Address, attributes[0].Address)
+	s.Equal(attr.Value, attributes[0].Value)
+}
+
+func (s *KeeperTestSuite) TestGetAttributesByName() {
+
+	attr := types.Attribute{
+		Name:          "example.attribute",
+		Value:         []byte("0123456789"),
+		Address:       s.user1,
+		AttributeType: types.AttributeType_String,
+	}
+	s.app.AttributeKeeper.SetAttribute(s.ctx, s.user1Addr, attr, s.user1Addr)
+
+	_, err := s.app.AttributeKeeper.GetAttributes(s.ctx, s.user1Addr, "blah")
+	s.Error(err)
+	s.Equal("no address bound to name", err.Error())
+	attributes, err := s.app.AttributeKeeper.GetAttributes(s.ctx, s.user1Addr, "example.attribute")
+	s.NoError(err)
 	s.Equal(1, len(attributes))
+	s.Equal(attr.Name, attributes[0].Name)
+	s.Equal(attr.Address, attributes[0].Address)
+	s.Equal(attr.Value, attributes[0].Value)
 }
 
 func (s *KeeperTestSuite) TestInitGenesisAddingAttributes() {

--- a/x/attribute/keeper/keeper_test.go
+++ b/x/attribute/keeper/keeper_test.go
@@ -1,0 +1,165 @@
+package keeper_test
+
+import (
+	"fmt"
+	"testing"
+
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+
+	"github.com/provenance-io/provenance/app"
+	simapp "github.com/provenance-io/provenance/app"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/provenance-io/provenance/x/attribute/types"
+	nametypes "github.com/provenance-io/provenance/x/name/types"
+	"github.com/stretchr/testify/suite"
+)
+
+type KeeperTestSuite struct {
+	suite.Suite
+
+	app *app.App
+	ctx sdk.Context
+
+	pubkey1   cryptotypes.PubKey
+	user1     string
+	user1Addr sdk.AccAddress
+
+	pubkey2   cryptotypes.PubKey
+	user2     string
+	user2Addr sdk.AccAddress
+}
+
+func TestKeeperTestSuite(t *testing.T) {
+	suite.Run(t, new(KeeperTestSuite))
+}
+
+func (s *KeeperTestSuite) SetupTest() {
+	app := simapp.Setup(false)
+	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+	s.app = app
+	s.ctx = ctx
+
+	s.pubkey1 = secp256k1.GenPrivKey().PubKey()
+	s.user1Addr = sdk.AccAddress(s.pubkey1.Address())
+	s.user1 = s.user1Addr.String()
+
+	s.pubkey2 = secp256k1.GenPrivKey().PubKey()
+	s.user2Addr = sdk.AccAddress(s.pubkey2.Address())
+	s.user2 = s.user2Addr.String()
+
+	var nameData nametypes.GenesisState
+	nameData.Bindings = append(nameData.Bindings, nametypes.NewNameRecord("attribute", s.user1Addr, false))
+	nameData.Bindings = append(nameData.Bindings, nametypes.NewNameRecord("example.attribute", s.user1Addr, false))
+	nameData.Params.AllowUnrestrictedNames = false
+	nameData.Params.MaxNameLevels = 3
+	nameData.Params.MinSegmentLength = 3
+	nameData.Params.MaxSegmentLength = 12
+
+	app.NameKeeper.InitGenesis(ctx, nameData)
+
+	params := app.AttributeKeeper.GetParams(ctx)
+	params.MaxValueLength = 10
+	app.AttributeKeeper.SetParams(ctx, params)
+	s.app.AccountKeeper.SetAccount(s.ctx, s.app.AccountKeeper.NewAccountWithAddress(s.ctx, s.user1Addr))
+}
+
+func (s *KeeperTestSuite) TestSetAttribute() {
+
+	cases := map[string]struct {
+		attr      types.Attribute
+		accAddr   sdk.AccAddress
+		ownerAddr sdk.AccAddress
+		wantErr   bool
+		errorMsg  string
+	}{
+		"should successfully add attribute": {
+			attr: types.Attribute{
+				Name:          "example.attribute",
+				Value:         []byte("0123456789"),
+				Address:       s.user1,
+				AttributeType: types.AttributeType_String,
+			},
+			accAddr:   s.user1Addr,
+			ownerAddr: s.user1Addr,
+			wantErr:   false,
+			errorMsg:  "",
+		},
+		"should fail due to validate basic error": {
+			attr: types.Attribute{
+				Name:          "",
+				Value:         []byte("01234567891"),
+				Address:       s.user1,
+				AttributeType: types.AttributeType_String,
+			},
+			accAddr:   s.user1Addr,
+			ownerAddr: s.user1Addr,
+			wantErr:   true,
+			errorMsg:  "invalid name: empty",
+		},
+		"should fail due to attribute length too long": {
+			attr: types.Attribute{
+				Name:          "name",
+				Value:         []byte("01234567891"),
+				Address:       s.user1,
+				AttributeType: types.AttributeType_String,
+			},
+			accAddr:   s.user1Addr,
+			ownerAddr: s.user1Addr,
+			wantErr:   true,
+			errorMsg:  "attribute value length of 11 exceeds max length 10",
+		},
+		"should fail unable to find owner": {
+			attr: types.Attribute{
+				Name:          "example.attribute",
+				Value:         []byte("0123456789"),
+				Address:       s.user1,
+				AttributeType: types.AttributeType_String,
+			},
+			accAddr:   s.user2Addr,
+			ownerAddr: s.user2Addr,
+			wantErr:   true,
+			errorMsg:  fmt.Sprintf("no account found for owner address \"%s\"", s.user2),
+		},
+		"should fail unable to normalize segment length too short": {
+			attr: types.Attribute{
+				Name:          "example.cant.normalize.me",
+				Value:         []byte("0123456789"),
+				Address:       s.user1,
+				AttributeType: types.AttributeType_String,
+			},
+			accAddr:   s.user2Addr,
+			ownerAddr: s.user2Addr,
+			wantErr:   true,
+			errorMsg:  "unable to normalize attribute name \"example.cant.normalize.me\": segment of name is too short",
+		},
+		"should fail unable to resolve name to user": {
+			attr: types.Attribute{
+				Name:          "example.not.found",
+				Value:         []byte("0123456789"),
+				Address:       s.user1,
+				AttributeType: types.AttributeType_String,
+			},
+			accAddr:   s.user1Addr,
+			ownerAddr: s.user1Addr,
+			wantErr:   true,
+			errorMsg:  fmt.Sprintf("\"example.not.found\" does not resolve to address \"%s\"", s.user1),
+		},
+	}
+	for n, tc := range cases {
+		tc := tc
+
+		s.Run(n, func() {
+			err := s.app.AttributeKeeper.SetAttribute(s.ctx, tc.accAddr, tc.attr, tc.ownerAddr)
+			if tc.wantErr {
+				s.Error(err)
+				s.Equal(tc.errorMsg, err.Error())
+			} else {
+				s.NoError(err)
+			}
+		})
+	}
+
+}

--- a/x/attribute/keeper/keeper_test.go
+++ b/x/attribute/keeper/keeper_test.go
@@ -164,6 +164,25 @@ func (s *KeeperTestSuite) TestSetAttribute() {
 
 }
 
+func (s *KeeperTestSuite) TestGetAllAttributes() {
+
+	attributes, err := s.app.AttributeKeeper.GetAllAttributes(s.ctx, s.user1Addr)
+	s.NoError(err)
+	s.Equal(0, len(attributes))
+
+	attr := types.Attribute{
+		Name:          "example.attribute",
+		Value:         []byte("0123456789"),
+		Address:       s.user1,
+		AttributeType: types.AttributeType_String,
+	}
+	s.app.AttributeKeeper.SetAttribute(s.ctx, s.user1Addr, attr, s.user1Addr)
+
+	attributes, err = s.app.AttributeKeeper.GetAllAttributes(s.ctx, s.user1Addr)
+	s.NoError(err)
+	s.Equal(1, len(attributes))
+}
+
 func (s *KeeperTestSuite) TestInitGenesisAddingAttributes() {
 	var attributeData types.GenesisState
 	attributeData.Attributes = append(attributeData.Attributes, types.Attribute{

--- a/x/attribute/keeper/keeper_test.go
+++ b/x/attribute/keeper/keeper_test.go
@@ -163,3 +163,14 @@ func (s *KeeperTestSuite) TestSetAttribute() {
 	}
 
 }
+
+func (s *KeeperTestSuite) TestInitGenesisShouldFailValidateBasicOnAttribute() {
+	var attributeData types.GenesisState
+	attributeData.Attributes = append(attributeData.Attributes, types.Attribute{
+		Name:          "",
+		Value:         []byte("0123456789"),
+		Address:       s.user1,
+		AttributeType: types.AttributeType_String,
+	})
+	s.Assert().Panics(func() { s.app.AttributeKeeper.InitGenesis(s.ctx, &attributeData) })
+}

--- a/x/attribute/keeper/keeper_test.go
+++ b/x/attribute/keeper/keeper_test.go
@@ -164,13 +164,22 @@ func (s *KeeperTestSuite) TestSetAttribute() {
 
 }
 
-func (s *KeeperTestSuite) TestInitGenesisShouldFailValidateBasicOnAttribute() {
+func (s *KeeperTestSuite) TestInitGenesisAddingAttributes() {
 	var attributeData types.GenesisState
+	attributeData.Attributes = append(attributeData.Attributes, types.Attribute{
+		Name:          "example.attribute",
+		Value:         []byte("0123456789"),
+		Address:       s.user1,
+		AttributeType: types.AttributeType_String,
+	})
+	s.Assert().NotPanics(func() { s.app.AttributeKeeper.InitGenesis(s.ctx, &attributeData) })
+
 	attributeData.Attributes = append(attributeData.Attributes, types.Attribute{
 		Name:          "",
 		Value:         []byte("0123456789"),
 		Address:       s.user1,
 		AttributeType: types.AttributeType_String,
 	})
+
 	s.Assert().Panics(func() { s.app.AttributeKeeper.InitGenesis(s.ctx, &attributeData) })
 }

--- a/x/attribute/module.go
+++ b/x/attribute/module.go
@@ -56,7 +56,7 @@ func (AppModuleBasic) ValidateGenesis(cdc codec.JSONMarshaler, config client.TxE
 		return fmt.Errorf("failed to unmarshal %s genesis state: %w", types.ModuleName, err)
 	}
 
-	return data.Validate()
+	return data.ValidateBasic()
 }
 
 // RegisterRESTRoutes registers rest routes.

--- a/x/attribute/types/attribute.go
+++ b/x/attribute/types/attribute.go
@@ -40,18 +40,20 @@ func (a Attribute) Hash() []byte {
 	return sum[:]
 }
 
-// Validate ensures an attribute is valid.
-func (a Attribute) Validate() error {
+// ValidateBascic ensures an attribute is valid.
+func (a Attribute) ValidateBasic() error {
 	if strings.TrimSpace(a.Name) == "" {
 		return fmt.Errorf("invalid name: empty")
 	}
 	if a.Value == nil {
 		return fmt.Errorf("invalid value: nil")
 	}
-	// TODO: this is now a stateful check and can't be performed here since we do not have the params for the module
-	// if len(a.Value) > maxValueLen {
-	// 	return fmt.Errorf("invalid value: too large")
-	// }
+
+	_, err := sdk.AccAddressFromBech32(a.Address)
+	if err != nil {
+		return fmt.Errorf("invalid attribute address: %s", a.Address)
+	}
+
 	if !ValidAttributeType(a.AttributeType) {
 		return fmt.Errorf("invalid attribute type")
 	}

--- a/x/attribute/types/attribute_test.go
+++ b/x/attribute/types/attribute_test.go
@@ -1,0 +1,209 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type AttributeTestSuite struct {
+	suite.Suite
+}
+
+func TestP8eTestSuite(t *testing.T) {
+	suite.Run(t, new(AttributeTestSuite))
+}
+
+func (s *AttributeTestSuite) TestAttributeValidateBasic() {
+	cases := map[string]struct {
+		attribute Attribute
+		expectErr bool
+		errValue  string
+	}{
+		"should fail to validate basic attribute empty name": {
+			Attribute{
+				Name:          "",
+				Value:         []byte("string value"),
+				Address:       "cosmos1v57fx2l2rt6ehujuu99u2fw05779m5e2ux4z2h",
+				AttributeType: AttributeType_String,
+			},
+			true,
+			"invalid name: empty",
+		},
+		"should fail to validate basic attribute value is nil": {
+			Attribute{
+				Name:          "value",
+				Value:         nil,
+				Address:       "cosmos1v57fx2l2rt6ehujuu99u2fw05779m5e2ux4z2h",
+				AttributeType: AttributeType_String,
+			},
+			true,
+			"invalid value: nil",
+		},
+		"should fail to validate basic attribute invalid address": {
+			Attribute{
+				Name:          "name",
+				Value:         []byte("string value"),
+				Address:       "not an address",
+				AttributeType: AttributeType_String,
+			},
+			true,
+			"invalid attribute address: not an address",
+		},
+		"should fail to validate basic attribute invalid type": {
+			Attribute{
+				Name:          "type",
+				Value:         []byte("string value"),
+				Address:       "cosmos1v57fx2l2rt6ehujuu99u2fw05779m5e2ux4z2h",
+				AttributeType: -100,
+			},
+			true,
+			"invalid attribute type",
+		},
+		"should fail to validate basic attribute invalid type unspecified": {
+			Attribute{
+				Name:          "type",
+				Value:         []byte("string value"),
+				Address:       "cosmos1v57fx2l2rt6ehujuu99u2fw05779m5e2ux4z2h",
+				AttributeType: AttributeType_Unspecified,
+			},
+			true,
+			"invalid attribute type",
+		},
+		"should fail to validate basic attribute invalid value for type uuid": {
+			Attribute{
+				Name:          "uuid",
+				Value:         []byte("string value"),
+				Address:       "cosmos1v57fx2l2rt6ehujuu99u2fw05779m5e2ux4z2h",
+				AttributeType: AttributeType_UUID,
+			},
+			true,
+			"invalid attribute value for assigned type: ATTRIBUTE_TYPE_UUID",
+		},
+		"should succeed to validate basic attribute for type uuid": {
+			Attribute{
+				Name:          "uuid",
+				Value:         []byte("91978ba2-5f35-459a-86a7-feca1b0512e0"),
+				Address:       "cosmos1v57fx2l2rt6ehujuu99u2fw05779m5e2ux4z2h",
+				AttributeType: AttributeType_UUID,
+			},
+			false,
+			"",
+		},
+		"should fail to validate basic attribute invalid value for type json": {
+			Attribute{
+				Name:          "json",
+				Value:         []byte("{"),
+				Address:       "cosmos1v57fx2l2rt6ehujuu99u2fw05779m5e2ux4z2h",
+				AttributeType: AttributeType_JSON,
+			},
+			true,
+			"invalid attribute value for assigned type: ATTRIBUTE_TYPE_JSON",
+		},
+		"should succeed to validate basic attribute for type json": {
+			Attribute{
+				Name:          "json",
+				Value:         []byte("{}"),
+				Address:       "cosmos1v57fx2l2rt6ehujuu99u2fw05779m5e2ux4z2h",
+				AttributeType: AttributeType_JSON,
+			},
+			false,
+			"",
+		},
+		"should fail to validate basic attribute invalid value for type uri": {
+			Attribute{
+				Name:          "uri",
+				Value:         []byte("not uri"),
+				Address:       "cosmos1v57fx2l2rt6ehujuu99u2fw05779m5e2ux4z2h",
+				AttributeType: AttributeType_Uri,
+			},
+			true,
+			"invalid attribute value for assigned type: ATTRIBUTE_TYPE_URI",
+		},
+		"should succeed to validate basic attribute for type uri": {
+			Attribute{
+				Name:          "uri",
+				Value:         []byte("ftp://www.this-is-uri.com"),
+				Address:       "cosmos1v57fx2l2rt6ehujuu99u2fw05779m5e2ux4z2h",
+				AttributeType: AttributeType_Uri,
+			},
+			false,
+			"",
+		},
+		"should fail to validate basic attribute invalid value for type int": {
+			Attribute{
+				Name:          "int",
+				Value:         []byte("not an int"),
+				Address:       "cosmos1v57fx2l2rt6ehujuu99u2fw05779m5e2ux4z2h",
+				AttributeType: AttributeType_Int,
+			},
+			true,
+			"invalid attribute value for assigned type: ATTRIBUTE_TYPE_INT",
+		},
+		"should succeed to validate basic attribute for type int": {
+			Attribute{
+				Name:          "int",
+				Value:         []byte("406"),
+				Address:       "cosmos1v57fx2l2rt6ehujuu99u2fw05779m5e2ux4z2h",
+				AttributeType: AttributeType_Int,
+			},
+			false,
+			"",
+		},
+		"should fail to validate basic attribute invalid value for type float": {
+			Attribute{
+				Name:          "float",
+				Value:         []byte("not a float"),
+				Address:       "cosmos1v57fx2l2rt6ehujuu99u2fw05779m5e2ux4z2h",
+				AttributeType: AttributeType_Float,
+			},
+			true,
+			"invalid attribute value for assigned type: ATTRIBUTE_TYPE_FLOAT",
+		},
+		"should succeed to validate basic attribute for type float": {
+			Attribute{
+				Name:          "float",
+				Value:         []byte("3.14"),
+				Address:       "cosmos1v57fx2l2rt6ehujuu99u2fw05779m5e2ux4z2h",
+				AttributeType: AttributeType_Float,
+			},
+			false,
+			"",
+		},
+		"should succeed to validate basic attribute for type proto": {
+			Attribute{
+				Name:          "proto",
+				Value:         []byte("Treat proto as just a special tag for bytes"),
+				Address:       "cosmos1v57fx2l2rt6ehujuu99u2fw05779m5e2ux4z2h",
+				AttributeType: AttributeType_Proto,
+			},
+			false,
+			"",
+		},
+		"should succeed to validate basic attribute for type bytes": {
+			Attribute{
+				Name:          "bytes",
+				Value:         []byte("there will be bytes"),
+				Address:       "cosmos1v57fx2l2rt6ehujuu99u2fw05779m5e2ux4z2h",
+				AttributeType: AttributeType_Bytes,
+			},
+			false,
+			"",
+		},
+	}
+
+	for n, tc := range cases {
+		tc := tc
+
+		s.Run(n, func() {
+			err := tc.attribute.ValidateBasic()
+			if tc.expectErr {
+				s.Error(err)
+				s.Equal(err.Error(), tc.errValue)
+			} else {
+				s.NoError(err)
+			}
+
+		})
+	}
+}

--- a/x/attribute/types/genesis.go
+++ b/x/attribute/types/genesis.go
@@ -8,10 +8,10 @@ func NewGenesisState(params Params, attributes []Attribute) *GenesisState {
 	}
 }
 
-// Validate ensures a genesis state is valid.
-func (state GenesisState) Validate() error {
+// ValidateBasic ensures a genesis state is valid.
+func (state GenesisState) ValidateBasic() error {
 	for _, a := range state.Attributes {
-		if err := a.Validate(); err != nil {
+		if err := a.ValidateBasic(); err != nil {
 			return err
 		}
 	}

--- a/x/attribute/types/msgs.go
+++ b/x/attribute/types/msgs.go
@@ -48,7 +48,7 @@ func (msg MsgAddAttributeRequest) ValidateBasic() error {
 		return err
 	}
 	a := NewAttribute(msg.Name, accAddr, msg.AttributeType, msg.Value)
-	return a.Validate()
+	return a.ValidateBasic()
 }
 
 // GetSignBytes encodes the message for signing


### PR DESCRIPTION
## Description

Refactor existing Validate method in x/attribute/types/attribute.go to be ValidateBasic to follow sdk standard. 

closes: #44 
---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Review `Codecov Report` in the comment section below once CI passes
