### PR TITLE
always anchor unresticted denom expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,24 +35,32 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ## Unreleased
 
 ### Bug Fixes
+
 * Wired recovery flag into `init` command #254
+* Always anchor unrestricted denom validation expressions #258
+
+
 ## [v1.1.1](https://github.com/provenance-io/provenance/releases/tag/v1.1.1) - 2021-04-15
 
 ### Bug Fixes
+
 * Add upgrade plan v1.1.1
 
 ## [v1.1.0](https://github.com/provenance-io/provenance/releases/tag/v1.1.0) - 2021-04-15
 
 ### Features
+
 * Add marker cli has two new flags to set SupplyFixed and AllowGovernanceControl #241
 * Modify 'enable governance' behavior on marker module #227
 * Typed Events and Metric counters in Name Module #85
 
 ### Improvements
+
 * Add some extra aliases for the CLI query metadata commands.
 * Make p8e contract spec id easier to communicate.
 
 ### Bug Fixes
+
 * Add pagination flags to the CLI query metadata commands.
 * Fix handling of Metadata Write message id helper fields.
 * Fix cli metadata address encoding/decoding command tree #231

--- a/x/marker/keeper/denom.go
+++ b/x/marker/keeper/denom.go
@@ -1,0 +1,94 @@
+package keeper
+
+import (
+	"errors"
+	"fmt"
+
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+
+	"github.com/provenance-io/provenance/x/marker/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// ValidateDenomMetadata performs extended validation of the denom metadata fields.
+// It checks that:
+//  - The proposed metadata passes ValidateDenomMetadataBasic.
+//  - The marker status is one that allows the denom metadata to be manipulated.
+//  - All DenomUnit Denom and Aliases strings pass the unrestricted denom regex.
+//    If there is an existing record:
+//     - The Base doesn't change.
+//       If marker status is active or finalized:
+//        - No DenomUnit entries are removed.
+//        - DenomUnit Denom fields aren't changed.
+//        - No aliases are removed from a DenomUnit.
+func (k Keeper) ValidateDenomMetadata(ctx sdk.Context, proposed banktypes.Metadata, existing *banktypes.Metadata, markerStatus types.MarkerStatus) error {
+	// Run all of the basic validation.
+	if err := types.ValidateDenomMetadataBasic(proposed); err != nil {
+		return fmt.Errorf("invalid proposed metadata: %w", err)
+	}
+
+	// Make sure the marker is in a status to allow any denom metadata adding or updating.
+	if !markerStatus.IsOneOf(types.StatusProposed, types.StatusActive, types.StatusFinalized) {
+		return fmt.Errorf("cannot add or update denom metadata for a marker with status [%s]", markerStatus)
+	}
+
+	// Make sure all the DenomUnit Denom and alias strings pass the extra validation regex.
+	for _, du := range proposed.DenomUnits {
+		if err := k.ValidateUnrestictedDenom(ctx, du.Denom); err != nil {
+			return fmt.Errorf("invalid denom unit denom: %w", err)
+		}
+		for _, a := range du.Aliases {
+			if err := k.ValidateUnrestictedDenom(ctx, a); err != nil {
+				return fmt.Errorf("invalid denom unit alias: %w", err)
+			}
+		}
+	}
+
+	if existing != nil {
+		// No matter what, the base cannot change.
+		if proposed.Base != existing.Base {
+			return errors.New("denom metadata base value cannot be changed")
+		}
+
+		// Some further restrictions apply for active and finalized entries.
+		// Note: If you add or remove a status here, you might also need to alter a similar call above.
+		if markerStatus.IsOneOf(types.StatusActive, types.StatusFinalized) {
+			for _, edu := range existing.DenomUnits {
+				// Make sure the existing DenomUnit hasn't been removed.
+				var pdu *banktypes.DenomUnit
+				for _, du := range proposed.DenomUnits {
+					if edu.Exponent == du.Exponent {
+						pdu = du
+						break
+					}
+				}
+				if pdu == nil {
+					return fmt.Errorf("cannot remove denom unit [%s] for a marker with status [%s]",
+						edu.Denom, markerStatus)
+				}
+				// Make sure the Denom value hasn't changed.
+				if edu.Denom != pdu.Denom {
+					return fmt.Errorf("cannot change denom unit Denom from [%s] to [%s] for a marker with status [%s]",
+						edu.Denom, pdu.Denom, markerStatus)
+				}
+				// Make sure none of the aliases have been removed.
+				for _, ea := range edu.Aliases {
+					found := false
+					for _, pa := range pdu.Aliases {
+						if ea == pa {
+							found = true
+							break
+						}
+					}
+					if !found {
+						return fmt.Errorf("cannot remove alias [%s] from denom unit [%s] for a marker with status [%s]",
+							ea, edu.Denom, markerStatus)
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/x/marker/keeper/denom_test.go
+++ b/x/marker/keeper/denom_test.go
@@ -52,6 +52,23 @@ func (s *DenomTestSuite) TestValidateDenomMetadataExtended() {
 		wantInErr                 []string
 	}{
 		{
+			"fails basic validation",
+			banktypes.Metadata{
+				Description: "a description",
+				DenomUnits: []*banktypes.DenomUnit{
+					{Denom: "nhash", Exponent: 0, Aliases: nil},
+					{Denom: "uhash", Exponent: 3, Aliases: nil},
+					{Denom: "invalid", Exponent: 9, Aliases: nil},
+				},
+				Base:    "1234invalid",
+				Display: "invalid",
+			},
+			nil,
+			types.StatusUndefined,
+			types.DefaultUnrestrictedDenomRegex,
+			[]string{"invalid proposed metadata", "invalid metadata base denom"},
+		},
+		{
 			"marker status undefined",
 			banktypes.Metadata{
 				Description: "a description",

--- a/x/marker/keeper/denom_test.go
+++ b/x/marker/keeper/denom_test.go
@@ -1,0 +1,413 @@
+package keeper_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	simapp "github.com/provenance-io/provenance/app"
+
+	"github.com/provenance-io/provenance/x/marker/types"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type DenomTestSuite struct {
+	app *simapp.App
+	ctx sdk.Context
+
+	suite.Suite
+}
+
+func (s *DenomTestSuite) SetupTest() {
+	s.app = simapp.Setup(false)
+	s.ctx = s.app.BaseApp.NewContext(false, tmproto.Header{})
+
+	s.app.MarkerKeeper.SetParams(s.ctx, types.DefaultParams())
+}
+
+func TestDenomTestSuite(t *testing.T) {
+	suite.Run(t, new(DenomTestSuite))
+}
+func (s *DenomTestSuite) TestInvalidDenomExpression() {
+	s.T().Run("invalid denom expression", func(t *testing.T) {
+		assert.Panics(t,
+			func() { s.app.MarkerKeeper.SetParams(s.ctx, types.Params{UnrestrictedDenomRegex: `(invalid`}) },
+			"value from ParamSetPair is invalid: error parsing regexp: missing closing ): `^(invalid$`",
+		)
+	})
+}
+func (s *DenomTestSuite) TestValidateDenomMetadataExtended() {
+
+	tests := []struct {
+		name                      string
+		proposed                  banktypes.Metadata
+		existing                  *banktypes.Metadata
+		markerStatus              types.MarkerStatus
+		denomValidationExpression string
+		wantInErr                 []string
+	}{
+		{
+			"marker status undefined",
+			banktypes.Metadata{
+				Description: "a description",
+				DenomUnits: []*banktypes.DenomUnit{
+					{Denom: "nhash", Exponent: 0, Aliases: nil},
+					{Denom: "uhash", Exponent: 3, Aliases: nil},
+					{Denom: "hash", Exponent: 9, Aliases: nil},
+				},
+				Base:    "nhash",
+				Display: "hash",
+			},
+			nil,
+			types.StatusUndefined,
+			types.DefaultUnrestrictedDenomRegex,
+			[]string{"cannot add or update denom metadata", "undefined"},
+		},
+		{
+			"marker status destroyed",
+			banktypes.Metadata{
+				Description: "a description",
+				DenomUnits: []*banktypes.DenomUnit{
+					{Denom: "nhash", Exponent: 0, Aliases: nil},
+					{Denom: "uhash", Exponent: 3, Aliases: nil},
+					{Denom: "hash", Exponent: 9, Aliases: nil},
+				},
+				Base:    "nhash",
+				Display: "hash",
+			},
+			nil,
+			types.StatusDestroyed,
+			types.DefaultUnrestrictedDenomRegex,
+			[]string{"cannot add or update denom metadata", "destroyed"},
+		},
+		{
+			"marker status cancelled",
+			banktypes.Metadata{
+				Description: "a description",
+				DenomUnits: []*banktypes.DenomUnit{
+					{Denom: "nhash", Exponent: 0, Aliases: nil},
+					{Denom: "uhash", Exponent: 3, Aliases: nil},
+					{Denom: "hash", Exponent: 9, Aliases: nil},
+				},
+				Base:    "nhash",
+				Display: "hash",
+			},
+			nil,
+			types.StatusCancelled,
+			types.DefaultUnrestrictedDenomRegex,
+			[]string{"cannot add or update denom metadata", "cancelled"},
+		},
+		{
+			"denom fails extra regex",
+			banktypes.Metadata{
+				Description: "a description",
+				DenomUnits: []*banktypes.DenomUnit{
+					{Denom: "nhash", Exponent: 0, Aliases: nil},
+					{Denom: "uhash", Exponent: 3, Aliases: nil},
+					{Denom: "hash", Exponent: 9, Aliases: nil},
+				},
+				Base:    "nhash",
+				Display: "hash",
+			},
+			nil,
+			types.StatusProposed,
+			`[nu]hash`,
+			[]string{"fails unrestricted marker denom validation", "hash"},
+		},
+		{
+			"alias fails extra regex",
+			banktypes.Metadata{
+				Description: "a description",
+				DenomUnits: []*banktypes.DenomUnit{
+					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
+					{Denom: "uhash", Exponent: 3, Aliases: nil},
+					{Denom: "hash", Exponent: 9, Aliases: nil},
+				},
+				Base:    "nhash",
+				Display: "hash",
+			},
+			nil,
+			types.StatusProposed,
+			`[nu]?hash`,
+			[]string{"fails unrestricted marker denom validation", "nanohash"},
+		},
+		{
+			"base changed",
+			banktypes.Metadata{
+				Description: "a description",
+				DenomUnits: []*banktypes.DenomUnit{
+					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
+					{Denom: "uhash", Exponent: 3, Aliases: nil},
+					{Denom: "hash", Exponent: 9, Aliases: nil},
+				},
+				Base:    "nhash",
+				Display: "hash",
+			},
+			&banktypes.Metadata{
+				Description: "a description",
+				DenomUnits: []*banktypes.DenomUnit{
+					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
+					{Denom: "uhash", Exponent: 3, Aliases: nil},
+					{Denom: "hash", Exponent: 9, Aliases: nil},
+				},
+				Base:    "uhash",
+				Display: "hash",
+			},
+			types.StatusProposed,
+			types.DefaultUnrestrictedDenomRegex,
+			[]string{"denom metadata base value cannot be changed"},
+		},
+		{
+			"active denom unit removed",
+			banktypes.Metadata{
+				Description: "a description",
+				DenomUnits: []*banktypes.DenomUnit{
+					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
+					{Denom: "hash", Exponent: 9, Aliases: nil},
+				},
+				Base:    "nhash",
+				Display: "hash",
+			},
+			&banktypes.Metadata{
+				Description: "a description",
+				DenomUnits: []*banktypes.DenomUnit{
+					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
+					{Denom: "uhash", Exponent: 3, Aliases: nil},
+					{Denom: "hash", Exponent: 9, Aliases: nil},
+				},
+				Base:    "nhash",
+				Display: "hash",
+			},
+			types.StatusActive,
+			types.DefaultUnrestrictedDenomRegex,
+			[]string{"cannot remove denom unit", "uhash"},
+		},
+		{
+			"finalized denom unit removed",
+			banktypes.Metadata{
+				Description: "a description",
+				DenomUnits: []*banktypes.DenomUnit{
+					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
+					{Denom: "hash", Exponent: 9, Aliases: nil},
+				},
+				Base:    "nhash",
+				Display: "hash",
+			},
+			&banktypes.Metadata{
+				Description: "a description",
+				DenomUnits: []*banktypes.DenomUnit{
+					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
+					{Denom: "uhash", Exponent: 3, Aliases: nil},
+					{Denom: "hash", Exponent: 9, Aliases: nil},
+				},
+				Base:    "nhash",
+				Display: "hash",
+			},
+			types.StatusFinalized,
+			types.DefaultUnrestrictedDenomRegex,
+			[]string{"cannot remove denom unit", "uhash"},
+		},
+		{
+			"proposed denom unit removed",
+			banktypes.Metadata{
+				Description: "a description",
+				DenomUnits: []*banktypes.DenomUnit{
+					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
+					{Denom: "hash", Exponent: 9, Aliases: nil},
+				},
+				Base:    "nhash",
+				Display: "hash",
+			},
+			&banktypes.Metadata{
+				Description: "a description",
+				DenomUnits: []*banktypes.DenomUnit{
+					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
+					{Denom: "uhash", Exponent: 3, Aliases: nil},
+					{Denom: "hash", Exponent: 9, Aliases: nil},
+				},
+				Base:    "nhash",
+				Display: "hash",
+			},
+			types.StatusProposed,
+			types.DefaultUnrestrictedDenomRegex,
+			[]string{},
+		},
+		{
+			"active denom unit denom changed",
+			banktypes.Metadata{
+				Description: "a description",
+				DenomUnits: []*banktypes.DenomUnit{
+					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
+					{Denom: "microhash", Exponent: 3, Aliases: nil},
+					{Denom: "hash", Exponent: 9, Aliases: nil},
+				},
+				Base:    "nhash",
+				Display: "hash",
+			},
+			&banktypes.Metadata{
+				Description: "a description",
+				DenomUnits: []*banktypes.DenomUnit{
+					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
+					{Denom: "uhash", Exponent: 3, Aliases: nil},
+					{Denom: "hash", Exponent: 9, Aliases: nil},
+				},
+				Base:    "nhash",
+				Display: "hash",
+			},
+			types.StatusActive,
+			types.DefaultUnrestrictedDenomRegex,
+			[]string{"denom unit Denom", "uhash", "microhash"},
+		},
+		{
+			"finalized denom unit denom changed",
+			banktypes.Metadata{
+				Description: "a description",
+				DenomUnits: []*banktypes.DenomUnit{
+					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
+					{Denom: "microhash", Exponent: 3, Aliases: nil},
+					{Denom: "hash", Exponent: 9, Aliases: nil},
+				},
+				Base:    "nhash",
+				Display: "hash",
+			},
+			&banktypes.Metadata{
+				Description: "a description",
+				DenomUnits: []*banktypes.DenomUnit{
+					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
+					{Denom: "uhash", Exponent: 3, Aliases: nil},
+					{Denom: "hash", Exponent: 9, Aliases: nil},
+				},
+				Base:    "nhash",
+				Display: "hash",
+			},
+			types.StatusFinalized,
+			types.DefaultUnrestrictedDenomRegex,
+			[]string{"denom unit Denom", "uhash", "microhash"},
+		},
+		{
+			"proposed denom unit denom changed",
+			banktypes.Metadata{
+				Description: "a description",
+				DenomUnits: []*banktypes.DenomUnit{
+					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
+					{Denom: "microhash", Exponent: 3, Aliases: nil},
+					{Denom: "hash", Exponent: 9, Aliases: nil},
+				},
+				Base:    "nhash",
+				Display: "hash",
+			},
+			&banktypes.Metadata{
+				Description: "a description",
+				DenomUnits: []*banktypes.DenomUnit{
+					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
+					{Denom: "uhash", Exponent: 3, Aliases: nil},
+					{Denom: "hash", Exponent: 9, Aliases: nil},
+				},
+				Base:    "nhash",
+				Display: "hash",
+			},
+			types.StatusProposed,
+			types.DefaultUnrestrictedDenomRegex,
+			[]string{},
+		},
+		{
+			"active denom unit alias removed",
+			banktypes.Metadata{
+				Description: "a description",
+				DenomUnits: []*banktypes.DenomUnit{
+					{Denom: "nhash", Exponent: 0, Aliases: nil},
+					{Denom: "uhash", Exponent: 3, Aliases: nil},
+					{Denom: "hash", Exponent: 9, Aliases: nil},
+				},
+				Base:    "nhash",
+				Display: "hash",
+			},
+			&banktypes.Metadata{
+				Description: "a description",
+				DenomUnits: []*banktypes.DenomUnit{
+					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
+					{Denom: "uhash", Exponent: 3, Aliases: nil},
+					{Denom: "hash", Exponent: 9, Aliases: nil},
+				},
+				Base:    "nhash",
+				Display: "hash",
+			},
+			types.StatusActive,
+			types.DefaultUnrestrictedDenomRegex,
+			[]string{"cannot remove alias", "nanohash", "nhash"},
+		},
+		{
+			"finalized denom unit alias removed",
+			banktypes.Metadata{
+				Description: "a description",
+				DenomUnits: []*banktypes.DenomUnit{
+					{Denom: "nhash", Exponent: 0, Aliases: nil},
+					{Denom: "uhash", Exponent: 3, Aliases: nil},
+					{Denom: "hash", Exponent: 9, Aliases: nil},
+				},
+				Base:    "nhash",
+				Display: "hash",
+			},
+			&banktypes.Metadata{
+				Description: "a description",
+				DenomUnits: []*banktypes.DenomUnit{
+					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
+					{Denom: "uhash", Exponent: 3, Aliases: nil},
+					{Denom: "hash", Exponent: 9, Aliases: nil},
+				},
+				Base:    "nhash",
+				Display: "hash",
+			},
+			types.StatusFinalized,
+			types.DefaultUnrestrictedDenomRegex,
+			[]string{"cannot remove alias", "nanohash", "nhash"},
+		},
+		{
+			"proposed denom unit alias removed",
+			banktypes.Metadata{
+				Description: "a description",
+				DenomUnits: []*banktypes.DenomUnit{
+					{Denom: "nhash", Exponent: 0, Aliases: nil},
+					{Denom: "uhash", Exponent: 3, Aliases: nil},
+					{Denom: "hash", Exponent: 9, Aliases: nil},
+				},
+				Base:    "nhash",
+				Display: "hash",
+			},
+			&banktypes.Metadata{
+				Description: "a description",
+				DenomUnits: []*banktypes.DenomUnit{
+					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
+					{Denom: "uhash", Exponent: 3, Aliases: nil},
+					{Denom: "hash", Exponent: 9, Aliases: nil},
+				},
+				Base:    "nhash",
+				Display: "hash",
+			},
+			types.StatusProposed,
+			types.DefaultUnrestrictedDenomRegex,
+			[]string{},
+		},
+	}
+
+	for _, tc := range tests {
+		s.T().Run(tc.name, func(t *testing.T) {
+			s.app.MarkerKeeper.SetParams(s.ctx, types.Params{UnrestrictedDenomRegex: tc.denomValidationExpression})
+
+			err := s.app.MarkerKeeper.ValidateDenomMetadata(s.ctx, tc.proposed, tc.existing, tc.markerStatus)
+			if len(tc.wantInErr) > 0 {
+				require.Error(t, err, "ValidateDenomMetadataExtended expected error")
+				for _, e := range tc.wantInErr {
+					assert.Contains(t, err.Error(), e, "ValidateDenomMetadataExtended expected in error message")
+				}
+			} else {
+				require.NoError(t, err, "ValidateDenomMetadataExtended unexpected error")
+			}
+		})
+	}
+}

--- a/x/marker/keeper/keeper_test.go
+++ b/x/marker/keeper/keeper_test.go
@@ -78,16 +78,16 @@ func TestAccountUnrestrictedDenoms(t *testing.T) {
 	// Require a long unrestricted denom
 	app.MarkerKeeper.SetParams(ctx, types.Params{UnrestrictedDenomRegex: "[a-z]{12,20}"})
 
-	_, err := server.AddMarker(sdk.WrapSDKContext(ctx), types.NewAddMarkerRequest("tooshort", sdk.NewInt(30), user, user, types.MarkerType_Coin, true, true))
+	_, err := server.AddMarker(sdk.WrapSDKContext(ctx), types.NewMsgAddMarkerRequest("tooshort", sdk.NewInt(30), user, user, types.MarkerType_Coin, true, true))
 	require.Error(t, err, "fails with unrestricted denom length fault")
 	require.Equal(t, fmt.Errorf("invalid denom [tooshort] (fails unrestricted marker denom validation [a-z]{12,20})"), err, "should fail with denom restriction")
 
-	_, err = server.AddMarker(sdk.WrapSDKContext(ctx), types.NewAddMarkerRequest("itslongenough", sdk.NewInt(30), user, user, types.MarkerType_Coin, true, true))
+	_, err = server.AddMarker(sdk.WrapSDKContext(ctx), types.NewMsgAddMarkerRequest("itslongenough", sdk.NewInt(30), user, user, types.MarkerType_Coin, true, true))
 	require.NoError(t, err, "should allow a marker with a sufficiently long denom")
 
 	// Set to an empty string (returns to default expression)
 	app.MarkerKeeper.SetParams(ctx, types.Params{UnrestrictedDenomRegex: ""})
-	_, err = server.AddMarker(sdk.WrapSDKContext(ctx), types.NewAddMarkerRequest("short", sdk.NewInt(30), user, user, types.MarkerType_Coin, true, true))
+	_, err = server.AddMarker(sdk.WrapSDKContext(ctx), types.NewMsgAddMarkerRequest("short", sdk.NewInt(30), user, user, types.MarkerType_Coin, true, true))
 	// succeeds now as the default unrestricted denom expression allows any valid denom (minimum length is 2)
 	require.NoError(t, err, "should allow any valid denom with a min length of two")
 }

--- a/x/marker/keeper/marker.go
+++ b/x/marker/keeper/marker.go
@@ -580,8 +580,7 @@ func (k Keeper) SetMarkerDenomMetadata(ctx sdk.Context, metadata banktypes.Metad
 		existing = &e
 	}
 
-	params := k.GetParams(ctx)
-	if err := types.ValidateDenomMetadataExtended(metadata, existing, marker.GetStatus(), params); err != nil {
+	if err := k.ValidateDenomMetadata(ctx, metadata, existing, marker.GetStatus()); err != nil {
 		return err
 	}
 

--- a/x/marker/keeper/msg_server.go
+++ b/x/marker/keeper/msg_server.go
@@ -38,10 +38,8 @@ func (k msgServer) AddMarker(goCtx context.Context, msg *types.MsgAddMarkerReque
 		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "a marker can not be created in an ACTIVE status")
 	}
 
-	params := k.GetParams(ctx)
-
 	// Add marker requests must pass extra validation for denom (in addition to regular coin validation expression)
-	if err = types.ValidUnrestictedDenom(msg.Amount.Denom, params); err != nil {
+	if err = k.ValidateUnrestictedDenom(ctx, msg.Amount.Denom); err != nil {
 		return nil, err
 	}
 
@@ -65,7 +63,7 @@ func (k msgServer) AddMarker(goCtx context.Context, msg *types.MsgAddMarkerReque
 		msg.MarkerType)
 	ma.SupplyFixed = msg.SupplyFixed
 
-	if params.EnableGovernance {
+	if k.GetEnableGovernance(ctx) {
 		ma.AllowGovernanceControl = true
 	} else {
 		ma.AllowGovernanceControl = msg.AllowGovernanceControl

--- a/x/marker/keeper/msg_server.go
+++ b/x/marker/keeper/msg_server.go
@@ -2,8 +2,6 @@ package keeper
 
 import (
 	"context"
-	"fmt"
-	"regexp"
 
 	"github.com/armon/go-metrics"
 
@@ -43,11 +41,8 @@ func (k msgServer) AddMarker(goCtx context.Context, msg *types.MsgAddMarkerReque
 	params := k.GetParams(ctx)
 
 	// Add marker requests must pass extra validation for denom (in addition to regular coin validation expression)
-	valExp := params.UnrestrictedDenomRegex
-	if v, expErr := regexp.Compile(valExp); expErr != nil {
-		return nil, expErr
-	} else if !v.MatchString(msg.Amount.Denom) {
-		return nil, fmt.Errorf("invalid denom (fails unrestricted marker denom validation %s): %s", valExp, msg.Amount.Denom)
+	if err = types.ValidUnrestictedDenom(msg.Amount.Denom, params); err != nil {
+		return nil, err
 	}
 
 	addr := types.MustGetMarkerAddress(msg.Amount.Denom)

--- a/x/marker/keeper/params.go
+++ b/x/marker/keeper/params.go
@@ -59,9 +59,10 @@ func (k Keeper) ValidateUnrestictedDenom(ctx sdk.Context, denom string) error {
 	// Anchors are enforced on the denom validation expression.  Similar to how the SDK does hits.
 	// https://github.com/cosmos/cosmos-sdk/blob/512b533242d34926972a8fc2f5639e8cf182f5bd/types/coin.go#L625
 	exp := k.GetUnrestrictedDenomRegex(ctx)
-	if r, err := regexp.Compile(fmt.Sprintf(`^%s$`, exp)); err != nil {
-		return err
-	} else if !r.MatchString(denom) {
+
+	// Safe to use must compile here because the regular expression is validated on parameter set.
+	r := regexp.MustCompile(fmt.Sprintf(`^%s$`, exp))
+	if !r.MatchString(denom) {
 		return fmt.Errorf("invalid denom [%s] (fails unrestricted marker denom validation %s)", denom, exp)
 	}
 	return nil

--- a/x/marker/keeper/params.go
+++ b/x/marker/keeper/params.go
@@ -1,6 +1,9 @@
 package keeper
 
 import (
+	"fmt"
+	"regexp"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/provenance-io/provenance/x/marker/types"
@@ -43,6 +46,23 @@ func (k Keeper) GetUnrestrictedDenomRegex(ctx sdk.Context) (regex string) {
 	regex = types.DefaultUnrestrictedDenomRegex
 	if k.paramSpace.Has(ctx, types.ParamStoreKeyUnrestrictedDenomRegex) {
 		k.paramSpace.Get(ctx, types.ParamStoreKeyUnrestrictedDenomRegex, &regex)
+		// use the default value for empty regex expressions.
+		if len(regex) == 0 {
+			regex = types.DefaultUnrestrictedDenomRegex
+		}
 	}
 	return
+}
+
+// ValidateUnrestictedDenom checks if the supplied denom is valid based on the module params
+func (k Keeper) ValidateUnrestictedDenom(ctx sdk.Context, denom string) error {
+	// Anchors are enforced on the denom validation expression.  Similar to how the SDK does hits.
+	// https://github.com/cosmos/cosmos-sdk/blob/512b533242d34926972a8fc2f5639e8cf182f5bd/types/coin.go#L625
+	exp := k.GetUnrestrictedDenomRegex(ctx)
+	if r, err := regexp.Compile(fmt.Sprintf(`^%s$`, exp)); err != nil {
+		return err
+	} else if !r.MatchString(denom) {
+		return fmt.Errorf("invalid denom [%s] (fails unrestricted marker denom validation %s)", denom, exp)
+	}
+	return nil
 }

--- a/x/marker/types/denom_test.go
+++ b/x/marker/types/denom_test.go
@@ -2,12 +2,13 @@ package types
 
 import (
 	"fmt"
+	"strings"
+	"testing"
+
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"strings"
-	"testing"
 )
 
 type DenomTestSuite struct {
@@ -340,7 +341,7 @@ func (s *DenomTestSuite) TestValidateDenomMetadataExtended() {
 			nil,
 			StatusProposed,
 			testParams(`^[nu]hash$`),
-			[]string{"fails unrestricted marker denom regex", "hash"},
+			[]string{"fails unrestricted marker denom validation", "hash"},
 		},
 		{
 			"alias fails extra regex",
@@ -357,7 +358,7 @@ func (s *DenomTestSuite) TestValidateDenomMetadataExtended() {
 			nil,
 			StatusProposed,
 			testParams(`^[nu]?hash$`),
-			[]string{"fails unrestricted marker denom regex", "nanohash"},
+			[]string{"fails unrestricted marker denom validation", "nanohash"},
 		},
 		{
 			"invalid unrestricted marker denom regex",

--- a/x/marker/types/denom_test.go
+++ b/x/marker/types/denom_test.go
@@ -22,8 +22,8 @@ func TestDenomTestSuite(t *testing.T) {
 }
 
 type denomMetadataTestCase struct {
-	name     string
-	md       banktypes.Metadata
+	name      string
+	md        banktypes.Metadata
 	wantInErr []string
 }
 
@@ -53,11 +53,11 @@ func getValidateDenomMetadataTestCases() []denomMetadataTestCase {
 			"first denom unit is not exponent 0",
 			banktypes.Metadata{
 				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
+				DenomUnits: []*banktypes.DenomUnit{
 					{Denom: "hash", Exponent: 1, Aliases: nil},
 				},
-				Base:        "hash",
-				Display:     "hash",
+				Base:    "hash",
+				Display: "hash",
 			},
 			[]string{"denom metadata"},
 		},
@@ -65,12 +65,12 @@ func getValidateDenomMetadataTestCases() []denomMetadataTestCase {
 			"first denom unit is not base",
 			banktypes.Metadata{
 				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
+				DenomUnits: []*banktypes.DenomUnit{
 					{Denom: "nhash", Exponent: 0, Aliases: nil},
 					{Denom: "hash", Exponent: 9, Aliases: nil},
 				},
-				Base:        "hash",
-				Display:     "hash",
+				Base:    "hash",
+				Display: "hash",
 			},
 			[]string{"denom metadata"},
 		},
@@ -78,13 +78,13 @@ func getValidateDenomMetadataTestCases() []denomMetadataTestCase {
 			"denom units not ordered",
 			banktypes.Metadata{
 				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
+				DenomUnits: []*banktypes.DenomUnit{
 					{Denom: "nhash", Exponent: 0, Aliases: nil},
 					{Denom: "hash", Exponent: 9, Aliases: nil},
 					{Denom: "uhash", Exponent: 3, Aliases: nil},
 				},
-				Base:        "nhash",
-				Display:     "hash",
+				Base:    "nhash",
+				Display: "hash",
 			},
 			[]string{"denom metadata"},
 		},
@@ -92,27 +92,27 @@ func getValidateDenomMetadataTestCases() []denomMetadataTestCase {
 			"description too long",
 			banktypes.Metadata{
 				Description: strings.Repeat("d", maxDenomMetadataDescriptionLength+1),
-				DenomUnits:  []*banktypes.DenomUnit{
+				DenomUnits: []*banktypes.DenomUnit{
 					{Denom: "nhash", Exponent: 0, Aliases: nil},
 					{Denom: "uhash", Exponent: 3, Aliases: nil},
 					{Denom: "hash", Exponent: 9, Aliases: nil},
 				},
-				Base:        "nhash",
-				Display:     "hash",
+				Base:    "nhash",
+				Display: "hash",
 			},
-			[]string{"description", fmt.Sprint(maxDenomMetadataDescriptionLength), fmt.Sprint(maxDenomMetadataDescriptionLength+1)},
+			[]string{"description", fmt.Sprint(maxDenomMetadataDescriptionLength), fmt.Sprint(maxDenomMetadataDescriptionLength + 1)},
 		},
 		{
 			"no root coin name",
 			banktypes.Metadata{
 				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
+				DenomUnits: []*banktypes.DenomUnit{
 					{Denom: "nhash", Exponent: 0, Aliases: nil},
 					{Denom: "hashx", Exponent: 3, Aliases: nil},
 					{Denom: "hash", Exponent: 9, Aliases: nil},
 				},
-				Base:        "nhash",
-				Display:     "hash",
+				Base:    "nhash",
+				Display: "hash",
 			},
 			[]string{"root coin name"},
 		},
@@ -120,13 +120,13 @@ func getValidateDenomMetadataTestCases() []denomMetadataTestCase {
 			"base prefix not SI",
 			banktypes.Metadata{
 				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
+				DenomUnits: []*banktypes.DenomUnit{
 					{Denom: "xhash", Exponent: 0, Aliases: nil},
 					{Denom: "uhash", Exponent: 3, Aliases: nil},
 					{Denom: "hash", Exponent: 9, Aliases: nil},
 				},
-				Base:        "xhash",
-				Display:     "hash",
+				Base:    "xhash",
+				Display: "hash",
 			},
 			[]string{"root coin name", "is not a SI prefix"},
 		},
@@ -134,13 +134,13 @@ func getValidateDenomMetadataTestCases() []denomMetadataTestCase {
 			"alias duplicates other name",
 			banktypes.Metadata{
 				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
+				DenomUnits: []*banktypes.DenomUnit{
 					{Denom: "nhash", Exponent: 0, Aliases: nil},
 					{Denom: "uhash", Exponent: 3, Aliases: nil},
 					{Denom: "hash", Exponent: 9, Aliases: []string{"uhash"}},
 				},
-				Base:        "nhash",
-				Display:     "hash",
+				Base:    "nhash",
+				Display: "hash",
 			},
 			[]string{"denom or alias", "is not unique", "uhash"},
 		},
@@ -148,14 +148,14 @@ func getValidateDenomMetadataTestCases() []denomMetadataTestCase {
 			"denom duplicates other name",
 			banktypes.Metadata{
 				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
+				DenomUnits: []*banktypes.DenomUnit{
 					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
 					{Denom: "uhash", Exponent: 3, Aliases: nil},
 					{Denom: "hash", Exponent: 9, Aliases: nil},
 					{Denom: "nanohash", Exponent: 12, Aliases: nil},
 				},
-				Base:        "nhash",
-				Display:     "hash",
+				Base:    "nhash",
+				Display: "hash",
 			},
 			[]string{"denom or alias", "is not unique", "nanohash"},
 		},
@@ -163,13 +163,13 @@ func getValidateDenomMetadataTestCases() []denomMetadataTestCase {
 			"denom unit denom is not valid a coin denomination",
 			banktypes.Metadata{
 				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
+				DenomUnits: []*banktypes.DenomUnit{
 					{Denom: "nhash", Exponent: 0, Aliases: nil},
 					{Denom: "uhash", Exponent: 3, Aliases: nil},
 					{Denom: "x", Exponent: 9, Aliases: nil},
 				},
-				Base:        "nhash",
-				Display:     "hash",
+				Base:    "nhash",
+				Display: "hash",
 			},
 			[]string{"denom metadata"},
 		},
@@ -177,13 +177,13 @@ func getValidateDenomMetadataTestCases() []denomMetadataTestCase {
 			"denom unit denom exponent is incorrect",
 			banktypes.Metadata{
 				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
+				DenomUnits: []*banktypes.DenomUnit{
 					{Denom: "nhash", Exponent: 0, Aliases: nil},
 					{Denom: "uhash", Exponent: 3, Aliases: nil},
 					{Denom: "hash", Exponent: 8, Aliases: nil},
 				},
-				Base:        "nhash",
-				Display:     "hash",
+				Base:    "nhash",
+				Display: "hash",
 			},
 			[]string{"exponent", "hash", "0", "-9", "= 9", "8"},
 		},
@@ -191,13 +191,13 @@ func getValidateDenomMetadataTestCases() []denomMetadataTestCase {
 			"denom unit alias is not valid a coin denomination",
 			banktypes.Metadata{
 				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
+				DenomUnits: []*banktypes.DenomUnit{
 					{Denom: "nhash", Exponent: 0, Aliases: nil},
 					{Denom: "uhash", Exponent: 3, Aliases: nil},
-					{Denom: "hash", Exponent: 9, Aliases: []string{strings.Repeat("x", 128)+"hash"}},
+					{Denom: "hash", Exponent: 9, Aliases: []string{strings.Repeat("x", 128) + "hash"}},
 				},
-				Base:        "nhash",
-				Display:     "hash",
+				Base:    "nhash",
+				Display: "hash",
 			},
 			[]string{"invalid alias", "x"},
 		},
@@ -205,29 +205,17 @@ func getValidateDenomMetadataTestCases() []denomMetadataTestCase {
 			"denom unit denom alias prefix mismatch",
 			banktypes.Metadata{
 				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
+				DenomUnits: []*banktypes.DenomUnit{
 					{Denom: "nhash", Exponent: 0, Aliases: nil},
 					{Denom: "uhash", Exponent: 3, Aliases: nil},
 					{Denom: "hash", Exponent: 9, Aliases: nil},
 					{Denom: "megahash", Exponent: 15, Aliases: []string{"mhash"}},
 				},
-				Base:        "nhash",
-				Display:     "hash",
+				Base:    "nhash",
+				Display: "hash",
 			},
 			[]string{"SI prefix", "mhash", "megahash"},
 		},
-	}
-}
-
-func defaultTestParams() Params {
-	return testParams(`^[a-zA-Z]{4,30}$`)
-}
-
-func testParams(regex string) Params {
-	return Params{
-		MaxTotalSupply:         0,
-		EnableGovernance:       false,
-		UnrestrictedDenomRegex: regex,
 	}
 }
 
@@ -249,408 +237,6 @@ func (s *DenomTestSuite) TestValidateDenomMetadataBasic() {
 	}
 }
 
-func (s *DenomTestSuite) TestValidateDenomMetadataExtended() {
-	basicTests := getValidateDenomMetadataTestCases()
-
-	// Should call ValidateDenomMetadataBasic, so all these should apply here too.
-	for _, tc := range basicTests {
-		s.T().Run("basic " + tc.name, func(t *testing.T) {
-			err := ValidateDenomMetadataExtended(tc.md, nil, StatusProposed, defaultTestParams())
-			if len(tc.wantInErr) > 0 {
-				require.Error(t, err, "ValidateDenomMetadataExtended expected error")
-				for _, e := range tc.wantInErr {
-					assert.Contains(t, err.Error(), e, "ValidateDenomMetadataExtended expected in error message")
-				}
-			} else {
-				require.NoError(t, err, "ValidateDenomMetadataExtended unexpected error")
-			}
-		})
-	}
-
-	tests := []struct {
-		name string
-		proposed     banktypes.Metadata
-		existing     *banktypes.Metadata
-		markerStatus MarkerStatus
-		params       Params
-		wantInErr    []string
-	}{
-		{
-			"marker status undefined",
-			banktypes.Metadata{
-				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
-					{Denom: "nhash", Exponent: 0, Aliases: nil},
-					{Denom: "uhash", Exponent: 3, Aliases: nil},
-					{Denom: "hash", Exponent: 9, Aliases: nil},
-				},
-				Base:        "nhash",
-				Display:     "hash",
-			},
-			nil,
-			StatusUndefined,
-			defaultTestParams(),
-			[]string{"cannot add or update denom metadata", "undefined"},
-		},
-		{
-			"marker status destroyed",
-			banktypes.Metadata{
-				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
-					{Denom: "nhash", Exponent: 0, Aliases: nil},
-					{Denom: "uhash", Exponent: 3, Aliases: nil},
-					{Denom: "hash", Exponent: 9, Aliases: nil},
-				},
-				Base:        "nhash",
-				Display:     "hash",
-			},
-			nil,
-			StatusDestroyed,
-			defaultTestParams(),
-			[]string{"cannot add or update denom metadata", "destroyed"},
-		},
-		{
-			"marker status cancelled",
-			banktypes.Metadata{
-				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
-					{Denom: "nhash", Exponent: 0, Aliases: nil},
-					{Denom: "uhash", Exponent: 3, Aliases: nil},
-					{Denom: "hash", Exponent: 9, Aliases: nil},
-				},
-				Base:        "nhash",
-				Display:     "hash",
-			},
-			nil,
-			StatusCancelled,
-			defaultTestParams(),
-			[]string{"cannot add or update denom metadata", "cancelled"},
-		},
-		{
-			"denom fails extra regex",
-			banktypes.Metadata{
-				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
-					{Denom: "nhash", Exponent: 0, Aliases: nil},
-					{Denom: "uhash", Exponent: 3, Aliases: nil},
-					{Denom: "hash", Exponent: 9, Aliases: nil},
-				},
-				Base:        "nhash",
-				Display:     "hash",
-			},
-			nil,
-			StatusProposed,
-			testParams(`^[nu]hash$`),
-			[]string{"fails unrestricted marker denom validation", "hash"},
-		},
-		{
-			"alias fails extra regex",
-			banktypes.Metadata{
-				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
-					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
-					{Denom: "uhash", Exponent: 3, Aliases: nil},
-					{Denom: "hash", Exponent: 9, Aliases: nil},
-				},
-				Base:        "nhash",
-				Display:     "hash",
-			},
-			nil,
-			StatusProposed,
-			testParams(`^[nu]?hash$`),
-			[]string{"fails unrestricted marker denom validation", "nanohash"},
-		},
-		{
-			"invalid unrestricted marker denom regex",
-			banktypes.Metadata{
-				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
-					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
-					{Denom: "uhash", Exponent: 3, Aliases: nil},
-					{Denom: "hash", Exponent: 9, Aliases: nil},
-				},
-				Base:        "nhash",
-				Display:     "hash",
-			},
-			nil,
-			StatusProposed,
-			testParams(`(foo`),
-			[]string{"error parsing regexp"},
-		},
-		{
-			"base changed",
-			banktypes.Metadata{
-				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
-					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
-					{Denom: "uhash", Exponent: 3, Aliases: nil},
-					{Denom: "hash", Exponent: 9, Aliases: nil},
-				},
-				Base:        "nhash",
-				Display:     "hash",
-			},
-			&banktypes.Metadata{
-				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
-					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
-					{Denom: "uhash", Exponent: 3, Aliases: nil},
-					{Denom: "hash", Exponent: 9, Aliases: nil},
-				},
-				Base:        "uhash",
-				Display:     "hash",
-			},
-			StatusProposed,
-			defaultTestParams(),
-			[]string{"denom metadata base value cannot be changed"},
-		},
-		{
-			"active denom unit removed",
-			banktypes.Metadata{
-				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
-					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
-					{Denom: "hash", Exponent: 9, Aliases: nil},
-				},
-				Base:        "nhash",
-				Display:     "hash",
-			},
-			&banktypes.Metadata{
-				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
-					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
-					{Denom: "uhash", Exponent: 3, Aliases: nil},
-					{Denom: "hash", Exponent: 9, Aliases: nil},
-				},
-				Base:        "nhash",
-				Display:     "hash",
-			},
-			StatusActive,
-			defaultTestParams(),
-			[]string{"cannot remove denom unit", "uhash"},
-		},
-		{
-			"finalized denom unit removed",
-			banktypes.Metadata{
-				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
-					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
-					{Denom: "hash", Exponent: 9, Aliases: nil},
-				},
-				Base:        "nhash",
-				Display:     "hash",
-			},
-			&banktypes.Metadata{
-				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
-					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
-					{Denom: "uhash", Exponent: 3, Aliases: nil},
-					{Denom: "hash", Exponent: 9, Aliases: nil},
-				},
-				Base:        "nhash",
-				Display:     "hash",
-			},
-			StatusFinalized,
-			defaultTestParams(),
-			[]string{"cannot remove denom unit", "uhash"},
-		},
-		{
-			"proposed denom unit removed",
-			banktypes.Metadata{
-				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
-					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
-					{Denom: "hash", Exponent: 9, Aliases: nil},
-				},
-				Base:        "nhash",
-				Display:     "hash",
-			},
-			&banktypes.Metadata{
-				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
-					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
-					{Denom: "uhash", Exponent: 3, Aliases: nil},
-					{Denom: "hash", Exponent: 9, Aliases: nil},
-				},
-				Base:        "nhash",
-				Display:     "hash",
-			},
-			StatusProposed,
-			defaultTestParams(),
-			[]string{},
-		},
-		{
-			"active denom unit denom changed",
-			banktypes.Metadata{
-				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
-					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
-					{Denom: "microhash", Exponent: 3, Aliases: nil},
-					{Denom: "hash", Exponent: 9, Aliases: nil},
-				},
-				Base:        "nhash",
-				Display:     "hash",
-			},
-			&banktypes.Metadata{
-				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
-					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
-					{Denom: "uhash", Exponent: 3, Aliases: nil},
-					{Denom: "hash", Exponent: 9, Aliases: nil},
-				},
-				Base:        "nhash",
-				Display:     "hash",
-			},
-			StatusActive,
-			defaultTestParams(),
-			[]string{"denom unit Denom", "uhash", "microhash"},
-		},
-		{
-			"finalized denom unit denom changed",
-			banktypes.Metadata{
-				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
-					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
-					{Denom: "microhash", Exponent: 3, Aliases: nil},
-					{Denom: "hash", Exponent: 9, Aliases: nil},
-				},
-				Base:        "nhash",
-				Display:     "hash",
-			},
-			&banktypes.Metadata{
-				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
-					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
-					{Denom: "uhash", Exponent: 3, Aliases: nil},
-					{Denom: "hash", Exponent: 9, Aliases: nil},
-				},
-				Base:        "nhash",
-				Display:     "hash",
-			},
-			StatusFinalized,
-			defaultTestParams(),
-			[]string{"denom unit Denom", "uhash", "microhash"},
-		},
-		{
-			"proposed denom unit denom changed",
-			banktypes.Metadata{
-				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
-					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
-					{Denom: "microhash", Exponent: 3, Aliases: nil},
-					{Denom: "hash", Exponent: 9, Aliases: nil},
-				},
-				Base:        "nhash",
-				Display:     "hash",
-			},
-			&banktypes.Metadata{
-				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
-					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
-					{Denom: "uhash", Exponent: 3, Aliases: nil},
-					{Denom: "hash", Exponent: 9, Aliases: nil},
-				},
-				Base:        "nhash",
-				Display:     "hash",
-			},
-			StatusProposed,
-			defaultTestParams(),
-			[]string{},
-		},
-		{
-			"active denom unit alias removed",
-			banktypes.Metadata{
-				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
-					{Denom: "nhash", Exponent: 0, Aliases: nil},
-					{Denom: "uhash", Exponent: 3, Aliases: nil},
-					{Denom: "hash", Exponent: 9, Aliases: nil},
-				},
-				Base:        "nhash",
-				Display:     "hash",
-			},
-			&banktypes.Metadata{
-				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
-					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
-					{Denom: "uhash", Exponent: 3, Aliases: nil},
-					{Denom: "hash", Exponent: 9, Aliases: nil},
-				},
-				Base:        "nhash",
-				Display:     "hash",
-			},
-			StatusActive,
-			defaultTestParams(),
-			[]string{"cannot remove alias", "nanohash", "nhash"},
-		},
-		{
-			"finalized denom unit alias removed",
-			banktypes.Metadata{
-				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
-					{Denom: "nhash", Exponent: 0, Aliases: nil},
-					{Denom: "uhash", Exponent: 3, Aliases: nil},
-					{Denom: "hash", Exponent: 9, Aliases: nil},
-				},
-				Base:        "nhash",
-				Display:     "hash",
-			},
-			&banktypes.Metadata{
-				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
-					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
-					{Denom: "uhash", Exponent: 3, Aliases: nil},
-					{Denom: "hash", Exponent: 9, Aliases: nil},
-				},
-				Base:        "nhash",
-				Display:     "hash",
-			},
-			StatusFinalized,
-			defaultTestParams(),
-			[]string{"cannot remove alias", "nanohash", "nhash"},
-		},
-		{
-			"proposed denom unit alias removed",
-			banktypes.Metadata{
-				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
-					{Denom: "nhash", Exponent: 0, Aliases: nil},
-					{Denom: "uhash", Exponent: 3, Aliases: nil},
-					{Denom: "hash", Exponent: 9, Aliases: nil},
-				},
-				Base:        "nhash",
-				Display:     "hash",
-			},
-			&banktypes.Metadata{
-				Description: "a description",
-				DenomUnits:  []*banktypes.DenomUnit{
-					{Denom: "nhash", Exponent: 0, Aliases: []string{"nanohash"}},
-					{Denom: "uhash", Exponent: 3, Aliases: nil},
-					{Denom: "hash", Exponent: 9, Aliases: nil},
-				},
-				Base:        "nhash",
-				Display:     "hash",
-			},
-			StatusProposed,
-			defaultTestParams(),
-			[]string{},
-		},
-	}
-
-	for _, tc := range tests {
-		s.T().Run(tc.name, func(t *testing.T) {
-			err := ValidateDenomMetadataExtended(tc.proposed, tc.existing, tc.markerStatus, tc.params)
-			if len(tc.wantInErr) > 0 {
-				require.Error(t, err, "ValidateDenomMetadataExtended expected error")
-				for _, e := range tc.wantInErr {
-					assert.Contains(t, err.Error(), e, "ValidateDenomMetadataExtended expected in error message")
-				}
-			} else {
-				require.NoError(t, err, "ValidateDenomMetadataExtended unexpected error")
-			}
-		})
-	}
-}
-
 func (s *DenomTestSuite) TestGetRootCoinName() {
 	tests := []struct {
 		name     string
@@ -665,10 +251,10 @@ func (s *DenomTestSuite) TestGetRootCoinName() {
 		{
 			"only one name",
 			banktypes.Metadata{
-				DenomUnits:  []*banktypes.DenomUnit{
+				DenomUnits: []*banktypes.DenomUnit{
 					{
-						Denom:    "onename",
-						Aliases:  nil,
+						Denom:   "onename",
+						Aliases: nil,
 					},
 				},
 			},
@@ -677,10 +263,10 @@ func (s *DenomTestSuite) TestGetRootCoinName() {
 		{
 			"no common root",
 			banktypes.Metadata{
-				DenomUnits:  []*banktypes.DenomUnit{
+				DenomUnits: []*banktypes.DenomUnit{
 					{
-						Denom:    "onename",
-						Aliases:  []string{"another"},
+						Denom:   "onename",
+						Aliases: []string{"another"},
 					},
 				},
 			},
@@ -689,10 +275,10 @@ func (s *DenomTestSuite) TestGetRootCoinName() {
 		{
 			"simple test",
 			banktypes.Metadata{
-				DenomUnits:  []*banktypes.DenomUnit{
+				DenomUnits: []*banktypes.DenomUnit{
 					{
-						Denom:    "onename",
-						Aliases:  []string{"twoname"},
+						Denom:   "onename",
+						Aliases: []string{"twoname"},
 					},
 				},
 			},
@@ -701,18 +287,18 @@ func (s *DenomTestSuite) TestGetRootCoinName() {
 		{
 			"real-use test",
 			banktypes.Metadata{
-				DenomUnits:  []*banktypes.DenomUnit{
+				DenomUnits: []*banktypes.DenomUnit{
 					{
-						Denom:    "nanohash",
-						Aliases:  []string{"nhash"},
+						Denom:   "nanohash",
+						Aliases: []string{"nhash"},
 					},
 					{
-						Denom:    "hash",
-						Aliases:  nil,
+						Denom:   "hash",
+						Aliases: nil,
 					},
 					{
-						Denom:    "kilohash",
-						Aliases:  []string{"khash"},
+						Denom:   "kilohash",
+						Aliases: []string{"khash"},
 					},
 				},
 			},

--- a/x/marker/types/params.go
+++ b/x/marker/types/params.go
@@ -123,10 +123,7 @@ func validateRegexParam(i interface{}) error {
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
 	}
-	if len(exp) < 1 {
-		return fmt.Errorf("invalid parameter, validation regex not be empty")
-	}
-	if exp[0:1] == "^" || exp[len(exp)-1:] == "$" {
+	if len(exp) > 0 && (exp[0:1] == "^" || exp[len(exp)-1:] == "$") {
 		return fmt.Errorf("invalid parameter, validation regex must not contain anchors ^,$")
 	}
 	_, err := regexp.Compile(fmt.Sprintf(`^%s$`, exp))

--- a/x/marker/types/params.go
+++ b/x/marker/types/params.go
@@ -123,7 +123,13 @@ func validateRegexParam(i interface{}) error {
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
 	}
-	_, err := regexp.Compile(exp)
+	if len(exp) < 1 {
+		return fmt.Errorf("invalid parameter, validation regex not be empty")
+	}
+	if exp[0:1] == "^" || exp[len(exp)-1:] == "$" {
+		return fmt.Errorf("invalid parameter, validation regex must not contain anchors ^,$")
+	}
+	_, err := regexp.Compile(fmt.Sprintf(`^%s$`, exp))
 
 	return err
 }

--- a/x/marker/types/params_test.go
+++ b/x/marker/types/params_test.go
@@ -61,6 +61,15 @@ func TestParamSetPairs(t *testing.T) {
 			require.Error(t, pairs[i].ValidatorFn("\\!(")) // invalid regex
 			require.NoError(t, pairs[i].ValidatorFn("[a-z].*"))
 
+			// Prohibit use of anchors (these are always enforced and will be added to every expression)
+			require.Error(t, pairs[i].ValidatorFn("^[a-z].*"))
+			require.Error(t, pairs[i].ValidatorFn("^[a-z].*$"))
+			require.Error(t, pairs[i].ValidatorFn("[a-z].*$"))
+
+			// If the expression contains the anchors but they are not at the end of the expression that is allowed (however unrealistic)
+			require.NoError(t, pairs[i].ValidatorFn("[a-z].*$."))
+			require.NoError(t, pairs[i].ValidatorFn(".^[a-z].*$."))
+
 		default:
 			require.Fail(t, "unexpected param set pair")
 		}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Standardize on always using the anchored regex for denom evaluation in markers similar to the upstream SDK approach
https://github.com/iramiller/cosmos-sdk/blob/512b533242d34926972a8fc2f5639e8cf182f5bd/types/coin.go#L625


closes: #258

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
