### PR TITLE
set ibc params in migration script for v039 chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * Added cli tx commands `add-scope` `remove-scope` for updating/adding/removing metadata `Scope`s. #199
 * Simulation testing support #95
 * Name module simulation testing #24
+* Added default IBC parameters for v039 chain genesis migration script #102
 
 ## [v0.3.0](https://github.com/provenance-io/provenance/releases/tag/v0.3.0) - 2021-03-19
 

--- a/internal/legacy/v040/migrate.go
+++ b/internal/legacy/v040/migrate.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
+
 	v038auth "github.com/cosmos/cosmos-sdk/x/auth/legacy/v038"
 	v039auth "github.com/cosmos/cosmos-sdk/x/auth/legacy/v039"
 	v040auth "github.com/cosmos/cosmos-sdk/x/auth/legacy/v040"
@@ -32,6 +33,11 @@ import (
 	v038upgrade "github.com/cosmos/cosmos-sdk/x/upgrade/legacy/v038"
 
 	captypes "github.com/cosmos/cosmos-sdk/x/capability/types"
+	evidencetypes "github.com/cosmos/cosmos-sdk/x/evidence/types"
+	ibcxfertypes "github.com/cosmos/cosmos-sdk/x/ibc/applications/transfer/types"
+	ibchost "github.com/cosmos/cosmos-sdk/x/ibc/core/24-host"
+	ibcexported "github.com/cosmos/cosmos-sdk/x/ibc/core/exported"
+	ibccoretypes "github.com/cosmos/cosmos-sdk/x/ibc/core/types"
 
 	v039attribute "github.com/provenance-io/provenance/x/attribute/legacy/v039"
 	v040attribute "github.com/provenance-io/provenance/x/attribute/legacy/v040"
@@ -237,20 +243,17 @@ func Migrate(appState v040gentypes.AppMap, clientCtx client.Context) v040gentype
 	capGenesis := captypes.DefaultGenesis()
 	appState[captypes.ModuleName] = v040Codec.MustMarshalJSON(capGenesis)
 
-	/*
-		TODO: default configuration for IBC
-		ibcTransferGenesis := ibcxfertypes.DefaultGenesisState()
-		ibcCoreGenesis := ibccoretypes.DefaultGenesisState()
-		evGenesis := evtypes.DefaultGenesisState()
+	ibcTransferGenesis := ibcxfertypes.DefaultGenesisState()
+	ibcCoreGenesis := ibccoretypes.DefaultGenesisState()
+	evGenesis := evidencetypes.DefaultGenesisState()
 
-		ibcTransferGenesis.Params.ReceiveEnabled = false
-		ibcTransferGenesis.Params.SendEnabled = false
-		ibcCoreGenesis.ClientGenesis.Params.AllowedClients = []string{exported.Tendermint}
+	ibcTransferGenesis.Params.ReceiveEnabled = true
+	ibcTransferGenesis.Params.SendEnabled = true
+	ibcCoreGenesis.ClientGenesis.Params.AllowedClients = []string{ibcexported.Solomachine, ibcexported.Tendermint}
 
-		appState[ibcxfertypes.ModuleName] = v040Codec.MustMarshalJSON(ibcTransferGenesis)
-		appState[host.ModuleName] = v040Codec.MustMarshalJSON(ibcCoreGenesis)
-		appState[evtypes.ModuleName] = v040Codec.MustMarshalJSON(evGenesis)
-	*/
+	appState[ibcxfertypes.ModuleName] = v040Codec.MustMarshalJSON(ibcTransferGenesis)
+	appState[ibchost.ModuleName] = v040Codec.MustMarshalJSON(ibcCoreGenesis)
+	appState[v040evidence.ModuleName] = v040Codec.MustMarshalJSON(evGenesis)
 
 	// Migrate x/account (attribute)
 	if appState[v039attribute.ModuleName] != nil {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Assigns migration genesis parameters for IBC modules during migrate process from v039 to v040 chains.  Values are based off of an enabled IBC that supports connections to solo-machine and tendermint consensus.  It is probable that only tendermint consensus based chains will be allowed in the final mainnet configuration.

closes: #102

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
