### PR TITLE
Parse public key PubKey type incorrectly initialized 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * Update Cosmos SDK to 0.42.3
 * Remove deprecated ModuleCdc amino encoding from name module #189
 * Remove deprecated ModuleCdc amino encoding from attribute module #188
+* Metadata Module parsing of base64 public key fixed #225
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 * Add pagination flags to the CLI query metadata commands.
 * Fix handling of Metadata Write message id helper fields.
+* Metadata Module parsing of base64 public key fixed #225
 
 ## [v1.0.0](https://github.com/provenance-io/provenance/releases/tag/v1.0.0) - 2021-03-31
 
@@ -50,7 +51,6 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * Update Cosmos SDK to 0.42.3
 * Remove deprecated ModuleCdc amino encoding from name module #189
 * Remove deprecated ModuleCdc amino encoding from attribute module #188
-* Metadata Module parsing of base64 public key fixed #225
 
 ### Features
 

--- a/x/metadata/legacy/v039/crypto.go
+++ b/x/metadata/legacy/v039/crypto.go
@@ -28,7 +28,7 @@ func ParsePublicKey(data []byte) (tmcrypt.PubKey, sdk.AccAddress, error) {
 		return nil, nil, err
 	}
 	// Create tendermint public key type and return with address.
-	tmKey := tmcurve.PubKey{} // PubKeySecp256k1{}
-	copy(tmKey[:], pk.SerializeCompressed())
+	tmKey := tmcurve.PubKey(pk.SerializeCompressed()) // PubKeySecp256k1{}
+
 	return tmKey, tmKey.Address().Bytes(), nil
 }

--- a/x/metadata/legacy/v040/migrate_test.go
+++ b/x/metadata/legacy/v040/migrate_test.go
@@ -150,6 +150,17 @@ var (
         }
       },
       "signer_role": 1
+    },
+    {
+      "signer": {
+        "encryption_public_key": {
+          "public_key_bytes": "BGxX6eJRAdXlU64APi95Al44m1FJVgfHlrTpXAqUAB+8JNhM0HgIGWElKbgD6K0KOX9HTJZdlX0z3WTmQrdW+8Q="
+        },
+        "signing_public_key": {
+          "public_key_bytes": "BGxX6eJRAdXlU64APi95Al44m1FJVgfHlrTpXAqUAB+8JNhM0HgIGWElKbgD6K0KOX9HTJZdlX0z3WTmQrdW+8Q="
+        }
+      },
+      "signer_role": 1
     }
   ],
   "record_group": [
@@ -315,11 +326,16 @@ func TestMigrate(t *testing.T) {
   "scopes": [
     {
       "data_access": [
-        "cosmos1rr4d0eu62pgt4edw38d2ev27798pfhdhm39zct"
+        "cosmos1rr4d0eu62pgt4edw38d2ev27798pfhdhm39zct",
+        "cosmos1vz99nyd2er8myeugsr4xm5duwhulhp5ae4dvpa"
       ],
       "owners": [
         {
           "address": "cosmos1rr4d0eu62pgt4edw38d2ev27798pfhdhm39zct",
+          "role": "PARTY_TYPE_ORIGINATOR"
+        },
+        {
+          "address": "cosmos1vz99nyd2er8myeugsr4xm5duwhulhp5ae4dvpa",
           "role": "PARTY_TYPE_ORIGINATOR"
         }
       ],

--- a/x/metadata/types/p8e.go
+++ b/x/metadata/types/p8e.go
@@ -385,8 +385,7 @@ func parsePublicKey(data []byte) (tmcrypt.PubKey, sdk.AccAddress, error) {
 		return nil, nil, err
 	}
 	// Create tendermint public key type and return with address.
-	tmKey := tmcurve.PubKey{} // PubKeySecp256k1{}
-	copy(tmKey[:], pk.SerializeCompressed())
+	tmKey := tmcurve.PubKey(pk.SerializeCompressed()) // PubKeySecp256k1{}
 	return tmKey, tmKey.Address().Bytes(), nil
 }
 

--- a/x/metadata/types/p8e_test.go
+++ b/x/metadata/types/p8e_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	b64 "encoding/base64"
 	"fmt"
 	"reflect"
 	"testing"
@@ -12,8 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/google/uuid"
@@ -52,7 +53,7 @@ func getPublicFieldNames(thing interface{}) []string {
 			retval = append(retval, field)
 		}
 	}
-	return retval;
+	return retval
 }
 
 // getAllFieldNames attempts to get the field names of the provided thing.
@@ -69,7 +70,7 @@ func getAllFieldNames(thing interface{}) (fields []string, err error) {
 	// Get the thing type and follow it until it's not a pointer anymore.
 	thingValue := reflect.ValueOf(thing)
 	thingType := thingValue.Type()
-	for  thingType.Kind() == reflect.Ptr {
+	for thingType.Kind() == reflect.Ptr {
 		thingValue = thingValue.Elem()
 		thingType = thingValue.Type()
 	}
@@ -82,7 +83,7 @@ func getAllFieldNames(thing interface{}) (fields []string, err error) {
 	if thingType.Kind() == reflect.Struct {
 		fieldCount := thingType.NumField()
 		for i := 0; i < fieldCount; i++ {
-			fields  = append(fields, thingType.Field(i).Name)
+			fields = append(fields, thingType.Field(i).Name)
 		}
 	}
 	return
@@ -92,7 +93,7 @@ func getAllFieldNames(thing interface{}) (fields []string, err error) {
 // Assumes elements in a set are unique.
 func assertSetsAreEqual(t *testing.T, expected []string, actual []string) bool {
 	allPass := assert.Equal(t, len(expected), len(actual), "lengths")
-	if (allPass) {
+	if allPass {
 		for _, e := range expected {
 			found := false
 			for _, a := range actual {
@@ -235,9 +236,9 @@ func (s *P8eTestSuite) TestEmptyScope() {
 	testedFields := []string{}
 	tests := []struct {
 		field string
-		name string
-		test func(scope *Scope, t *testing.T)
-	} {
+		name  string
+		test  func(scope *Scope, t *testing.T)
+	}{
 		{
 			"",
 			"Does not return nil",
@@ -320,9 +321,9 @@ func (s *P8eTestSuite) TestEmptySession() {
 	testedFields := []string{}
 	tests := []struct {
 		field string
-		name string
-		test func(session *Session, t *testing.T)
-	} {
+		name  string
+		test  func(session *Session, t *testing.T)
+	}{
 		{
 			"",
 			"Does not return nil",
@@ -398,9 +399,9 @@ func (s *P8eTestSuite) TestEmptyRecord() {
 	testedFields := []string{}
 	tests := []struct {
 		field string
-		name string
-		test func(record *Record, t *testing.T)
-	} {
+		name  string
+		test  func(record *Record, t *testing.T)
+	}{
 		{
 			"",
 			"Does not return nil",
@@ -490,9 +491,9 @@ func (s *P8eTestSuite) TestEmptyProcess() {
 	testedFields := []string{}
 	tests := []struct {
 		field string
-		name string
-		test func(record *Process, t *testing.T)
-	} {
+		name  string
+		test  func(record *Process, t *testing.T)
+	}{
 		{
 			"",
 			"Does not return nil",
@@ -550,10 +551,10 @@ func (s *P8eTestSuite) TestConvertP8eMemorializeContractRequest() {
 	sessionID := SessionMetadataAddress(scopeUUID, sessionUUID)
 
 	tests := []struct {
-		name string
-		req MsgP8EMemorializeContractRequest
-		p8EData P8EData
-		signers []string
+		name     string
+		req      MsgP8EMemorializeContractRequest
+		p8EData  P8EData
+		signers  []string
 		errorMsg string
 	}{
 		{
@@ -567,7 +568,7 @@ func (s *P8eTestSuite) TestConvertP8eMemorializeContractRequest() {
 						{
 							SignerRole: p8e.PartyType_PARTY_TYPE_OWNER,
 							Signer: &p8e.SigningAndEncryptionPublicKeys{
-								SigningPublicKey:    &p8e.PublicKey{
+								SigningPublicKey: &p8e.PublicKey{
 									PublicKeyBytes: s.pubkey1.Bytes(),
 									Type:           p8e.PublicKeyType_ELLIPTIC,
 									Curve:          p8e.PublicKeyCurve_SECP256K1,
@@ -579,26 +580,26 @@ func (s *P8eTestSuite) TestConvertP8eMemorializeContractRequest() {
 					},
 				},
 				Contract: &p8e.Contract{
-					Definition:     nil,
-					Spec:           &p8e.Fact{
-						Name:         "", // TODO
+					Definition: nil,
+					Spec: &p8e.Fact{
+						Name: "", // TODO
 						DataLocation: &p8e.Location{
 							Ref:       nil, // TODO
 							Classname: "",
 						},
 					},
 					Invoker: &p8e.SigningAndEncryptionPublicKeys{
-						SigningPublicKey:    &p8e.PublicKey{
+						SigningPublicKey: &p8e.PublicKey{
 							PublicKeyBytes: s.pubkey1.Bytes(),
 							Type:           p8e.PublicKeyType_ELLIPTIC,
 							Curve:          p8e.PublicKeyCurve_SECP256K1,
 						},
 						EncryptionPublicKey: nil,
 					},
-					Inputs: []*p8e.Fact{}, // TODO
-					Conditions: []*p8e.Condition{}, // TODO
+					Inputs:         []*p8e.Fact{},          // TODO
+					Conditions:     []*p8e.Condition{},     // TODO
 					Considerations: []*p8e.Consideration{}, // TODO
-					Recitals: []*p8e.Recital{}, // TODO
+					Recitals:       []*p8e.Recital{},       // TODO
 					TimesExecuted:  1,
 					StartTime:      nil,
 				},
@@ -608,8 +609,8 @@ func (s *P8eTestSuite) TestConvertP8eMemorializeContractRequest() {
 							Algo:      "",
 							Provider:  "",
 							Signature: "",
-							Signer:    &p8e.SigningAndEncryptionPublicKeys{
-								SigningPublicKey:    &p8e.PublicKey{
+							Signer: &p8e.SigningAndEncryptionPublicKeys{
+								SigningPublicKey: &p8e.PublicKey{
 									PublicKeyBytes: s.pubkey1.Bytes(),
 									Type:           p8e.PublicKeyType_ELLIPTIC,
 									Curve:          p8e.PublicKeyCurve_SECP256K1,
@@ -655,4 +656,37 @@ func (s *P8eTestSuite) TestConvertP8eMemorializeContractRequest() {
 			}
 		})
 	}
+}
+
+func (s *P8eTestSuite) TestParsePublicKey() {
+	tests := []struct {
+		name      string
+		key       string
+		expectErr bool
+	}{
+		// {
+		// 	"uncompressed public key",
+		// 	"BGxX6eJRAdXlU64APi95Al44m1FJVgfHlrTpXAqUAB+8JNhM0HgIGWElKbgD6K0KOX9HTJZdlX0z3WTmQrdW+8Q",
+		// 	"blah",
+		// },
+		{
+			"compressed public key",
+			"AmxX6eJRAdXlU64APi95Al44m1FJVgfHlrTpXAqUAB+8",
+			false,
+		},
+	}
+
+	for _, tc := range tests {
+		s.T().Run(tc.name, func(t *testing.T) {
+			b, _ := b64.StdEncoding.DecodeString(tc.key)
+			pubKey, addr, err := parsePublicKey(b)
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NotNil(t, pubKey, "should have successfully created public key")
+				assert.NotNil(t, addr, "should have successfully  account address")
+			}
+		})
+	}
+
 }

--- a/x/metadata/types/p8e_test.go
+++ b/x/metadata/types/p8e_test.go
@@ -664,15 +664,20 @@ func (s *P8eTestSuite) TestParsePublicKey() {
 		key       string
 		expectErr bool
 	}{
-		// {
-		// 	"uncompressed public key",
-		// 	"BGxX6eJRAdXlU64APi95Al44m1FJVgfHlrTpXAqUAB+8JNhM0HgIGWElKbgD6K0KOX9HTJZdlX0z3WTmQrdW+8Q",
-		// 	"blah",
-		// },
 		{
-			"compressed public key",
-			"AmxX6eJRAdXlU64APi95Al44m1FJVgfHlrTpXAqUAB+8",
+			"should parse uncompressed public key",
+			"BGxX6eJRAdXlU64APi95Al44m1FJVgfHlrTpXAqUAB+8JNhM0HgIGWElKbgD6K0KOX9HTJZdlX0z3WTmQrdW+8Q=",
 			false,
+		},
+		{
+			"should parse compressed public key",
+			"AmxX6eJRAdXlU64APi95Al44m1FJVgfHlrTpXAqUAB+8=",
+			false,
+		},
+		{
+			"should fail to parse incorrect public key size",
+			"4m1FJVgfHlrTpXAqUAB+8",
+			true,
 		},
 	}
 
@@ -684,7 +689,7 @@ func (s *P8eTestSuite) TestParsePublicKey() {
 				assert.Error(t, err)
 			} else {
 				assert.NotNil(t, pubKey, "should have successfully created public key")
-				assert.NotNil(t, addr, "should have successfully  account address")
+				assert.NotNil(t, addr, "should have successfully account address")
 			}
 		})
 	}


### PR DESCRIPTION
## Description

Metadata module parsePublicKey was not correctly initializing the PubKey type causing a panic when converting base64 key to pubkey and address.

closes: #225 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Review `Codecov Report` in the comment section below once CI passes
