### PR TITLE
Fix incorrect conversion pieces in P8EMemorializeContract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 * Add pagination flags to the CLI query metadata commands.
 * Fix handling of Metadata Write message id helper fields.
+* Fix some conversion pieces in `P8EMemorializeContract`.
 
 ## [v1.0.0](https://github.com/provenance-io/provenance/releases/tag/v1.0.0) - 2021-03-31
 

--- a/x/metadata/types/p8e.go
+++ b/x/metadata/types/p8e.go
@@ -160,11 +160,11 @@ func ConvertP8eMemorializeContractRequest(msg *MsgP8EMemorializeContractRequest)
 	}
 
 	// Set the session pieces.
-	p8EData.Session.SpecificationId, err = parseSessionID(p8EData.Scope.ScopeId, msg.GroupId)
+	p8EData.Session.SessionId, err = parseSessionID(p8EData.Scope.ScopeId, msg.GroupId)
 	if err != nil {
 		return p8EData, signers, err
 	}
-	p8EData.Session.SpecificationId, err = getSessionSpecID(msg.Contract)
+	p8EData.Session.SpecificationId, err = getContractSpecID(msg.Contract)
 	if err != nil {
 		return p8EData, signers, err
 	}
@@ -442,7 +442,7 @@ func getFirstRecitalWithRole(recitals []*p8e.Recital, role p8e.PartyType) *p8e.R
 	return nil
 }
 
-func getSessionSpecID(contract *p8e.Contract) (MetadataAddress, error) {
+func getContractSpecID(contract *p8e.Contract) (MetadataAddress, error) {
 	if contract == nil {
 		return MetadataAddress{}, fmt.Errorf("nil contract")
 	}
@@ -451,5 +451,5 @@ func getSessionSpecID(contract *p8e.Contract) (MetadataAddress, error) {
 		return MetadataAddress{}, fmt.Errorf("no spec datalocation ref hash value")
 	}
 	hash := contract.Spec.DataLocation.Ref.Hash
-	return ConvertHashToAddress(SessionKeyPrefix, hash)
+	return ConvertHashToAddress(ContractSpecificationKeyPrefix, hash)
 }

--- a/x/metadata/types/p8e_test.go
+++ b/x/metadata/types/p8e_test.go
@@ -635,7 +635,7 @@ func (s *P8eTestSuite) TestConvertP8eMemorializeContractRequest() {
 		// TODO: getValueOwner fails
 		// TODO: getValueOwner fails
 		// TODO: parseSessionID fails
-		// TODO: getSessionSpecID fails
+		// TODO: getContractSpecID fails
 		// TODO: convertSigners fails
 	}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

* Rename `getSessionSpecID` to `getContractSpecID` because there's no such thing as a session spec.
* Fix `getContractSpecID` to use the correct type prefix.
* Correctly set the `SessionId` instead of setting the wrong field.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
