### PR TITLE
Fix panic when using packed config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 * Removed some unneeded code from the persistent record update validation [#471](https://github.com/provenance-io/provenance/issues/471)
+* Fixed packed config loading bug [#487](https://github.com/provenance-io/provenance/issues/487)
 
 ## [v1.7.0](https://github.com/provenance-io/provenance/releases/tag/v1.7.0) - 2021-09-03
 

--- a/cmd/provenanced/config/manager_test.go
+++ b/cmd/provenanced/config/manager_test.go
@@ -118,7 +118,7 @@ func (s *ConfigManagerTestSuite) TestManagerWriteAppConfigWithIndexEventsThenRea
 	s.Require().Equal(appConfig.IndexEvents, appConfig2.IndexEvents, "index events before/after")
 }
 
-func (s *ConfigManagerTestSuite) TestPackedConfigCosmosLoadNoGlobalLabels() {
+func (s *ConfigManagerTestSuite) TestPackedConfigCosmosLoadDefaults() {
 	dCmd := s.makeDummyCmd()
 
 	appConfig := serverconfig.DefaultConfig()
@@ -130,11 +130,12 @@ func (s *ConfigManagerTestSuite) TestPackedConfigCosmosLoadNoGlobalLabels() {
 	ctx := client.GetClientContextFromCmd(dCmd)
 	vpr := ctx.Viper
 	s.Require().NotPanics(func() {
-		serverconfig.GetConfig(vpr)
+		appConfig2 := serverconfig.GetConfig(vpr)
+		s.Assert().Equal(*appConfig, appConfig2)
 	})
 }
 
-func (s *ConfigManagerTestSuite) TestPackedConfigCosmosLoadWithGlobalLabels() {
+func (s *ConfigManagerTestSuite) TestPackedConfigCosmosLoadGlobalLabels() {
 	dCmd := s.makeDummyCmd()
 
 	appConfig := serverconfig.DefaultConfig()
@@ -148,6 +149,7 @@ func (s *ConfigManagerTestSuite) TestPackedConfigCosmosLoadWithGlobalLabels() {
 	ctx := client.GetClientContextFromCmd(dCmd)
 	vpr := ctx.Viper
 	s.Require().NotPanics(func() {
-		serverconfig.GetConfig(vpr)
+		appConfig2 := serverconfig.GetConfig(vpr)
+		s.Assert().Equal(appConfig.Telemetry.GlobalLabels, appConfig2.Telemetry.GlobalLabels)
 	})
 }

--- a/cmd/provenanced/config/manager_test.go
+++ b/cmd/provenanced/config/manager_test.go
@@ -56,6 +56,7 @@ func (s *ConfigManagerTestSuite) makeDummyCmd() *cobra.Command {
 	}
 	dummyCmd.SetOut(ioutil.Discard)
 	dummyCmd.SetErr(ioutil.Discard)
+	dummyCmd.SetArgs([]string{})
 	var err error
 	dummyCmd, err = dummyCmd.ExecuteContextC(ctx)
 	s.Require().NoError(err, "dummy command execution")
@@ -115,4 +116,38 @@ func (s *ConfigManagerTestSuite) TestManagerWriteAppConfigWithIndexEventsThenRea
 	appConfig2, err2 := ExtractAppConfig(dCmd)
 	s.Require().NoError(err2, "extracging app config")
 	s.Require().Equal(appConfig.IndexEvents, appConfig2.IndexEvents, "index events before/after")
+}
+
+func (s *ConfigManagerTestSuite) TestPackedConfigCosmosLoadNoGlobalLabels() {
+	dCmd := s.makeDummyCmd()
+
+	appConfig := serverconfig.DefaultConfig()
+	tmConfig := tmconfig.DefaultConfig()
+	clientConfig := DefaultClientConfig()
+	generateAndWritePackedConfig(dCmd, appConfig, tmConfig, clientConfig, false)
+	s.Require().NoError(loadPackedConfig(dCmd))
+
+	ctx := client.GetClientContextFromCmd(dCmd)
+	vpr := ctx.Viper
+	s.Require().NotPanics(func() {
+		serverconfig.GetConfig(vpr)
+	})
+}
+
+func (s *ConfigManagerTestSuite) TestPackedConfigCosmosLoadWithGlobalLabels() {
+	dCmd := s.makeDummyCmd()
+
+	appConfig := serverconfig.DefaultConfig()
+	appConfig.Telemetry.GlobalLabels = append(appConfig.Telemetry.GlobalLabels, []string{"key1", "value1"})
+	appConfig.Telemetry.GlobalLabels = append(appConfig.Telemetry.GlobalLabels, []string{"key2", "value2"})
+	tmConfig := tmconfig.DefaultConfig()
+	clientConfig := DefaultClientConfig()
+	generateAndWritePackedConfig(dCmd, appConfig, tmConfig, clientConfig, false)
+	s.Require().NoError(loadPackedConfig(dCmd))
+
+	ctx := client.GetClientContextFromCmd(dCmd)
+	vpr := ctx.Viper
+	s.Require().NotPanics(func() {
+		serverconfig.GetConfig(vpr)
+	})
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

When using a packed config, provide the global-labels to viper in the same way they're expected in the cosmos `GetConfig` function.

closes: #487

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Review `Codecov Report` in the comment section below once CI passes
