### PR TITLE
Fix the documented type bytes for scope specifications and contract specifications

### DIFF
--- a/x/metadata/spec/02_state.md
+++ b/x/metadata/spec/02_state.md
@@ -236,7 +236,7 @@ Byte Array Length: `17`
 
 | Byte range | Description
 |------------|---
-| 0          | `0x03`
+| 0          | `0x04`
 | 1-16       | UUID of this scope specification
 
 * Field Name: `ScopeSpecification.specification_id`
@@ -308,7 +308,7 @@ Byte Array Length: `17`
 
 | Byte range | Description
 |------------|---
-| 0          | `0x04`
+| 0          | `0x03`
 | 1-16       | UUID of this contract specification
 
 * Field Name: `ContractSpecification.specification_id`


### PR DESCRIPTION

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

The metadata module spec state documentation incorrectly had the scope specification type byte as `0x03` and the contract specification type byte as `0x04`.

The correct values are:
- Scope specification: `0x04`
- Contract Specification: `0x03`
See: https://github.com/provenance-io/provenance/blob/main/x/metadata/types/keys.go#L68-L71

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
