### PR TITLE
Support wasm marker withrawals for any denom/amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * Resolves an issue where Gov Proposals to Create a new name would fail for new root domains #192
 
+### Features
+
+* Allow withdrawals of any coin type from a marker account in WASM smart contracts. #151
+
 ## [v0.3.0](https://github.com/provenance-io/provenance/releases/tag/v0.3.0) - 2021-03-19
 
 ### Features


### PR DESCRIPTION
This PR allows smart contracts to withdraw any fund from a marker account (not just the marker coin). In addition, denoms are now validated with the cosmos sdk, instead of just empty string checks.

closes: #151 