### PR TITLE
Fix logger ignoring configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+### Bug Fixes
+
+* Fix logger config being ignored [PR 510](https://github.com/provenance-io/provenance/pull/510)
+
 ## [v1.7.2](https://github.com/provenance-io/provenance/releases/tag/v1.7.2) - 2021-09-27
 
 ### Bug Fixes

--- a/cmd/provenanced/config/interceptor.go
+++ b/cmd/provenanced/config/interceptor.go
@@ -2,19 +2,15 @@ package config
 
 import (
 	"fmt"
-	"io"
-	"os"
 	"strings"
 
-	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
-	tmcfg "github.com/tendermint/tendermint/config"
+	tmconfig "github.com/tendermint/tendermint/config"
 
 	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/server"
 )
 
@@ -36,24 +32,8 @@ func InterceptConfigsPreRunHandler(cmd *cobra.Command) error {
 		return err
 	}
 
-	// Create the logger that we'll want for the new server context
-	var logWriter io.Writer
-	if strings.ToLower(vpr.GetString(flags.FlagLogFormat)) == tmcfg.LogFormatPlain {
-		logWriter = zerolog.ConsoleWriter{Out: os.Stderr}
-	} else {
-		logWriter = os.Stderr
-	}
-
-	logLvlStr := vpr.GetString(flags.FlagLogLevel)
-	logLvl, perr := zerolog.ParseLevel(logLvlStr)
-	if perr != nil {
-		return fmt.Errorf("failed to parse log level (%s): %w", logLvlStr, perr)
-	}
-
-	serverLogger := server.ZeroLogWrapper{Logger: zerolog.New(logWriter).Level(logLvl).With().Timestamp().Logger()}
-
-	// Create a new Server context with the same viper as the client context, a default config, and the just defined logger.
-	serverCtx := server.NewContext(vpr, tmcfg.DefaultConfig(), serverLogger)
+	// Create a new Server context with the same viper as the client context, a default config, and no logger.
+	serverCtx := server.NewContext(vpr, tmconfig.DefaultConfig(), nil)
 	if err := server.SetCmdServerContext(cmd, serverCtx); err != nil {
 		return err
 	}


### PR DESCRIPTION
…that the configured values can be used as needed.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

The logger was being created before the configuration was being loaded. That made it so that the configured `log_level` and `log_format` were being ignored and only flags and defaults were used for them.

This fix moves the logger creation and setting until later, once the configs have been loaded.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
