### PR TITLE
Fix p8e contract specification uuid.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+### Bug Fixes
+
+* More mapping fixes related to `WriteP8EContractSpec` and `P8EMemorializeContract` #275
+
 ## [v1.2.0](https://github.com/provenance-io/provenance/releases/tag/v1.2.0) - 2021-04-26
 
 ### Improvements

--- a/x/metadata/keeper/record.go
+++ b/x/metadata/keeper/record.go
@@ -74,7 +74,7 @@ func (k Keeper) SetRecord(ctx sdk.Context, record types.Record) {
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(
 			eventType,
-			sdk.NewAttribute(types.AttributeKeyScopeID, recordID.String()),
+			sdk.NewAttribute(types.AttributeKeyRecordID, recordID.String()),
 		),
 	)
 }

--- a/x/metadata/legacy/v040/migrate_test.go
+++ b/x/metadata/legacy/v040/migrate_test.go
@@ -246,12 +246,12 @@ func TestMigrate(t *testing.T) {
         "name": "ExampleContract",
         "website_url": ""
       },
-      "hash": "E36eeTUk8GYXGXjIbZTm4s/Dw3G1e42SinH1195t4ekgcXXPhfIpfQaEJ21PTzKhdv6JjhzQJ2kAJXK+TRXmeQ==",
+      "hash": "fJXLW6TsYwWys0utfWwrqaZiqAx27Kl2sj3dXVO9fOU8g32/uuL2fBr6ajlSeRMPRrNE05Mz8AVJE2XvWhvEvw==",
       "owner_addresses": [],
       "parties_involved": [
         "PARTY_TYPE_ORIGINATOR"
       ],
-      "specification_id": "contractspec1qvfha8nex5j0qeshr9uvsmv5um3q7sghss"
+      "specification_id": "contractspec1qd7ftj6m5nkxxpdjkd966ltv9w5sjjc9tt"
     }
   ],
   "o_s_locator_params": {
@@ -278,7 +278,7 @@ func TestMigrate(t *testing.T) {
         "PARTY_TYPE_ORIGINATOR"
       ],
       "result_type": "DEFINITION_TYPE_PROPOSED",
-      "specification_id": "recspec1q5fha8nex5j0qeshr9uvsmv5um32y0aeyhnus90eqmv3xfwwugdwqt2xfzw",
+      "specification_id": "recspec1q47ftj6m5nkxxpdjkd966ltv9w56y0aeyhnus90eqmv3xfwwugdwq738ll6",
       "type_name": "io.provenance.loan.LoanProtos$PartiesList"
     },
     {
@@ -299,7 +299,7 @@ func TestMigrate(t *testing.T) {
         "PARTY_TYPE_ORIGINATOR"
       ],
       "result_type": "DEFINITION_TYPE_PROPOSED",
-      "specification_id": "recspec1q5fha8nex5j0qeshr9uvsmv5um3fk945f58q5h9vf7tghmaskk67kve3mq3",
+      "specification_id": "recspec1q47ftj6m5nkxxpdjkd966ltv9w5ek945f58q5h9vf7tghmaskk67kezsda9",
       "type_name": "io.provenance.common.DocumentProtos$DocumentList"
     }
   ],

--- a/x/metadata/types/p8e.go
+++ b/x/metadata/types/p8e.go
@@ -10,11 +10,10 @@ import (
 
 	"github.com/btcsuite/btcd/btcec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/golang/protobuf/proto"
+	"github.com/gogo/protobuf/proto"
+	"github.com/google/uuid"
 	tmcrypt "github.com/tendermint/tendermint/crypto"
 	tmcurve "github.com/tendermint/tendermint/crypto/secp256k1"
-
-	"github.com/google/uuid"
 )
 
 // ConvertP8eContractSpec converts a v39 ContractSpec to a v40 ContractSpecification

--- a/x/metadata/types/p8e.go
+++ b/x/metadata/types/p8e.go
@@ -2,7 +2,7 @@ package types
 
 import (
 	"bytes"
-	"crypto/sha256"
+	"crypto/sha512"
 	"encoding/base64"
 	"fmt"
 
@@ -26,8 +26,8 @@ func ConvertP8eContractSpec(old *p8e.ContractSpec, owners []string) (
 	if err != nil {
 		return newSpec, nil, err
 	}
-	sha256Old := sha256.Sum256(rawProtoOld)
-	specUUID, err := uuid.FromBytes(sha256Old[0:16])
+	sha512Old := sha512.Sum512(rawProtoOld)
+	specUUID, err := uuid.FromBytes(sha512Old[0:16])
 	if err != nil {
 		return newSpec, nil, err
 	}
@@ -47,7 +47,7 @@ func ConvertP8eContractSpec(old *p8e.ContractSpec, owners []string) (
 		PartiesInvolved: parties,
 		OwnerAddresses:  owners,
 		Source: &ContractSpecification_Hash{
-			Hash: base64.StdEncoding.EncodeToString(sha256Old[:]),
+			Hash: base64.StdEncoding.EncodeToString(sha512Old[:]),
 		},
 		ClassName: old.Definition.ResourceLocation.Classname,
 	}

--- a/x/metadata/types/p8e_test.go
+++ b/x/metadata/types/p8e_test.go
@@ -128,13 +128,14 @@ func appendUnique(list []string, newval string) []string {
 }
 
 func createContractSpec(inputSpecs []*p8e.DefinitionSpec, outputSpec p8e.OutputSpec, definitionSpec p8e.DefinitionSpec) p8e.ContractSpec {
-	return p8e.ContractSpec{ConsiderationSpecs: []*p8e.ConsiderationSpec{
-		{FuncName: "additionalParties",
-			InputSpecs:       inputSpecs,
-			OutputSpec:       &outputSpec,
-			ResponsibleParty: 1,
+	return p8e.ContractSpec{
+		ConsiderationSpecs: []*p8e.ConsiderationSpec{
+			{FuncName: "additionalParties",
+				InputSpecs:       inputSpecs,
+				OutputSpec:       &outputSpec,
+				ResponsibleParty: 1,
+			},
 		},
-	},
 		Definition:      &definitionSpec,
 		InputSpecs:      inputSpecs,
 		PartiesInvolved: []p8e.PartyType{p8e.PartyType_PARTY_TYPE_AFFILIATE},
@@ -159,7 +160,6 @@ func (s *P8eTestSuite) TestConvertP8eContractSpec() {
 	invalidDefSpecNoClass := createDefinitionSpec("perform_action", "", p8e.ProvenanceReference{Hash: "Adv+huolGTKofYCR0dw5GHm/R7sUWOwF32XR8r8r9kDy4il5U/LApxOWYHb05jhK4+eY4YzRMRiWcxU3Lx0+Mw=="}, 1)
 	invalidDefSpecUUID := createDefinitionSpec("perform_input_checks", "io.provenance.loan.LoanProtos$PartiesList", p8e.ProvenanceReference{ScopeUuid: &p8e.UUID{Value: "not-a-uuid"}, Name: "recordname"}, 1)
 	invalidDefSpecUUIDNoName := createDefinitionSpec("perform_input_checks", "io.provenance.loan.LoanProtos$PartiesList", p8e.ProvenanceReference{ScopeUuid: &p8e.UUID{Value: uuid.New().String()}}, 1)
-	invalidDefSpecHash := createDefinitionSpec("ExampleContract", "io.provenance.contracts.ExampleContract", p8e.ProvenanceReference{Hash: "should fail to decode this"}, 1)
 
 	cases := map[string]struct {
 		v39CSpec p8e.ContractSpec
@@ -196,12 +196,6 @@ func (s *P8eTestSuite) TestConvertP8eContractSpec() {
 			[]string{s.user1},
 			true,
 			"record specification type name cannot be empty",
-		},
-		"should fail to decode resource location": {
-			createContractSpec([]*p8e.DefinitionSpec{&validDefSpec}, p8e.OutputSpec{Spec: &validDefSpec}, invalidDefSpecHash),
-			[]string{s.user1},
-			true,
-			"illegal base64 data at input byte 6",
 		},
 		"should fail to decode input spec uuid": {
 			createContractSpec([]*p8e.DefinitionSpec{&invalidDefSpecUUID}, p8e.OutputSpec{Spec: &validDefSpec}, validDefSpec),


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

For `WriteP8EContractSpec`, use a hash of the proto as the source hash. Also use the first 16 bytes of that hash as the uuid. This more closely reflects what was previously done.

For `P8EMemorializeContract` get the contract spec uuid from the `contract.Spec` area. Also use the `contract.Definition` for the session name (instead of using the `.Spec`).

Fix the `SetRecord` event key (was `scope_id` but should be `record_id`).

closes: #275

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
