### PR TITLE
Loosen Contract Spec ID p8e Conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Improvements
 * Add some extra aliases for the CLI query metadata commands.
+* Make p8e contract spec id easier to communicate.
 
 ### Bug Fixes
 * Add pagination flags to the CLI query metadata commands.

--- a/x/metadata/types/p8e.go
+++ b/x/metadata/types/p8e.go
@@ -450,7 +450,7 @@ func getContractSpecID(contract *p8e.Contract) (MetadataAddress, error) {
 		contract.Spec.DataLocation.Ref != nil && len(contract.Spec.DataLocation.Ref.Hash) > 0 {
 		hash = contract.Spec.DataLocation.Ref.Hash
 	} else if contract.Definition != nil && contract.Definition.ResourceLocation != nil &&
-		contract.Definition.ResourceLocation.Ref != nil &&  len(contract.Definition.ResourceLocation.Ref.Hash) > 0 {
+		contract.Definition.ResourceLocation.Ref != nil && len(contract.Definition.ResourceLocation.Ref.Hash) > 0 {
 		hash = contract.Definition.ResourceLocation.Ref.Hash
 	}
 	if len(hash) == 0 {
@@ -461,9 +461,8 @@ func getContractSpecID(contract *p8e.Contract) (MetadataAddress, error) {
 	if addr, err := MetadataAddressFromBech32(hash); err == nil {
 		if addr.IsContractSpecificationAddress() {
 			return addr, nil
-		} else {
-			return addr, fmt.Errorf("metadata address is not for a contract spec: %s", hash)
 		}
+		return addr, fmt.Errorf("metadata address is not for a contract spec: %s", hash)
 	}
 
 	// Okay, it's hopefully a hash...


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

* Allow the contract spec id to be communicated through either the `contract.Spec.DataLocation.Ref.Hash` or `contract.Definition.ResourceLocation.Ref.Hash` fields.
* Allow the value of those fields to be either a hash or the bech32 contract spec id string.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
