### PR TITLE
Fix devnet PIO_HOME value and simplify the container.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -387,10 +387,9 @@ localnet-stop:
 docker-build-dev: vendor
 	docker build --tag provenance-io/blockchain-dev -f networks/dev/blockchain-dev/Dockerfile .
 
-
 # Generate config files for a single node devnet
 devnet-generate: devnet-stop docker-build-dev
-	@if ! [ -f build/nodedev/config/genesis.json ]; then docker run --rm -v $(CURDIR)/build:/provenance:Z provenance-io/blockchain-dev testnet --v 1 -o . --starting-ip-address 192.168.21.2 --keyring-backend=test --chain-id=chain-dev ; fi
+	docker run --rm -v $(CURDIR)/build:/provenance:Z provenance-io/blockchain-dev keys list
 
 # Run a single node devnet locally
 devnet-up:

--- a/networks/dev/docker-compose.yml
+++ b/networks/dev/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     environment:
       - ID=dev
       - LOG=${LOG:-provenanced.log}
-      - PIO_HOME=/provenance
+      - PIO_HOME=/provenance/nodedev
     volumes:
       - ./build:/provenance:Z
 


### PR DESCRIPTION
## Description

* Fix the `devnet` environment variable `PIO_HOME` to have the correct value for the devnet node. This makes it so you can run commands like `docker exec dev-node provenanced config changed` and it'll work as expected. Similarly, if you `docker exec -it dev-node /bin/sh` into the container, the `provenanced` commands will be using the proper `home` and behave as expected.
* Update `make devnet-generate` to list the node's keys instead of generating testnet nodes that are then not used. The `entrypoint.sh` script handles initializing things if there's no genesis file, and that's the main thing we want done with `make devnet-generate`. The `keys list` command outputs possibly useful info, but is mostly just a harmless command that can be run to trigger the initialization stuff in `entrypoint.sh` (if it hasn't been done yet).

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
