### PR TITLE
Fix warning on a couple sims actions.

### DIFF
--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -88,7 +88,7 @@ jobs:
         run: go version
       - uses: technote-space/get-diff-action@v4
         with:
-          SUFFIX_FILTER: |
+          PATTERNS: |
             **/**.go
             go.mod
             go.sum
@@ -116,7 +116,7 @@ jobs:
         run: go version
       - uses: technote-space/get-diff-action@v4
         with:
-          SUFFIX_FILTER: |
+          PATTERNS: |
             **/**.go
             go.mod
             go.sum


### PR DESCRIPTION
## Description

Fixes a warning in both the `test-sim-import-export` and `test-sim-multi-seed-short` Github actions.

> Unexpected input(s) 'SUFFIX_FILTER', valid inputs are ['GITHUB_TOKEN', 'DOT', 'BASE', 'RELATIVE', 'DIFF_FILTER', 'FORMAT', 'ESCAPE_JSON', 'SEPARATOR', 'PATTERNS', 'MINIMATCH_OPTION_NOBRACE', 'MINIMATCH_OPTION_NOGLOBSTAR', 'MINIMATCH_OPTION_DOT', 'MINIMATCH_OPTION_NOEXT', 'MINIMATCH_OPTION_NOCASE', 'MINIMATCH_OPTION_MATCH_BASE', 'MINIMATCH_OPTION_NONEGATE', 'FILES', 'SUMMARY_INCLUDE_FILES', 'ABSOLUTE', 'SET_ENV_NAME', 'SET_ENV_NAME_FILTERED_DIFF', 'SET_ENV_NAME_MATCHED_FILES', 'SET_ENV_NAME_COUNT', 'SET_ENV_NAME_INSERTIONS', 'SET_ENV_NAME_DELETIONS', 'SET_ENV_NAME_LINES', 'DIFF_DEFAULT', 'FILTERED_DIFF_DEFAULT', 'MATCHED_FILES_DEFAULT', 'COUNT_DEFAULT', 'INSERTIONS_DEFAULT', 'DELETIONS_DEFAULT', 'LINES_DEFAULT', 'CHECK_ONLY_COMMIT_WHEN_DRAFT']

This is from the `technote-space/get-diff-action` step of the actions. The `test-sim-nondeterminism` action uses `PATTERNS` there, and has the same stuff under it, so that's what I went with for these ones.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
