### PR TITLE
P8EMemorializeContract: Limit scope field changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+### Bug Fixes
+
+* P8EMemorializeContract: preserve some Scope fields if the scope already exists [PR 336](https://github.com/provenance-io/provenance/pull/336)
 
 ## [v1.3.1](https://github.com/provenance-io/provenance/releases/tag/v1.3.1) - 2021-05-21
 

--- a/x/metadata/keeper/keeper.go
+++ b/x/metadata/keeper/keeper.go
@@ -245,7 +245,7 @@ func (k Keeper) EmitEvent(ctx sdk.Context, event proto.Message) {
 }
 
 // unionUnique gets a union of the provided sets of strings without any duplicates.
-func (k Keeper) unionNoDups(sets ...[]string) []string {
+func (k Keeper) UnionDistinct(sets ...[]string) []string {
 	retval := []string{}
 	for _, s := range sets {
 		for _, v := range s {

--- a/x/metadata/keeper/keeper.go
+++ b/x/metadata/keeper/keeper.go
@@ -244,6 +244,26 @@ func (k Keeper) EmitEvent(ctx sdk.Context, event proto.Message) {
 	}
 }
 
+// unionUnique gets a union of the provided sets of strings without any duplicates.
+func (k Keeper) unionNoDups(sets ...[]string) []string {
+	retval := []string{}
+	for _, s := range sets {
+		for _, v := range s {
+			f := false
+			for _, r := range retval {
+				if r == v {
+					f = true
+					break
+				}
+			}
+			if !f {
+				retval = append(retval, v)
+			}
+		}
+	}
+	return retval
+}
+
 func (k Keeper) checkValidURI(uri string, ctx sdk.Context) (*url.URL, error) {
 	urlToPersist, err := url.Parse(uri)
 	if err != nil {

--- a/x/metadata/keeper/keeper_test.go
+++ b/x/metadata/keeper/keeper_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"fmt"
+	"sort"
 	"testing"
 
 	simapp "github.com/provenance-io/provenance/app"
@@ -534,4 +535,72 @@ func (s *KeeperTestSuite) TestDeleteOSLocator() {
 		s.Require().False(found)
 
 	})
+}
+
+func (s *KeeperTestSuite) TestUnionDistinct() {
+	tests := []struct {
+		name string
+		inputs [][]string
+		output []string
+	}{
+		{
+			"empty in empty out",
+			[][]string{},
+			[]string{},
+		},
+		{
+			"one set in same set out",
+			[][]string{{"a", "b", "c"}},
+			[]string{"a", "b", "c"},
+		},
+		{
+			"two dup sets in single entries out",
+			[][]string{{"a", "b", "c"},{"a", "b", "c"}},
+			[]string{"a", "b", "c"},
+		},
+		{
+			"unique sets in combined for out",
+			[][]string{{"a", "b", "c"},{"d", "e"}},
+			[]string{"a", "b", "c", "d", "e"},
+		},
+		{
+			"empty set filled set in combined for out",
+			[][]string{{},{"a", "b", "c"}},
+			[]string{"a", "b", "c"},
+		},
+		{
+			"filled set empty set in combined for out",
+			[][]string{{"a", "b", "c"},{}},
+			[]string{"a", "b", "c"},
+		},
+		{
+			"two sets with one common entry in combined correctly for out",
+			[][]string{{"a", "b", "c"},{"d", "a", "e"}},
+			[]string{"a", "b", "c", "d", "e"},
+		},
+		{
+			"set with one entry and set with two entries in combined correctly for out",
+			[][]string{{"a"},{"a", "b"}},
+			[]string{"a", "b"},
+		},
+		{
+			"set with two entries set with one entry in combined correctly for out",
+			[][]string{{"a", "b"},{"a"}},
+			[]string{"a", "b"},
+		},
+		{
+			"set with dups and set with two entries in combined correctly for out",
+			[][]string{{"a", "a"},{"a", "b"}},
+			[]string{"a", "b"},
+		},
+	}
+
+	for _, tc := range tests {
+		s.T().Run(tc.name, func(t *testing.T) {
+			output := s.app.MetadataKeeper.UnionDistinct(tc.inputs...)
+			sort.Strings(output)
+			sort.Strings(tc.output)
+			assert.Equal(t, tc.output, output)
+		})
+	}
 }

--- a/x/metadata/keeper/keeper_test.go
+++ b/x/metadata/keeper/keeper_test.go
@@ -539,7 +539,7 @@ func (s *KeeperTestSuite) TestDeleteOSLocator() {
 
 func (s *KeeperTestSuite) TestUnionDistinct() {
 	tests := []struct {
-		name string
+		name   string
 		inputs [][]string
 		output []string
 	}{
@@ -555,42 +555,42 @@ func (s *KeeperTestSuite) TestUnionDistinct() {
 		},
 		{
 			"two dup sets in single entries out",
-			[][]string{{"a", "b", "c"},{"a", "b", "c"}},
+			[][]string{{"a", "b", "c"}, {"a", "b", "c"}},
 			[]string{"a", "b", "c"},
 		},
 		{
 			"unique sets in combined for out",
-			[][]string{{"a", "b", "c"},{"d", "e"}},
+			[][]string{{"a", "b", "c"}, {"d", "e"}},
 			[]string{"a", "b", "c", "d", "e"},
 		},
 		{
 			"empty set filled set in combined for out",
-			[][]string{{},{"a", "b", "c"}},
+			[][]string{{}, {"a", "b", "c"}},
 			[]string{"a", "b", "c"},
 		},
 		{
 			"filled set empty set in combined for out",
-			[][]string{{"a", "b", "c"},{}},
+			[][]string{{"a", "b", "c"}, {}},
 			[]string{"a", "b", "c"},
 		},
 		{
 			"two sets with one common entry in combined correctly for out",
-			[][]string{{"a", "b", "c"},{"d", "a", "e"}},
+			[][]string{{"a", "b", "c"}, {"d", "a", "e"}},
 			[]string{"a", "b", "c", "d", "e"},
 		},
 		{
 			"set with one entry and set with two entries in combined correctly for out",
-			[][]string{{"a"},{"a", "b"}},
+			[][]string{{"a"}, {"a", "b"}},
 			[]string{"a", "b"},
 		},
 		{
 			"set with two entries set with one entry in combined correctly for out",
-			[][]string{{"a", "b"},{"a"}},
+			[][]string{{"a", "b"}, {"a"}},
 			[]string{"a", "b"},
 		},
 		{
 			"set with dups and set with two entries in combined correctly for out",
-			[][]string{{"a", "a"},{"a", "b"}},
+			[][]string{{"a", "a"}, {"a", "b"}},
 			[]string{"a", "b"},
 		},
 	}

--- a/x/metadata/keeper/msg_server.go
+++ b/x/metadata/keeper/msg_server.go
@@ -491,6 +491,15 @@ func (k msgServer) P8EMemorializeContract(
 		return nil, err
 	}
 
+	existingScope, found := k.GetScope(ctx, p8EData.Scope.ScopeId)
+	if found {
+		// We don't want to update the scope's owners or value owner.
+		p8EData.Scope.Owners = existingScope.Owners
+		p8EData.Scope.ValueOwnerAddress = existingScope.ValueOwnerAddress
+		// We only want to add to the data access list.
+		p8EData.Scope.DataAccess = k.unionNoDups(existingScope.DataAccess, p8EData.Scope.DataAccess)
+	}
+
 	scopeResp, err := k.WriteScope(goCtx, &types.MsgWriteScopeRequest{
 		Scope:   *p8EData.Scope,
 		Signers: p8EData.Signers,

--- a/x/metadata/keeper/msg_server.go
+++ b/x/metadata/keeper/msg_server.go
@@ -497,7 +497,7 @@ func (k msgServer) P8EMemorializeContract(
 		p8EData.Scope.Owners = existingScope.Owners
 		p8EData.Scope.ValueOwnerAddress = existingScope.ValueOwnerAddress
 		// We only want to add to the data access list.
-		p8EData.Scope.DataAccess = k.unionNoDups(existingScope.DataAccess, p8EData.Scope.DataAccess)
+		p8EData.Scope.DataAccess = k.UnionDistinct(existingScope.DataAccess, p8EData.Scope.DataAccess)
 	}
 
 	scopeResp, err := k.WriteScope(goCtx, &types.MsgWriteScopeRequest{


### PR DESCRIPTION
…preserve its owners and value owners. Also only add to the data access list (instead of fully overwritting it).

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This PR makes the following changes to the processing done during P8EMemorializeContract:
1.  If there's already a Scope with the given scope id, don't update the `Owners` or `ValueOwnerAddress` fields.
2. If there's already a scope with the given scope id, copy it's existing `DataAccess` values and add any new ones that might be missing (but don't remove any existing values).

### Details:

Currently, during a P8EMemorializeContract call, the `Scope.Owners`, `Scope.ValueOwnerAddress`, and `Scope.DataAccess` values are populated using only info in the `MsgP8EMemorializeContractRequest`.

This has caused a problem in the following scenario:
1) `MsgP8EMemorializeContractRequest` is called with a contract just for an `ORIGINATOR`.
2) `MsgP8EMemorializeContractRequest` is called with a contract that has an `ORIGINATOR` and a `SERVICING`, that is to be added to the previously created scope.
3) `MsgP8EMemorializeContractRequest` is called again for the contract with just for an `ORIGINATOR`.

Problem: Now, both the `ORIGINATOR` and `SERVICING` parties are owners on the scope, so both need to sign for step number 3 (which would then actually remove the `SERVICING` owner).

After some discussion, we decided that we don't want `MsgP8EMemorializeContractRequest` to update the `Scope.Owners`, or `Scope.ValueOwnerAddress` fields. We also want the `Scope.DataAccess` values to only be additive. E.g., during step number 2 (above), the SERVICING party would be added to the `DataAccess` list, but during step 3, they'd still be there (they wouldn't be removed).

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
