### PR TITLE
Cherry pick 489 Adding a marker with more than 2^64 coins and minting more panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 -->
 
 ## Unreleased
+
 ### Improvements
 
 * Ensure marker state transition validation does not panic [#492](https://github.com/provenance-io/provenance/issues/492)
@@ -43,6 +44,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 * Fix marker permissions migration and add panic on `eigengrau` upgrade [#484](https://github.com/provenance-io/provenance/issues/484)
+* Fixed marker with more than uint64 causes panic [#489](https://github.com/provenance-io/provenance/issues/489)
 
 ## [v1.7.0](https://github.com/provenance-io/provenance/releases/tag/v1.7.0) - 2021-09-03
 ### Features

--- a/x/marker/keeper/marker.go
+++ b/x/marker/keeper/marker.go
@@ -360,9 +360,10 @@ func (k Keeper) IncreaseSupply(ctx sdk.Context, marker types.MarkerAccountI, coi
 
 	inCirculation := sdk.NewCoin(marker.GetDenom(), k.bankKeeper.GetSupply(ctx, marker.GetDenom()).Amount)
 	total := inCirculation.Add(coin)
-	maxAllowed := k.GetParams(ctx).MaxTotalSupply
-	if total.Amount.Uint64() > maxAllowed {
-		return fmt.Errorf("requested supply %d exceeds maximum allowed value %d", total.Amount.Uint64(), maxAllowed)
+	maxAllowed := sdk.NewCoin(marker.GetDenom(), sdk.NewIntFromUint64(k.GetParams(ctx).MaxTotalSupply))
+	if total.Amount.GT(maxAllowed.Amount) {
+		return fmt.Errorf(
+			"requested supply %d exceeds maximum allowed value %d", total.Amount, maxAllowed.Amount)
 	}
 
 	// If the marker has a fixed supply then adjust the supply to match the new total


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
 
Cherry pick issue 489 `Adding a marker with more than 2^64 coins and minting more panics` from main to v1.7.x

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
