### PR TITLE
pass custom hd path to entrypoint sourced from env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -385,7 +385,7 @@ localnet-stop:
 
 # Quick build using devnet environment and go platform target options.
 docker-build-dev: vendor
-	docker build --tag provenance-io/blockchain-dev -f networks/dev/blockchain-dev/Dockerfile .
+	docker build --tag provenance-io/blockchain-dev -f networks/dev/blockchain-dev/Dockerfile --build-arg hd_path=${HD_PATH} .
 
 # Generate config files for a single node devnet
 devnet-generate: devnet-stop docker-build-dev

--- a/networks/dev/blockchain-dev/Dockerfile
+++ b/networks/dev/blockchain-dev/Dockerfile
@@ -41,6 +41,9 @@ COPY --from=build /go/bin/provenanced /usr/bin/provenanced
 
 COPY networks/dev/mnemonics/ /mnemonics/
 
+ARG hd_path
+ENV HD_PATH=$hd_path
+
 ENTRYPOINT ["/usr/bin/entrypoint.sh"]
 CMD ["start"]
 STOPSIGNAL SIGTERM

--- a/networks/dev/blockchain-dev/entrypoint.sh
+++ b/networks/dev/blockchain-dev/entrypoint.sh
@@ -18,7 +18,10 @@ if ! [ -f ${PIO_HOME}/config/genesis.json ]; then
     do
       key_name=$(basename $f .txt)
       echo "Adding account $key_name from mnemonic file $f with 100000000000000000000nhash"
-      "${BINARY}" -t --home "${PIO_HOME}" keys add $key_name --recover --keyring-backend test < $f  
+      if [ -z "${HD_PATH}" ];
+        then "${BINARY}" -t --home "${PIO_HOME}" keys add $key_name --recover --keyring-backend test < $f;
+        else "${BINARY}" -t --home "${PIO_HOME}" keys add $key_name --hd-path $HD_PATH --recover --keyring-backend test < $f;
+      fi  
       "${BINARY}" -t --home "${PIO_HOME}" add-genesis-account $key_name 100000000000000000000nhash --keyring-backend test
       let num_accounts=num_accounts+1
   done


### PR DESCRIPTION
## Description

- makefile command to build devnet image passes in hd_path arg from environment variable
- docker file accepts a hd_path arg that is translated into an environment variable for the entrypoint script
- entrypoint script utilizes HD_PATH if exists with `key add` command

closes: #532

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
