### PR TITLE
explicitly use coin type 1 in devnet keys

### DIFF
--- a/networks/dev/blockchain-dev/entrypoint.sh
+++ b/networks/dev/blockchain-dev/entrypoint.sh
@@ -18,7 +18,7 @@ if ! [ -f ${PIO_HOME}/config/genesis.json ]; then
     do
       key_name=$(basename $f .txt)
       echo "Adding account $key_name from mnemonic file $f with 100000000000000000000nhash"
-      "${BINARY}" -t --home "${PIO_HOME}" keys add $key_name --recover --keyring-backend test < $f  
+      "${BINARY}" -t --home "${PIO_HOME}" keys add $key_name --coin-type 1 --recover --keyring-backend test < $f  
       "${BINARY}" -t --home "${PIO_HOME}" add-genesis-account $key_name 100000000000000000000nhash --keyring-backend test
       let num_accounts=num_accounts+1
   done


### PR DESCRIPTION
## Description

explicitly use coin type 1 in devnet keys

closes: #534 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
