### PR TITLE
Replace call to client.ReadHomeFlag

### DIFF
--- a/cmd/provenanced/cmd/root.go
+++ b/cmd/provenanced/cmd/root.go
@@ -74,7 +74,10 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 			cmd.SetOut(cmd.OutOrStdout())
 			cmd.SetErr(cmd.ErrOrStderr())
 
-			initClientCtx = client.ReadHomeFlag(initClientCtx, cmd)
+			if cmd.Flags().Changed(flags.FlagHome) {
+				rootDir, _ := cmd.Flags().GetString(flags.FlagHome)
+				initClientCtx = initClientCtx.WithHomeDir(rootDir)
+			}
 			if err := client.SetCmdClientContext(cmd, initClientCtx); err != nil {
 				return err
 			}


### PR DESCRIPTION
## Description

The Cosmos-SDK is removing the `client.ReadHomeFlag` function. In preparation of that, replace our use of it with the little bit that it does.

Note: I skipped the CHANGELOG entry because there's no functionality change. It's just removing a function call and replacing it with what the lines of the function (and changing a variable name). I'll add one if requested, though.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] ~~Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`~~
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
