### PR TITLE
Allow attributes to be associated with scopes.

### DIFF
--- a/.github/workflows/build-and-publish-proto-bindings.yml
+++ b/.github/workflows/build-and-publish-proto-bindings.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Java Setup
         uses: actions/setup-java@v2.5.0
         with:
+          distribution: 'zulu'
           java-version: 11
           server-id: github
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * Upgrade provenance to 0.45 cosmos sdk release [#607](https://github.com/provenance-io/provenance/issues/607)
 * Upgrade wasmd to v0.22.0 Note: this removes dependency on provenance-io's wasmd fork [#479](https://github.com/provenance-io/provenance/issues/479)
 * Add support for Scope mutation via wasm Smart Contracts [#531](https://github.com/provenance-io/provenance/issues/531)
+* Allow attributes to be associated with scopes [#631](https://github.com/provenance-io/provenance/issues/631)
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * Allow manager to adjust grants on finalized markers [#545](https://github.com/provenance-io/provenance/issues/545)
 * Add migration to re-index the metadata indexes involving addresses [#541](https://github.com/provenance-io/provenance/issues/541)
 * Add migration to delete empty sessions [#480](https://github.com/provenance-io/provenance/issues/480)
+* Add Java distribution tag to workflow [#624](https://github.com/provenance-io/provenance/issues/624)
 
 ## [v1.7.6](https://github.com/provenance-io/provenance/releases/tag/v1.7.6) - 2021-12-15
 

--- a/cmd/provenanced/cmd/root_test.go
+++ b/cmd/provenanced/cmd/root_test.go
@@ -9,5 +9,5 @@ import (
 )
 
 func TestIAVLConfig(t *testing.T) {
-	require.Equal(t,getIAVLCacheSize(app.EmptyAppOptions{}),cast.ToInt(serverconfig.DefaultConfig().IAVLCacheSize))
+	require.Equal(t, getIAVLCacheSize(app.EmptyAppOptions{}), cast.ToInt(serverconfig.DefaultConfig().IAVLCacheSize))
 }

--- a/internal/antewrapper/msg_fees_decorator_test.go
+++ b/internal/antewrapper/msg_fees_decorator_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/provenance-io/provenance/internal/antewrapper"
 )
 
-
-
 // checkTx true, high min gas price(high enough so that additional fee in same denom tips it over,
 //and this is what sets it apart from MempoolDecorator which has already been run)
 func (suite *AnteTestSuite) TestEnsureMempoolAndMsgFees() {
@@ -363,4 +361,3 @@ func setUpApp(suite *AnteTestSuite, checkTx bool, additionalFeeCoinDenom string,
 	antehandler := sdk.ChainAnteDecorators(mfd)
 	return err, antehandler
 }
-

--- a/internal/antewrapper/testutil_test.go
+++ b/internal/antewrapper/testutil_test.go
@@ -213,10 +213,9 @@ func (suite *AnteTestSuite) CreateMsgFee(fee sdk.Coin, msgs ...sdk.Msg) error {
 
 // NewTestGasLimit is a test fee gas limit.
 // they keep changing this value and our tests break, hence moving it to test.
-func (suite *AnteTestSuite)NewTestGasLimit() uint64 {
+func (suite *AnteTestSuite) NewTestGasLimit() uint64 {
 	return 100000
 }
-
 
 func TestAnteTestSuite(t *testing.T) {
 	suite.Run(t, new(AnteTestSuite))

--- a/x/attribute/client/cli/cli_test.go
+++ b/x/attribute/client/cli/cli_test.go
@@ -135,26 +135,26 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	attributeData.Attributes = append(attributeData.Attributes,
 		attributetypes.NewAttribute(
 			"example.attribute",
-			s.account1Addr,
+			s.account1Str,
 			attributetypes.AttributeType_String,
 			[]byte("example attribute value string")))
 	attributeData.Attributes = append(attributeData.Attributes,
 		attributetypes.NewAttribute(
 			"example.attribute.count",
-			s.account1Addr,
+			s.account1Str,
 			attributetypes.AttributeType_Int,
 			[]byte("2")))
 	for i := 0; i < s.accAttrCount; i++ {
 		attributeData.Attributes = append(attributeData.Attributes,
 			attributetypes.NewAttribute(
 				fmt.Sprintf("example.attribute.%s", toWritten(i)),
-				s.account3Addr,
+				s.account3Str,
 				attributetypes.AttributeType_Int,
 				[]byte(fmt.Sprintf("%d", i))))
 		attributeData.Attributes = append(attributeData.Attributes,
 			attributetypes.NewAttribute(
 				"example.attribute.overload",
-				s.account4Addr,
+				s.account4Str,
 				attributetypes.AttributeType_String,
 				[]byte(toWritten(i))))
 	}

--- a/x/attribute/client/cli/tx.go
+++ b/x/attribute/client/cli/tx.go
@@ -12,8 +12,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/provenance-io/provenance/x/attribute/types"
 )
 
@@ -57,7 +55,7 @@ Refer to %s tx name bind --help for more information on how to do this.`, versio
 
 			err = types.ValidateAttributeAddress(account)
 			if err != nil {
-				return err
+				return fmt.Errorf("invalid address: %w", err)
 			}
 			attributeType, err := types.AttributeTypeFromString(strings.TrimSpace(args[2]))
 			if err != nil {
@@ -104,7 +102,7 @@ func NewUpdateAccountAttributeCmd() *cobra.Command {
 
 			err = types.ValidateAttributeAddress(account)
 			if err != nil {
-				return err
+				return fmt.Errorf("invalid account address: %w", err)
 			}
 			origAttributeType, err := types.AttributeTypeFromString(strings.TrimSpace(args[2]))
 			if err != nil {
@@ -170,9 +168,9 @@ func NewDeleteDistinctAccountAttributeCmd() *cobra.Command {
 				return err
 			}
 
-			account, err := sdk.AccAddressFromBech32(args[1])
+			err = types.ValidateAttributeAddress(args[1])
 			if err != nil {
-				return fmt.Errorf("account address must be a Bech32 string: %w", err)
+				return fmt.Errorf("invalid attribute address: %w", err)
 			}
 			attributeType, err := types.AttributeTypeFromString(strings.TrimSpace(args[2]))
 			if err != nil {
@@ -182,7 +180,7 @@ func NewDeleteDistinctAccountAttributeCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("error encoding value %s to type %s : %v", deleteValue, attributeType.String(), err)
 			}
-			msg := types.NewMsgDeleteDistinctAttributeRequest(account, clientCtx.GetFromAddress(), args[0], deleteValue)
+			msg := types.NewMsgDeleteDistinctAttributeRequest(args[1], clientCtx.GetFromAddress(), args[0], deleteValue)
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}
@@ -206,12 +204,12 @@ func NewDeleteAccountAttributeCmd() *cobra.Command {
 				return err
 			}
 
-			account, err := sdk.AccAddressFromBech32(args[1])
+			err = types.ValidateAttributeAddress(args[1])
 			if err != nil {
-				return fmt.Errorf("account address must be a Bech32 string: %w", err)
+				return fmt.Errorf("invalid address: %w", err)
 			}
 			msg := types.NewMsgDeleteAttributeRequest(
-				account,
+				args[1],
 				clientCtx.GetFromAddress(),
 				args[0],
 			)

--- a/x/attribute/client/cli/tx.go
+++ b/x/attribute/client/cli/tx.go
@@ -53,9 +53,11 @@ Refer to %s tx name bind --help for more information on how to do this.`, versio
 			}
 
 			name := args[0]
-			account, err := sdk.AccAddressFromBech32(args[1])
+			account := args[1]
+
+			err = types.ValidateAttributeAddress(account)
 			if err != nil {
-				return fmt.Errorf("account address must be a Bech32 string: %w", err)
+				return err
 			}
 			attributeType, err := types.AttributeTypeFromString(strings.TrimSpace(args[2]))
 			if err != nil {

--- a/x/attribute/client/cli/tx.go
+++ b/x/attribute/client/cli/tx.go
@@ -100,9 +100,11 @@ func NewUpdateAccountAttributeCmd() *cobra.Command {
 			}
 
 			name := args[0]
-			account, err := sdk.AccAddressFromBech32(args[1])
+			account := args[1]
+
+			err = types.ValidateAttributeAddress(account)
 			if err != nil {
-				return fmt.Errorf("account address must be a Bech32 string: %w", err)
+				return err
 			}
 			origAttributeType, err := types.AttributeTypeFromString(strings.TrimSpace(args[2]))
 			if err != nil {

--- a/x/attribute/client/rest/grpc_query_test.go
+++ b/x/attribute/client/rest/grpc_query_test.go
@@ -32,6 +32,7 @@ type IntegrationTestSuite struct {
 
 	accountAddr sdk.AccAddress
 	accountKey  *secp256r1.PrivKey
+	accountStr  string
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {
@@ -40,6 +41,7 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	addr, err := sdk.AccAddressFromHex(s.accountKey.PubKey().Address().String())
 	s.Require().NoError(err)
 	s.accountAddr = addr
+	s.accountStr = s.accountAddr.String()
 	s.T().Log("setting up integration test suite")
 
 	cfg := testutil.DefaultTestNetworkConfig()
@@ -74,7 +76,7 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	accountData.Attributes = append(accountData.Attributes,
 		attributetypes.NewAttribute(
 			"example.attribute",
-			s.accountAddr,
+			s.accountStr,
 			attributetypes.AttributeType_String,
 			[]byte("example attribute value string")))
 	accountData.Params.MaxValueLength = 32
@@ -131,7 +133,7 @@ func (s *IntegrationTestSuite) TestGRPCQueries() {
 				Account: s.accountAddr.String(),
 				Attributes: []attributetypes.Attribute{
 					attributetypes.NewAttribute("example.attribute",
-						s.accountAddr,
+						s.accountStr,
 						attributetypes.AttributeType_String,
 						[]byte("example attribute value string")),
 				},
@@ -148,7 +150,7 @@ func (s *IntegrationTestSuite) TestGRPCQueries() {
 				Account: s.accountAddr.String(),
 				Attributes: []attributetypes.Attribute{
 					attributetypes.NewAttribute("example.attribute",
-						s.accountAddr,
+						s.accountStr,
 						attributetypes.AttributeType_String,
 						[]byte("example attribute value string")),
 				},
@@ -177,7 +179,7 @@ func (s *IntegrationTestSuite) TestGRPCQueries() {
 				Account: s.accountAddr.String(),
 				Attributes: []attributetypes.Attribute{
 					attributetypes.NewAttribute("example.attribute",
-						s.accountAddr,
+						s.accountStr,
 						attributetypes.AttributeType_String,
 						[]byte("example attribute value string")),
 				},

--- a/x/attribute/client/rest/tx.go
+++ b/x/attribute/client/rest/tx.go
@@ -49,11 +49,6 @@ func NewAddAttributeRequestHandlerFn(clientCtx client.Context) http.HandlerFunc 
 		if !req.BaseReq.ValidateBasic(w) {
 			return
 		}
-		account, err := sdk.AccAddressFromBech32(req.Account)
-		if err != nil {
-			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
-			return
-		}
 		owner, err := sdk.AccAddressFromBech32(req.BaseReq.From)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
@@ -70,7 +65,7 @@ func NewAddAttributeRequestHandlerFn(clientCtx client.Context) http.HandlerFunc 
 			return
 		}
 		msg := types.NewMsgAddAttributeRequest(
-			account,
+			req.Account,
 			owner, // name must resolve to this address
 			req.Name,
 			at,

--- a/x/attribute/client/rest/tx.go
+++ b/x/attribute/client/rest/tx.go
@@ -98,18 +98,13 @@ func NewDeleteAttributeHandlerFn(clientCtx client.Context) http.HandlerFunc {
 		if !req.BaseReq.ValidateBasic(w) {
 			return
 		}
-		account, err := sdk.AccAddressFromBech32(req.Account)
-		if err != nil {
-			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
-			return
-		}
 		owner, err := sdk.AccAddressFromBech32(req.BaseReq.From)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
 		msg := types.NewMsgDeleteAttributeRequest(
-			account,
+			req.Account,
 			owner, // name must resolve to this address
 			req.Name,
 		)

--- a/x/attribute/handler_test.go
+++ b/x/attribute/handler_test.go
@@ -169,7 +169,7 @@ func (s HandlerTestSuite) TestMsgDistinctDeleteAttributeRequest() {
 	cases := []CommonTest{
 		{
 			"should successfully delete attribute with value",
-			types.NewMsgDeleteDistinctAttributeRequest(s.user1Addr, s.user1Addr, "example.name", []byte("value")),
+			types.NewMsgDeleteDistinctAttributeRequest(s.user1, s.user1Addr, "example.name", []byte("value")),
 			[]string{s.user1},
 			"",
 			types.NewEventDistinctAttributeDelete("example.name", string([]byte("value")), s.user1, s.user1),
@@ -193,7 +193,7 @@ func (s HandlerTestSuite) TestMsgDeleteAttributeRequest() {
 	cases := []CommonTest{
 		{
 			"should successfully add new attribute",
-			types.NewMsgDeleteAttributeRequest(s.user1Addr, s.user1Addr, "example.name"),
+			types.NewMsgDeleteAttributeRequest(s.user1, s.user1Addr, "example.name"),
 			[]string{s.user1},
 			"",
 			types.NewEventAttributeDelete("example.name", s.user1, s.user1),

--- a/x/attribute/handler_test.go
+++ b/x/attribute/handler_test.go
@@ -133,7 +133,7 @@ func (s HandlerTestSuite) TestMsgUpdateAttributeRequest() {
 		{
 			"should successfully update attribute",
 			types.NewMsgUpdateAttributeRequest(
-				s.user1Addr,
+				s.user1,
 				s.user1Addr, "example.name",
 				[]byte("value"), []byte("1"),
 				types.AttributeType_String,

--- a/x/attribute/handler_test.go
+++ b/x/attribute/handler_test.go
@@ -100,7 +100,7 @@ func (s HandlerTestSuite) TestMsgAddAttributeRequest() {
 	cases := []CommonTest{
 		{
 			"should successfully add new attribute",
-			types.NewMsgAddAttributeRequest(s.user1Addr,
+			types.NewMsgAddAttributeRequest(s.user1,
 				s.user1Addr, "example.name", types.AttributeType_String, []byte("value")),
 			[]string{s.user1},
 			"",

--- a/x/attribute/keeper/keeper.go
+++ b/x/attribute/keeper/keeper.go
@@ -64,16 +64,16 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 	return ctx.Logger().With("module", fmt.Sprintf("x/%s", types.ModuleName))
 }
 
-// GetAllAttributes gets all attributes for account.
-func (k Keeper) GetAllAttributes(ctx sdk.Context, acc sdk.AccAddress) ([]types.Attribute, error) {
+// GetAllAttributes gets all attributes for an address.
+func (k Keeper) GetAllAttributes(ctx sdk.Context, addr string) ([]types.Attribute, error) {
 	defer telemetry.MeasureSince(time.Now(), types.ModuleName, "keeper_method", "get_all")
 
 	pred := func(s string) bool { return true }
-	return k.prefixScan(ctx, types.AccountAttributesKeyPrefix(acc), pred)
+	return k.prefixScan(ctx, types.AccountAttributesKeyPrefix(types.GetAttributeAddressBytes(addr)), pred)
 }
 
 // GetAttributes gets all attributes with the given name from an account.
-func (k Keeper) GetAttributes(ctx sdk.Context, acc sdk.AccAddress, name string) ([]types.Attribute, error) {
+func (k Keeper) GetAttributes(ctx sdk.Context, addr string, name string) ([]types.Attribute, error) {
 	defer telemetry.MeasureSince(time.Now(), types.ModuleName, "keeper_method", "get")
 
 	name = strings.ToLower(strings.TrimSpace(name))
@@ -81,7 +81,7 @@ func (k Keeper) GetAttributes(ctx sdk.Context, acc sdk.AccAddress, name string) 
 		return nil, err
 	}
 	pred := func(s string) bool { return strings.EqualFold(s, name) }
-	return k.prefixScan(ctx, types.AccountAttributesNameKeyPrefix(acc, name), pred)
+	return k.prefixScan(ctx, types.AccountAttributesNameKeyPrefix(types.GetAttributeAddressBytes(addr), name), pred)
 }
 
 // IterateRecords iterates over all the stored attribute records and passes them to a callback function.
@@ -146,11 +146,7 @@ func (k Keeper) SetAttribute(
 		return err
 	}
 
-	addr, err := sdk.AccAddressFromBech32(attr.Address)
-	if err != nil {
-		return err
-	}
-	key := types.AccountAttributeKey(addr, attr)
+	key := types.AccountAttributeKey(attr.GetAddressBytes(), attr)
 
 	store := ctx.KVStore(k.storeKey)
 	store.Set(key, bz)
@@ -168,10 +164,7 @@ func (k Keeper) UpdateAttribute(ctx sdk.Context, originalAttribute types.Attribu
 ) error {
 	defer telemetry.MeasureSince(time.Now(), types.ModuleName, "keeper_method", "update")
 
-	accountAddress, err := sdk.AccAddressFromBech32(originalAttribute.Address)
-	if err != nil {
-		return err
-	}
+	var err error
 
 	if err = originalAttribute.ValidateBasic(); err != nil {
 		return err
@@ -209,8 +202,10 @@ func (k Keeper) UpdateAttribute(ctx sdk.Context, originalAttribute types.Attribu
 		return fmt.Errorf("\"%s\" does not resolve to address \"%s\"", updateAttribute.Name, owner.String())
 	}
 
+	addrBz := originalAttribute.GetAddressBytes()
+
 	store := ctx.KVStore(k.storeKey)
-	it := sdk.KVStorePrefixIterator(store, types.AccountAttributesNameKeyPrefix(accountAddress, normalizedOrigName))
+	it := sdk.KVStorePrefixIterator(store, types.AccountAttributesNameKeyPrefix(addrBz, normalizedOrigName))
 	var found bool
 	for ; it.Valid(); it.Next() {
 		attr := types.Attribute{}
@@ -226,7 +221,7 @@ func (k Keeper) UpdateAttribute(ctx sdk.Context, originalAttribute types.Attribu
 			if err != nil {
 				return err
 			}
-			updatedKey := types.AccountAttributeKey(accountAddress, updateAttribute)
+			updatedKey := types.AccountAttributeKey(addrBz, updateAttribute)
 			store.Set(updatedKey, bz)
 
 			attributeUpdateEvent := types.NewEventAttributeUpdate(originalAttribute, updateAttribute, owner.String())
@@ -244,8 +239,8 @@ func (k Keeper) UpdateAttribute(ctx sdk.Context, originalAttribute types.Attribu
 	return nil
 }
 
-// Removes attributes under the given account.
-func (k Keeper) DeleteAttribute(ctx sdk.Context, acc sdk.AccAddress, name string, value *[]byte, owner sdk.AccAddress) error {
+// DeleteAttribute removes attributes under the given account from the state store.
+func (k Keeper) DeleteAttribute(ctx sdk.Context, addr string, name string, value *[]byte, owner sdk.AccAddress) error {
 	defer telemetry.MeasureSince(time.Now(), types.ModuleName, "keeper_method", "delete")
 
 	var deleteDistinct bool
@@ -265,7 +260,7 @@ func (k Keeper) DeleteAttribute(ctx sdk.Context, acc sdk.AccAddress, name string
 	}
 
 	store := ctx.KVStore(k.storeKey)
-	it := sdk.KVStorePrefixIterator(store, types.AccountAttributesNameKeyPrefix(acc, name))
+	it := sdk.KVStorePrefixIterator(store, types.AccountAttributesNameKeyPrefix(types.GetAttributeAddressBytes(addr), name))
 	var count int
 	for ; it.Valid(); it.Next() {
 		attr := types.Attribute{}
@@ -278,12 +273,12 @@ func (k Keeper) DeleteAttribute(ctx sdk.Context, acc sdk.AccAddress, name string
 			store.Delete(it.Key())
 
 			if !deleteDistinct {
-				deleteEvent := types.NewEventAttributeDelete(name, acc.String(), owner.String())
+				deleteEvent := types.NewEventAttributeDelete(name, addr, owner.String())
 				if err := ctx.EventManager().EmitTypedEvent(deleteEvent); err != nil {
 					return err
 				}
 			} else {
-				deleteEvent := types.NewEventDistinctAttributeDelete(name, string(*value), acc.String(), owner.String())
+				deleteEvent := types.NewEventDistinctAttributeDelete(name, string(*value), addr, owner.String())
 				if err := ctx.EventManager().EmitTypedEvent(deleteEvent); err != nil {
 					return err
 				}
@@ -323,14 +318,7 @@ func (k Keeper) prefixScan(ctx sdk.Context, prefix []byte, f namePred) (attrs []
 // A genesis helper that imports attribute state without owner checks.
 func (k Keeper) importAttribute(ctx sdk.Context, attr types.Attribute) error {
 	// Ensure attribute is valid
-	if err := attr.ValidateBasic(); err != nil {
-		return err
-	}
-	// Attribute must have a valid, non-empty address to import
-	if strings.TrimSpace(attr.Address) == "" {
-		return fmt.Errorf("unable to import attribute with empty address")
-	}
-	acc, err := sdk.AccAddressFromBech32(attr.Address)
+	err := attr.ValidateBasic()
 	if err != nil {
 		return err
 	}
@@ -344,7 +332,7 @@ func (k Keeper) importAttribute(ctx sdk.Context, attr types.Attribute) error {
 	if err != nil {
 		return err
 	}
-	key := types.AccountAttributeKey(acc, attr)
+	key := types.AccountAttributeKey(attr.GetAddressBytes(), attr)
 	store := ctx.KVStore(k.storeKey)
 	store.Set(key, bz)
 	return nil

--- a/x/attribute/keeper/keeper.go
+++ b/x/attribute/keeper/keeper.go
@@ -69,7 +69,7 @@ func (k Keeper) GetAllAttributes(ctx sdk.Context, addr string) ([]types.Attribut
 	defer telemetry.MeasureSince(time.Now(), types.ModuleName, "keeper_method", "get_all")
 
 	pred := func(s string) bool { return true }
-	return k.prefixScan(ctx, types.AccountAttributesKeyPrefix(types.GetAttributeAddressBytes(addr)), pred)
+	return k.prefixScan(ctx, types.AddrStrAttributesKeyPrefix(addr), pred)
 }
 
 // GetAttributes gets all attributes with the given name from an account.
@@ -81,7 +81,7 @@ func (k Keeper) GetAttributes(ctx sdk.Context, addr string, name string) ([]type
 		return nil, err
 	}
 	pred := func(s string) bool { return strings.EqualFold(s, name) }
-	return k.prefixScan(ctx, types.AccountAttributesNameKeyPrefix(types.GetAttributeAddressBytes(addr), name), pred)
+	return k.prefixScan(ctx, types.AddrStrAttributesNameKeyPrefix(addr, name), pred)
 }
 
 // IterateRecords iterates over all the stored attribute records and passes them to a callback function.
@@ -146,7 +146,7 @@ func (k Keeper) SetAttribute(
 		return err
 	}
 
-	key := types.AccountAttributeKey(attr.GetAddressBytes(), attr)
+	key := types.AddrAttributeKey(attr.GetAddressBytes(), attr)
 
 	store := ctx.KVStore(k.storeKey)
 	store.Set(key, bz)
@@ -205,7 +205,7 @@ func (k Keeper) UpdateAttribute(ctx sdk.Context, originalAttribute types.Attribu
 	addrBz := originalAttribute.GetAddressBytes()
 
 	store := ctx.KVStore(k.storeKey)
-	it := sdk.KVStorePrefixIterator(store, types.AccountAttributesNameKeyPrefix(addrBz, normalizedOrigName))
+	it := sdk.KVStorePrefixIterator(store, types.AddrAttributesNameKeyPrefix(addrBz, normalizedOrigName))
 	var found bool
 	for ; it.Valid(); it.Next() {
 		attr := types.Attribute{}
@@ -221,7 +221,7 @@ func (k Keeper) UpdateAttribute(ctx sdk.Context, originalAttribute types.Attribu
 			if err != nil {
 				return err
 			}
-			updatedKey := types.AccountAttributeKey(addrBz, updateAttribute)
+			updatedKey := types.AddrAttributeKey(addrBz, updateAttribute)
 			store.Set(updatedKey, bz)
 
 			attributeUpdateEvent := types.NewEventAttributeUpdate(originalAttribute, updateAttribute, owner.String())
@@ -260,7 +260,7 @@ func (k Keeper) DeleteAttribute(ctx sdk.Context, addr string, name string, value
 	}
 
 	store := ctx.KVStore(k.storeKey)
-	it := sdk.KVStorePrefixIterator(store, types.AccountAttributesNameKeyPrefix(types.GetAttributeAddressBytes(addr), name))
+	it := sdk.KVStorePrefixIterator(store, types.AddrStrAttributesNameKeyPrefix(addr, name))
 	var count int
 	for ; it.Valid(); it.Next() {
 		attr := types.Attribute{}
@@ -332,7 +332,7 @@ func (k Keeper) importAttribute(ctx sdk.Context, attr types.Attribute) error {
 	if err != nil {
 		return err
 	}
-	key := types.AccountAttributeKey(attr.GetAddressBytes(), attr)
+	key := types.AddrAttributeKey(attr.GetAddressBytes(), attr)
 	store := ctx.KVStore(k.storeKey)
 	store.Set(key, bz)
 	return nil

--- a/x/attribute/keeper/keeper_test.go
+++ b/x/attribute/keeper/keeper_test.go
@@ -371,7 +371,7 @@ func (s *KeeperTestSuite) TestDeleteAttribute() {
 
 	cases := map[string]struct {
 		name      string
-		accAddr   sdk.AccAddress
+		accAddr   string
 		ownerAddr sdk.AccAddress
 		wantErr   bool
 		errorMsg  string
@@ -390,14 +390,14 @@ func (s *KeeperTestSuite) TestDeleteAttribute() {
 		},
 		"attribute will be removed without error when name has been removed": {
 			name:      "deleted",
-			accAddr:   s.user1Addr,
+			accAddr:   s.user1,
 			ownerAddr: s.user1Addr,
 			wantErr:   false,
 			errorMsg:  "",
 		},
 		"should successfully delete attribute": {
 			name:      "example.attribute",
-			accAddr:   s.user1Addr,
+			accAddr:   s.user1,
 			ownerAddr: s.user1Addr,
 			wantErr:   false,
 			errorMsg:  "",
@@ -440,7 +440,7 @@ func (s *KeeperTestSuite) TestDeleteDistinctAttribute() {
 		name      string
 		value     []byte
 		attrType  types.AttributeType
-		accAddr   sdk.AccAddress
+		accAddr   string
 		ownerAddr sdk.AccAddress
 		wantErr   bool
 		errorMsg  string
@@ -465,7 +465,7 @@ func (s *KeeperTestSuite) TestDeleteDistinctAttribute() {
 			testName:  "should successfully delete attribute",
 			name:      "example.attribute",
 			value:     []byte("123456789"),
-			accAddr:   s.user1Addr,
+			accAddr:   s.user1,
 			ownerAddr: s.user1Addr,
 			wantErr:   false,
 			errorMsg:  "",
@@ -474,7 +474,7 @@ func (s *KeeperTestSuite) TestDeleteDistinctAttribute() {
 			testName:  "should fail to delete attribute, was already deleted",
 			name:      "example.attribute",
 			value:     []byte("123456789"),
-			accAddr:   s.user1Addr,
+			accAddr:   s.user1,
 			ownerAddr: s.user1Addr,
 			wantErr:   true,
 			errorMsg:  "no keys deleted with name example.attribute value 123456789",
@@ -483,7 +483,7 @@ func (s *KeeperTestSuite) TestDeleteDistinctAttribute() {
 			testName:  "should successfully delete attribute, with same key but different value",
 			name:      "example.attribute",
 			value:     []byte("diff value"),
-			accAddr:   s.user1Addr,
+			accAddr:   s.user1,
 			ownerAddr: s.user1Addr,
 			wantErr:   false,
 			errorMsg:  "",
@@ -506,7 +506,7 @@ func (s *KeeperTestSuite) TestDeleteDistinctAttribute() {
 
 func (s *KeeperTestSuite) TestGetAllAttributes() {
 
-	attributes, err := s.app.AttributeKeeper.GetAllAttributes(s.ctx, s.user1Addr)
+	attributes, err := s.app.AttributeKeeper.GetAllAttributes(s.ctx, s.user1)
 	s.NoError(err)
 	s.Equal(0, len(attributes))
 
@@ -517,7 +517,7 @@ func (s *KeeperTestSuite) TestGetAllAttributes() {
 		AttributeType: types.AttributeType_String,
 	}
 	s.NoError(s.app.AttributeKeeper.SetAttribute(s.ctx, attr, s.user1Addr), "should save successfully")
-	attributes, err = s.app.AttributeKeeper.GetAllAttributes(s.ctx, s.user1Addr)
+	attributes, err = s.app.AttributeKeeper.GetAllAttributes(s.ctx, s.user1)
 	s.NoError(err)
 	s.Equal(attr.Name, attributes[0].Name)
 	s.Equal(attr.Address, attributes[0].Address)
@@ -533,10 +533,10 @@ func (s *KeeperTestSuite) TestGetAttributesByName() {
 		AttributeType: types.AttributeType_String,
 	}
 	s.NoError(s.app.AttributeKeeper.SetAttribute(s.ctx, attr, s.user1Addr), "should save successfully")
-	_, err := s.app.AttributeKeeper.GetAttributes(s.ctx, s.user1Addr, "blah")
+	_, err := s.app.AttributeKeeper.GetAttributes(s.ctx, s.user1, "blah")
 	s.Error(err)
 	s.Equal("no address bound to name", err.Error())
-	attributes, err := s.app.AttributeKeeper.GetAttributes(s.ctx, s.user1Addr, "example.attribute")
+	attributes, err := s.app.AttributeKeeper.GetAttributes(s.ctx, s.user1, "example.attribute")
 	s.NoError(err)
 	s.Equal(1, len(attributes))
 	s.Equal(attr.Name, attributes[0].Name)

--- a/x/attribute/keeper/keeper_test.go
+++ b/x/attribute/keeper/keeper_test.go
@@ -366,7 +366,7 @@ func (s *KeeperTestSuite) TestDeleteAttribute() {
 
 	// Create a name, make an attribute under it, then remove the name leaving an orphan attribute.
 	s.NoError(s.app.NameKeeper.SetNameRecord(s.ctx, "deleted", s.user1Addr, false), "name record should save successfully")
-	s.NoError(s.app.AttributeKeeper.SetAttribute(s.ctx, types.NewAttribute("deleted", s.user1Addr, types.AttributeType_String, []byte("test")), s.user1Addr), "should save successfully")
+	s.NoError(s.app.AttributeKeeper.SetAttribute(s.ctx, types.NewAttribute("deleted", s.user1, types.AttributeType_String, []byte("test")), s.user1Addr), "should save successfully")
 	s.NoError(s.app.NameKeeper.DeleteRecord(s.ctx, "deleted"), "name record should be removed successfully")
 
 	cases := map[string]struct {

--- a/x/attribute/keeper/msg_server.go
+++ b/x/attribute/keeper/msg_server.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/armon/go-metrics"
 	"github.com/cosmos/cosmos-sdk/telemetry"
@@ -125,7 +126,7 @@ func (k msgServer) DeleteAttribute(goCtx context.Context, msg *types.MsgDeleteAt
 
 	err := types.ValidateAttributeAddress(msg.Account)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid account address: %w", err)
 	}
 
 	ownerAddr, err := sdk.AccAddressFromBech32(msg.Owner)
@@ -166,7 +167,7 @@ func (k msgServer) DeleteDistinctAttribute(goCtx context.Context, msg *types.Msg
 
 	err := types.ValidateAttributeAddress(msg.Account)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid account address: %w", err)
 	}
 
 	ownerAddr, err := sdk.AccAddressFromBech32(msg.Owner)

--- a/x/attribute/keeper/msg_server.go
+++ b/x/attribute/keeper/msg_server.go
@@ -123,7 +123,7 @@ func (k msgServer) UpdateAttribute(goCtx context.Context, msg *types.MsgUpdateAt
 func (k msgServer) DeleteAttribute(goCtx context.Context, msg *types.MsgDeleteAttributeRequest) (*types.MsgDeleteAttributeResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	accountAddr, err := sdk.AccAddressFromBech32(msg.Account)
+	err := types.ValidateAttributeAddress(msg.Account)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +133,7 @@ func (k msgServer) DeleteAttribute(goCtx context.Context, msg *types.MsgDeleteAt
 		return nil, err
 	}
 
-	err = k.Keeper.DeleteAttribute(ctx, accountAddr, msg.Name, nil, ownerAddr)
+	err = k.Keeper.DeleteAttribute(ctx, msg.Account, msg.Name, nil, ownerAddr)
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +164,7 @@ func (k msgServer) DeleteAttribute(goCtx context.Context, msg *types.MsgDeleteAt
 func (k msgServer) DeleteDistinctAttribute(goCtx context.Context, msg *types.MsgDeleteDistinctAttributeRequest) (*types.MsgDeleteDistinctAttributeResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	accountAddr, err := sdk.AccAddressFromBech32(msg.Account)
+	err := types.ValidateAttributeAddress(msg.Account)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +174,7 @@ func (k msgServer) DeleteDistinctAttribute(goCtx context.Context, msg *types.Msg
 		return nil, err
 	}
 
-	err = k.Keeper.DeleteAttribute(ctx, accountAddr, msg.Name, &msg.Value, ownerAddr)
+	err = k.Keeper.DeleteAttribute(ctx, msg.Account, msg.Name, &msg.Value, ownerAddr)
 	if err != nil {
 		return nil, err
 	}

--- a/x/attribute/keeper/querier.go
+++ b/x/attribute/keeper/querier.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -48,7 +49,7 @@ func queryAttribute(ctx sdk.Context, path []string, _ abci.RequestQuery, keeper 
 	addr := strings.TrimSpace(path[0])
 	err := types.ValidateAttributeAddress(addr)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "account address must be a Bech32 string")
+		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, fmt.Sprintf("invalid account address: %v", err))
 	}
 	name := strings.TrimSpace(path[1])
 	if name == "" {
@@ -75,7 +76,7 @@ func queryAttributes(ctx sdk.Context, path []string, _ abci.RequestQuery, keeper
 	addr := strings.TrimSpace(path[0])
 	err := types.ValidateAttributeAddress(addr)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "account address must be a Bech32 string")
+		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, fmt.Sprintf("invalid account address: %v", err))
 	}
 	attrs, err := keeper.GetAllAttributes(ctx, addr)
 	if err != nil {

--- a/x/attribute/keeper/querier.go
+++ b/x/attribute/keeper/querier.go
@@ -46,10 +46,7 @@ func queryAttribute(ctx sdk.Context, path []string, _ abci.RequestQuery, keeper 
 		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "missing account address and/or attribute name")
 	}
 	addr := strings.TrimSpace(path[0])
-	if addr == "" {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "account address cannot be empty")
-	}
-	account, err := sdk.AccAddressFromBech32(addr)
+	err := types.ValidateAttributeAddress(addr)
 	if err != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "account address must be a Bech32 string")
 	}
@@ -57,11 +54,11 @@ func queryAttribute(ctx sdk.Context, path []string, _ abci.RequestQuery, keeper 
 	if name == "" {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "attribute name cannot be empty")
 	}
-	attrs, err := keeper.GetAttributes(ctx, account, name)
+	attrs, err := keeper.GetAttributes(ctx, addr, name)
 	if err != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, err.Error())
 	}
-	res := types.QueryAttributesResponse{Account: account.String()}
+	res := types.QueryAttributesResponse{Account: addr}
 	res.Attributes = append(res.Attributes, attrs...)
 	bz, err := codec.MarshalJSONIndent(legacyQuerierCdc, res)
 	if err != nil {
@@ -76,18 +73,15 @@ func queryAttributes(ctx sdk.Context, path []string, _ abci.RequestQuery, keeper
 		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "missing account address")
 	}
 	addr := strings.TrimSpace(path[0])
-	if addr == "" {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "account address cannot be empty")
-	}
-	account, err := sdk.AccAddressFromBech32(addr)
+	err := types.ValidateAttributeAddress(addr)
 	if err != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "account address must be a Bech32 string")
 	}
-	attrs, err := keeper.GetAllAttributes(ctx, account)
+	attrs, err := keeper.GetAllAttributes(ctx, addr)
 	if err != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, err.Error())
 	}
-	res := types.QueryAttributesResponse{Account: account.String()}
+	res := types.QueryAttributesResponse{Account: addr}
 	res.Attributes = append(res.Attributes, attrs...)
 	bz, err := codec.MarshalJSONIndent(legacyQuerierCdc, res)
 	if err != nil {

--- a/x/attribute/keeper/query_server.go
+++ b/x/attribute/keeper/query_server.go
@@ -30,23 +30,19 @@ func (k Keeper) Attribute(c context.Context, req *types.QueryAttributeRequest) (
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
-	if req.Account == "" {
-		return nil, status.Error(codes.InvalidArgument, "empty account address")
-	}
 	if req.Name == "" {
 		return nil, status.Error(codes.InvalidArgument, "empty attribute name")
+	}
+	if err := types.ValidateAttributeAddress(req.Account); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid account address")
 	}
 	ctx := sdk.UnwrapSDKContext(c)
 	attributes := make([]types.Attribute, 0)
 	store := ctx.KVStore(k.storeKey)
-	accAddr, err := sdk.AccAddressFromBech32(req.Account)
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid account address")
-	}
-	attributeStore := prefix.NewStore(store, types.AccountAttributesNameKeyPrefix(accAddr, req.Name))
+	attributeStore := prefix.NewStore(store, types.AddrStrAttributesNameKeyPrefix(req.Account, req.Name))
 	pageRes, err := query.Paginate(attributeStore, req.Pagination, func(key []byte, value []byte) error {
 		var result types.Attribute
-		err = k.cdc.Unmarshal(value, &result)
+		err := k.cdc.Unmarshal(value, &result)
 		if err != nil {
 			return err
 		}
@@ -56,29 +52,25 @@ func (k Keeper) Attribute(c context.Context, req *types.QueryAttributeRequest) (
 	if err != nil {
 		return nil, err
 	}
-	return &types.QueryAttributeResponse{Account: accAddr.String(), Attributes: attributes, Pagination: pageRes}, nil
+	return &types.QueryAttributeResponse{Account: req.Account, Attributes: attributes, Pagination: pageRes}, nil
 }
 
-// Attributes queries for all attributes on a specied account
+// Attributes queries for all attributes on a specified account
 func (k Keeper) Attributes(c context.Context, req *types.QueryAttributesRequest) (*types.QueryAttributesResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
-	if req.Account == "" {
-		return nil, status.Error(codes.InvalidArgument, "empty account address")
+	if err := types.ValidateAttributeAddress(req.Account); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid account address")
 	}
 	ctx := sdk.UnwrapSDKContext(c)
 	attributes := make([]types.Attribute, 0)
 	store := ctx.KVStore(k.storeKey)
-	accAddr, err := sdk.AccAddressFromBech32(req.Account)
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid account address")
-	}
-	attributeStore := prefix.NewStore(store, types.AccountAttributesKeyPrefix(accAddr))
+	attributeStore := prefix.NewStore(store, types.AddrStrAttributesKeyPrefix(req.Account))
 
 	pageRes, err := query.Paginate(attributeStore, req.Pagination, func(key []byte, value []byte) error {
 		var result types.Attribute
-		err = k.cdc.Unmarshal(value, &result)
+		err := k.cdc.Unmarshal(value, &result)
 		if err != nil {
 			return err
 		}
@@ -90,7 +82,7 @@ func (k Keeper) Attributes(c context.Context, req *types.QueryAttributesRequest)
 		return nil, err
 	}
 
-	return &types.QueryAttributesResponse{Account: accAddr.String(), Attributes: attributes, Pagination: pageRes}, nil
+	return &types.QueryAttributesResponse{Account: req.Account, Attributes: attributes, Pagination: pageRes}, nil
 }
 
 // Scan queries for all attributes on a specied account that have a given suffix in their name
@@ -98,24 +90,20 @@ func (k Keeper) Scan(c context.Context, req *types.QueryScanRequest) (*types.Que
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
-	if req.Account == "" {
-		return nil, status.Error(codes.InvalidArgument, "empty account address")
-	}
 	if req.Suffix == "" {
 		return nil, status.Error(codes.InvalidArgument, "empty attribute name suffix")
+	}
+	if err := types.ValidateAttributeAddress(req.Account); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid account address")
 	}
 	ctx := sdk.UnwrapSDKContext(c)
 	attributes := make([]types.Attribute, 0)
 	store := ctx.KVStore(k.storeKey)
-	accAddr, err := sdk.AccAddressFromBech32(req.Account)
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid account address")
-	}
-	attributeStore := prefix.NewStore(store, types.AccountAttributesKeyPrefix(accAddr))
+	attributeStore := prefix.NewStore(store, types.AddrStrAttributesKeyPrefix(req.Account))
 
 	pageRes, err := query.FilteredPaginate(attributeStore, req.Pagination, func(key []byte, value []byte, accumulate bool) (bool, error) {
 		var result types.Attribute
-		err = k.cdc.Unmarshal(value, &result)
+		err := k.cdc.Unmarshal(value, &result)
 		if err != nil {
 			return false, err
 		}
@@ -132,5 +120,5 @@ func (k Keeper) Scan(c context.Context, req *types.QueryScanRequest) (*types.Que
 		return nil, err
 	}
 
-	return &types.QueryScanResponse{Account: accAddr.String(), Attributes: attributes, Pagination: pageRes}, nil
+	return &types.QueryScanResponse{Account: req.Account, Attributes: attributes, Pagination: pageRes}, nil
 }

--- a/x/attribute/keeper/query_server.go
+++ b/x/attribute/keeper/query_server.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"google.golang.org/grpc/codes"
@@ -34,7 +35,7 @@ func (k Keeper) Attribute(c context.Context, req *types.QueryAttributeRequest) (
 		return nil, status.Error(codes.InvalidArgument, "empty attribute name")
 	}
 	if err := types.ValidateAttributeAddress(req.Account); err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid account address")
+		return nil, status.Errorf(codes.InvalidArgument, fmt.Sprintf("invalid account address: %v", err))
 	}
 	ctx := sdk.UnwrapSDKContext(c)
 	attributes := make([]types.Attribute, 0)
@@ -61,7 +62,7 @@ func (k Keeper) Attributes(c context.Context, req *types.QueryAttributesRequest)
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
 	if err := types.ValidateAttributeAddress(req.Account); err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid account address")
+		return nil, status.Errorf(codes.InvalidArgument, fmt.Sprintf("invalid account address: %v", err))
 	}
 	ctx := sdk.UnwrapSDKContext(c)
 	attributes := make([]types.Attribute, 0)
@@ -94,7 +95,7 @@ func (k Keeper) Scan(c context.Context, req *types.QueryScanRequest) (*types.Que
 		return nil, status.Error(codes.InvalidArgument, "empty attribute name suffix")
 	}
 	if err := types.ValidateAttributeAddress(req.Account); err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid account address")
+		return nil, status.Errorf(codes.InvalidArgument, fmt.Sprintf("invalid account address: %v", err))
 	}
 	ctx := sdk.UnwrapSDKContext(c)
 	attributes := make([]types.Attribute, 0)

--- a/x/attribute/legacy/v042/store.go
+++ b/x/attribute/legacy/v042/store.go
@@ -26,7 +26,7 @@ func MigrateAddressLength(ctx sdk.Context, storeKey sdk.StoreKey) error {
 			return err
 		}
 
-		newStoreKey := types.AccountAttributeKey(attrAddress, attribute)
+		newStoreKey := types.AddrAttributeKey(attrAddress, attribute)
 
 		bz, err := types.ModuleCdc.Marshal(&attribute)
 		if err != nil {

--- a/x/attribute/legacy/v042/store_test.go
+++ b/x/attribute/legacy/v042/store_test.go
@@ -136,7 +136,7 @@ func (s *MigrateTestSuite) TestMigrateTestSuite() {
 		s.Assert().Nil(result)
 
 		// Should find attribute with updated key
-		key = types.AccountAttributeKey(acc, attr)
+		key = types.AddrAttributeKey(acc, attr)
 		result = store.Get(key)
 		s.Assert().NotNil(result)
 		var resultAttr types.Attribute

--- a/x/attribute/simulation/decoder_test.go
+++ b/x/attribute/simulation/decoder_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/kv"
 
 	"github.com/provenance-io/provenance/app"
@@ -18,7 +17,7 @@ func TestDecodeStore(t *testing.T) {
 	cdc := app.MakeEncodingConfig().Marshaler
 	dec := simulation.NewDecodeStore(cdc)
 
-	testAttributeRecord := types.NewAttribute("test", sdk.AccAddress{}, types.AttributeType_Int, []byte{1})
+	testAttributeRecord := types.NewAttribute("test", "", types.AttributeType_Int, []byte{1})
 
 	kvPairs := kv.Pairs{
 		Pairs: []kv.Pair{

--- a/x/attribute/simulation/operations.go
+++ b/x/attribute/simulation/operations.go
@@ -149,7 +149,7 @@ func SimulateMsgUpdateAttribute(k keeper.Keeper, ak authkeeper.AccountKeeperI, b
 		t := types.AttributeType(r.Intn(9))
 		simAccount, _ := simtypes.FindAccount(accs, mustGetAddress(ownerAddress))
 		msg := types.NewMsgUpdateAttributeRequest(
-			mustGetAddress(randomAttribute.GetAddress()),
+			randomAttribute.GetAddress(),
 			mustGetAddress(ownerAddress),
 			randomAttribute.Name,
 			randomAttribute.Value,

--- a/x/attribute/simulation/operations.go
+++ b/x/attribute/simulation/operations.go
@@ -107,7 +107,7 @@ func SimulateMsgAddAttribute(k keeper.Keeper, ak authkeeper.AccountKeeperI, bk b
 
 		t := types.AttributeType(r.Intn(9))
 		msg := types.NewMsgAddAttributeRequest(
-			mustGetAddress(randomRecord.GetAddress()),
+			randomRecord.GetAddress(),
 			simAccount.Address,
 			randomRecord.Name,
 			t,

--- a/x/attribute/simulation/operations.go
+++ b/x/attribute/simulation/operations.go
@@ -191,7 +191,7 @@ func SimulateMsgDeleteAttribute(k keeper.Keeper, ak authkeeper.AccountKeeperI, b
 		}
 
 		simAccount, _ := simtypes.FindAccount(accs, mustGetAddress(ownerAddress))
-		msg := types.NewMsgDeleteAttributeRequest(mustGetAddress(randomAttribute.Address), mustGetAddress(ownerAddress), randomAttribute.Name)
+		msg := types.NewMsgDeleteAttributeRequest(randomAttribute.Address, mustGetAddress(ownerAddress), randomAttribute.Name)
 
 		return Dispatch(r, app, ctx, ak, bk, simAccount, chainID, msg)
 	}
@@ -226,7 +226,7 @@ func SimulateMsgDeleteDistinctAttribute(k keeper.Keeper, ak authkeeper.AccountKe
 		}
 
 		simAccount, _ := simtypes.FindAccount(accs, mustGetAddress(ownerAddress))
-		msg := types.NewMsgDeleteDistinctAttributeRequest(mustGetAddress(randomAttribute.Address), mustGetAddress(ownerAddress), randomAttribute.Name, randomAttribute.Value)
+		msg := types.NewMsgDeleteDistinctAttributeRequest(randomAttribute.Address, mustGetAddress(ownerAddress), randomAttribute.Name, randomAttribute.Value)
 
 		return Dispatch(r, app, ctx, ak, bk, simAccount, chainID, msg)
 	}

--- a/x/attribute/simulation/operations_test.go
+++ b/x/attribute/simulation/operations_test.go
@@ -105,7 +105,7 @@ func (suite *SimTestSuite) TestSimulateMsgUpdateAttribute() {
 	r := rand.New(s)
 	accounts := suite.getTestingAccounts(r, 3)
 	suite.app.NameKeeper.SetNameRecord(suite.ctx, "example.provenance", accounts[0].Address, false)
-	suite.app.AttributeKeeper.SetAttribute(suite.ctx, types.NewAttribute("example.provenance", accounts[1].Address, types.AttributeType_String, []byte("test")), accounts[0].Address)
+	suite.app.AttributeKeeper.SetAttribute(suite.ctx, types.NewAttribute("example.provenance", accounts[1].Address.String(), types.AttributeType_String, []byte("test")), accounts[0].Address)
 
 	// begin a new block
 	suite.app.BeginBlock(abci.RequestBeginBlock{Header: tmproto.Header{Height: suite.app.LastBlockHeight() + 1, AppHash: suite.app.LastCommitID().Hash}})
@@ -134,7 +134,7 @@ func (suite *SimTestSuite) TestSimulateMsgDeleteAttribute() {
 	r := rand.New(s)
 	accounts := suite.getTestingAccounts(r, 3)
 	suite.app.NameKeeper.SetNameRecord(suite.ctx, "example.provenance", accounts[0].Address, false)
-	suite.app.AttributeKeeper.SetAttribute(suite.ctx, types.NewAttribute("example.provenance", accounts[1].Address, types.AttributeType_String, []byte("test")), accounts[0].Address)
+	suite.app.AttributeKeeper.SetAttribute(suite.ctx, types.NewAttribute("example.provenance", accounts[1].Address.String(), types.AttributeType_String, []byte("test")), accounts[0].Address)
 
 	// begin a new block
 	suite.app.BeginBlock(abci.RequestBeginBlock{Header: tmproto.Header{Height: suite.app.LastBlockHeight() + 1, AppHash: suite.app.LastCommitID().Hash}})
@@ -164,7 +164,7 @@ func (suite *SimTestSuite) TestSimulateMsgDeleteDistinctAttribute() {
 	accounts := suite.getTestingAccounts(r, 3)
 
 	suite.app.NameKeeper.SetNameRecord(suite.ctx, "example.provenance", accounts[0].Address, false)
-	suite.app.AttributeKeeper.SetAttribute(suite.ctx, types.NewAttribute("example.provenance", accounts[1].Address, types.AttributeType_String, []byte("test")), accounts[0].Address)
+	suite.app.AttributeKeeper.SetAttribute(suite.ctx, types.NewAttribute("example.provenance", accounts[1].Address.String(), types.AttributeType_String, []byte("test")), accounts[0].Address)
 
 	// begin a new block
 	suite.app.BeginBlock(abci.RequestBeginBlock{Header: tmproto.Header{Height: suite.app.LastBlockHeight() + 1, AppHash: suite.app.LastCommitID().Hash}})

--- a/x/attribute/types/attribute.go
+++ b/x/attribute/types/attribute.go
@@ -65,6 +65,29 @@ func (a Attribute) ValidateBasic() error {
 	return nil
 }
 
+// GetAddressBytes Gets the bytes of this attribute's address.
+// If the address is neither an account address nor metadata address (or is an empty string), an empty byte slice is returned.
+func (a Attribute) GetAddressBytes() []byte {
+	return GetAttributeAddressBytes(a.Address)
+}
+
+// GetAttributeAddressBytes Gets the bytes of an address used in an attribute.
+// If the address is neither an account address nor metadata address (or is an empty string), an empty byte slice is returned.
+func GetAttributeAddressBytes(addr string) []byte {
+	if len(strings.TrimSpace(addr)) == 0 {
+		return []byte{}
+	}
+	accAddr, accErr := sdk.AccAddressFromBech32(addr)
+	if accErr == nil {
+		return accAddr.Bytes()
+	}
+	mdAddr, mdErr := metadatatypes.MetadataAddressFromBech32(addr)
+	if mdErr == nil {
+		return mdAddr.Bytes()
+	}
+	return []byte{}
+}
+
 // ValidateAttributeAddress validates that the provide string is a valid address for an attribute.
 // Failures:
 //  * The provided address is empty

--- a/x/attribute/types/attribute.go
+++ b/x/attribute/types/attribute.go
@@ -51,7 +51,7 @@ func (a Attribute) ValidateBasic() error {
 		return fmt.Errorf("invalid value: nil")
 	}
 
-	err := validateAttributeAddress(a.Address)
+	err := ValidateAttributeAddress(a.Address)
 	if err != nil {
 		return fmt.Errorf("invalid attribute address: %w", err)
 	}
@@ -65,11 +65,11 @@ func (a Attribute) ValidateBasic() error {
 	return nil
 }
 
-// validateAttributeAddress validates that the provide string is a valid address for an attribute.
+// ValidateAttributeAddress validates that the provide string is a valid address for an attribute.
 // Failures:
 //  * The provided address is empty
 //  * The provided address is neither an account address nor scope metadata address.
-func validateAttributeAddress(addr string) error {
+func ValidateAttributeAddress(addr string) error {
 	if len(strings.TrimSpace(addr)) == 0 {
 		return errors.New("must not be empty")
 	}

--- a/x/attribute/types/attribute.go
+++ b/x/attribute/types/attribute.go
@@ -6,13 +6,14 @@ import (
 	"encoding/json"
 	"errors"
 	fmt "fmt"
-	metadatatypes "github.com/provenance-io/provenance/x/metadata/types"
 	"math/big"
 	"net/url"
 	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	uuid "github.com/google/uuid"
+	"github.com/google/uuid"
+
+	metadatatypes "github.com/provenance-io/provenance/x/metadata/types"
 )
 
 // NewAttribute creates a new instance of an Attribute

--- a/x/attribute/types/attribute.go
+++ b/x/attribute/types/attribute.go
@@ -14,7 +14,7 @@ import (
 )
 
 // NewAttribute creates a new instance of an Attribute
-func NewAttribute(name string, account sdk.AccAddress, attrType AttributeType, value []byte) Attribute { // nolint:interfacer
+func NewAttribute(name string, address string, attrType AttributeType, value []byte) Attribute { // nolint:interfacer
 	// Ensure string type values are trimmed.
 	if attrType != AttributeType_Bytes && attrType != AttributeType_Proto {
 		trimmed := strings.TrimSpace(string(value))
@@ -22,7 +22,7 @@ func NewAttribute(name string, account sdk.AccAddress, attrType AttributeType, v
 	}
 	return Attribute{
 		Name:          name,
-		Address:       account.String(),
+		Address:       address,
 		AttributeType: attrType,
 		Value:         value,
 	}

--- a/x/attribute/types/keys.go
+++ b/x/attribute/types/keys.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/address"
 )
 
@@ -29,22 +28,32 @@ var (
 	AttributeKeyPrefix      = []byte{0x02}
 )
 
-// AccountAttributeKey creates a key for an account attribute
-func AccountAttributeKey(acc sdk.AccAddress, attr Attribute) []byte {
-	key := append(AttributeKeyPrefix, address.MustLengthPrefix(acc.Bytes())...)
+// AddrAttributeKey creates a key for an account attribute
+func AddrAttributeKey(addr []byte, attr Attribute) []byte {
+	key := append(AttributeKeyPrefix, address.MustLengthPrefix(addr)...)
 	key = append(key, GetNameKeyBytes(attr.Name)...)
 	return append(key, attr.Hash()...)
 }
 
-// AccountAttributesKeyPrefix returns a prefix key for all attributes on an account
-func AccountAttributesKeyPrefix(acc sdk.AccAddress) []byte {
-	return append(AttributeKeyPrefix, address.MustLengthPrefix(acc.Bytes())...)
+// AddrAttributesKeyPrefix returns a prefix key for all attributes on an account
+func AddrAttributesKeyPrefix(addr []byte) []byte {
+	return append(AttributeKeyPrefix, address.MustLengthPrefix(addr)...)
 }
 
-// AccountAttributesNameKeyPrefix returns a prefix key for all attributes with a given name on an account
-func AccountAttributesNameKeyPrefix(acc sdk.AccAddress, attributeName string) []byte {
-	key := append(AttributeKeyPrefix, address.MustLengthPrefix(acc.Bytes())...)
+// AddrStrAttributesKeyPrefix is the same as AddrAttributesKeyPrefix but takes in the address as a string.
+func AddrStrAttributesKeyPrefix(addr string) []byte {
+	return AddrAttributesKeyPrefix(GetAttributeAddressBytes(addr))
+}
+
+// AddrAttributesNameKeyPrefix returns a prefix key for all attributes with a given name on an account
+func AddrAttributesNameKeyPrefix(addr []byte, attributeName string) []byte {
+	key := append(AttributeKeyPrefix, address.MustLengthPrefix(addr)...)
 	return append(key, GetNameKeyBytes(attributeName)...)
+}
+
+// AddrStrAttributesNameKeyPrefix is the same as AddrAttributesNameKeyPrefix but takes in the address as a string.
+func AddrStrAttributesNameKeyPrefix(addr string, attributeName string) []byte {
+	return AddrAttributesNameKeyPrefix(GetAttributeAddressBytes(addr), attributeName)
 }
 
 // GetNameKeyBytes returns a set of bytes that uniquely identifies the given name

--- a/x/attribute/types/msgs.go
+++ b/x/attribute/types/msgs.go
@@ -24,8 +24,14 @@ var (
 )
 
 // NewMsgAddAttributeRequest creates a new add attribute message
-func NewMsgAddAttributeRequest(account sdk.AccAddress, owner sdk.AccAddress, name string, attributeType AttributeType, value []byte) *MsgAddAttributeRequest { // nolint:interfacer
-	return &MsgAddAttributeRequest{Account: account.String(), Name: strings.ToLower(strings.TrimSpace(name)), Owner: owner.String(), AttributeType: attributeType, Value: value}
+func NewMsgAddAttributeRequest(account string, owner sdk.AccAddress, name string, attributeType AttributeType, value []byte) *MsgAddAttributeRequest { // nolint:interfacer
+	return &MsgAddAttributeRequest{
+		Account: account,
+		Name: strings.ToLower(strings.TrimSpace(name)),
+		Owner: owner.String(),
+		AttributeType: attributeType,
+		Value: value,
+	}
 }
 
 // Route returns the name of the module.

--- a/x/attribute/types/msgs.go
+++ b/x/attribute/types/msgs.go
@@ -38,20 +38,13 @@ func (msg MsgAddAttributeRequest) Type() string { return TypeMsgAddAttribute }
 
 // ValidateBasic runs stateless validation checks on the message.
 func (msg MsgAddAttributeRequest) ValidateBasic() error {
-	if len(msg.Account) == 0 {
-		return fmt.Errorf("empty account address")
-	}
-	accAddr, err := sdk.AccAddressFromBech32(msg.Account)
-	if err != nil {
-		return err
-	}
 	if len(msg.Owner) == 0 {
 		return fmt.Errorf("empty owner address")
 	}
 	if _, err := sdk.AccAddressFromBech32(msg.Owner); err != nil {
 		return err
 	}
-	a := NewAttribute(msg.Name, accAddr, msg.AttributeType, msg.Value)
+	a := NewAttribute(msg.Name, msg.Account, msg.AttributeType, msg.Value)
 	return a.ValidateBasic()
 }
 
@@ -99,20 +92,13 @@ func (msg MsgUpdateAttributeRequest) Type() string { return TypeMsgUpdateAttribu
 
 // ValidateBasic runs stateless validation checks on the message.
 func (msg MsgUpdateAttributeRequest) ValidateBasic() error {
-	if len(msg.Account) == 0 {
-		return fmt.Errorf("empty account address")
-	}
-	accAddr, err := sdk.AccAddressFromBech32(msg.Account)
-	if err != nil {
-		return err
-	}
 	if len(msg.Owner) == 0 {
 		return fmt.Errorf("empty owner address")
 	}
 	if _, err := sdk.AccAddressFromBech32(msg.Owner); err != nil {
 		return err
 	}
-	a := NewAttribute(msg.Name, accAddr, msg.UpdateAttributeType, msg.UpdateValue)
+	a := NewAttribute(msg.Name, msg.Account, msg.UpdateAttributeType, msg.UpdateValue)
 	return a.ValidateBasic()
 }
 

--- a/x/attribute/types/msgs.go
+++ b/x/attribute/types/msgs.go
@@ -130,8 +130,12 @@ func (msg MsgUpdateAttributeRequest) String() string {
 }
 
 // NewMsgDeleteAttributeRequest deletes all attributes with specific name
-func NewMsgDeleteAttributeRequest(account sdk.AccAddress, owner sdk.AccAddress, name string) *MsgDeleteAttributeRequest { // nolint:interfacer
-	return &MsgDeleteAttributeRequest{Account: account.String(), Name: strings.ToLower(strings.TrimSpace(name)), Owner: owner.String()}
+func NewMsgDeleteAttributeRequest(account string, owner sdk.AccAddress, name string) *MsgDeleteAttributeRequest { // nolint:interfacer
+	return &MsgDeleteAttributeRequest{
+		Account: account,
+		Name:    strings.ToLower(strings.TrimSpace(name)),
+		Owner:   owner.String(),
+	}
 }
 
 // Route returns the name of the module.
@@ -147,11 +151,8 @@ func (msg MsgDeleteAttributeRequest) ValidateBasic() error {
 	if strings.TrimSpace(msg.Name) == "" {
 		return fmt.Errorf("empty name")
 	}
-	if len(msg.Account) == 0 {
-		return fmt.Errorf("empty account address")
-	}
-	if _, err := sdk.AccAddressFromBech32(msg.Account); err != nil {
-		return err
+	if err := ValidateAttributeAddress(msg.Account); err != nil {
+		return fmt.Errorf("invalid account address: %w", err)
 	}
 	if len(msg.Owner) == 0 {
 		return fmt.Errorf("empty owner address")
@@ -184,9 +185,9 @@ func (msg MsgDeleteAttributeRequest) GetSigners() []sdk.AccAddress {
 }
 
 // NewMsgDeleteDistinctAttributeRequest deletes a attribute with specific value and type
-func NewMsgDeleteDistinctAttributeRequest(account sdk.AccAddress, owner sdk.AccAddress, name string, value []byte) *MsgDeleteDistinctAttributeRequest { // nolint:interfacer
+func NewMsgDeleteDistinctAttributeRequest(account string, owner sdk.AccAddress, name string, value []byte) *MsgDeleteDistinctAttributeRequest { // nolint:interfacer
 	return &MsgDeleteDistinctAttributeRequest{
-		Account: account.String(),
+		Account: account,
 		Name:    strings.ToLower(strings.TrimSpace(name)),
 		Owner:   owner.String(),
 		Value:   value,
@@ -209,11 +210,8 @@ func (msg MsgDeleteDistinctAttributeRequest) ValidateBasic() error {
 	if len(msg.Value) == 0 {
 		return fmt.Errorf("empty value")
 	}
-	if len(msg.Account) == 0 {
-		return fmt.Errorf("empty account address")
-	}
-	if _, err := sdk.AccAddressFromBech32(msg.Account); err != nil {
-		return err
+	if err := ValidateAttributeAddress(msg.Account); err != nil {
+		return fmt.Errorf("invalid account address: %w", err)
 	}
 	if len(msg.Owner) == 0 {
 		return fmt.Errorf("empty owner address")

--- a/x/attribute/types/msgs.go
+++ b/x/attribute/types/msgs.go
@@ -26,11 +26,11 @@ var (
 // NewMsgAddAttributeRequest creates a new add attribute message
 func NewMsgAddAttributeRequest(account string, owner sdk.AccAddress, name string, attributeType AttributeType, value []byte) *MsgAddAttributeRequest { // nolint:interfacer
 	return &MsgAddAttributeRequest{
-		Account: account,
-		Name: strings.ToLower(strings.TrimSpace(name)),
-		Owner: owner.String(),
+		Account:       account,
+		Name:          strings.ToLower(strings.TrimSpace(name)),
+		Owner:         owner.String(),
 		AttributeType: attributeType,
-		Value: value,
+		Value:         value,
 	}
 }
 

--- a/x/attribute/types/msgs.go
+++ b/x/attribute/types/msgs.go
@@ -76,9 +76,9 @@ func (msg MsgAddAttributeRequest) String() string {
 }
 
 // NewMsgUpdateAttributeRequest creates a new add attribute message
-func NewMsgUpdateAttributeRequest(account sdk.AccAddress, owner sdk.AccAddress, name string, originalValue []byte, updateValue []byte, origAttrType AttributeType, updatedAttrType AttributeType) *MsgUpdateAttributeRequest { // nolint:interfacer
+func NewMsgUpdateAttributeRequest(account string, owner sdk.AccAddress, name string, originalValue []byte, updateValue []byte, origAttrType AttributeType, updatedAttrType AttributeType) *MsgUpdateAttributeRequest { // nolint:interfacer
 	return &MsgUpdateAttributeRequest{
-		Account:               account.String(),
+		Account:               account,
 		Name:                  strings.ToLower(strings.TrimSpace(name)),
 		Owner:                 owner.String(),
 		OriginalValue:         originalValue,

--- a/x/attribute/types/msgs_test.go
+++ b/x/attribute/types/msgs_test.go
@@ -21,15 +21,16 @@ var (
 // test ValidateBasic for TestMsgAddAttribute
 func TestMsgAddAttribute(t *testing.T) {
 	tests := []struct {
-		account, owner     sdk.AccAddress
+		account   string
+		owner     sdk.AccAddress
 		name, proposalType string
 		proposalValue      string
 		expectPass         bool
 	}{
-		{nil, addrs[1], "test", "string", "nil owner", false},
-		{addrs[0], nil, "test", "string", "nil account", false},
-		{nil, nil, "test", "string", "nil owner and account", false},
-		{addrs[0], addrs[1], "test", "string", "valid attribute", true},
+		{"", addrs[1], "test", "string", "nil owner", false},
+		{addrs[0].String(), nil, "test", "string", "nil account", false},
+		{"", nil, "test", "string", "nil owner and account", false},
+		{addrs[0].String(), addrs[1], "test", "string", "valid attribute", true},
 	}
 
 	for i, tc := range tests {

--- a/x/attribute/types/msgs_test.go
+++ b/x/attribute/types/msgs_test.go
@@ -55,7 +55,8 @@ func TestMsgAddAttribute(t *testing.T) {
 // test ValidateBasic for TestMsgUpdateAttribute
 func TestMsgUpdateAttribute(t *testing.T) {
 	tests := []struct {
-		account, owner sdk.AccAddress
+		account        string
+		owner          sdk.AccAddress
 		name           string
 		originalValue  []byte
 		originalType   AttributeType
@@ -64,9 +65,9 @@ func TestMsgUpdateAttribute(t *testing.T) {
 		expectPass     bool
 		expectedError  string
 	}{
-		{addrs[0], addrs[1], "example", []byte("original"), AttributeType_String, []byte("update"), AttributeType_Bytes, true, ""},
-		{nil, addrs[1], "example", []byte("original"), AttributeType_String, []byte("update"), AttributeType_Bytes, false, ""},
-		{addrs[0], nil, "example", []byte(""), AttributeType_String, []byte("update"), AttributeType_Bytes, false, ""},
+		{addrs[0].String(), addrs[1], "example", []byte("original"), AttributeType_String, []byte("update"), AttributeType_Bytes, true, ""},
+		{"", addrs[1], "example", []byte("original"), AttributeType_String, []byte("update"), AttributeType_Bytes, false, ""},
+		{addrs[0].String(), nil, "example", []byte(""), AttributeType_String, []byte("update"), AttributeType_Bytes, false, ""},
 	}
 
 	for _, tc := range tests {

--- a/x/attribute/types/msgs_test.go
+++ b/x/attribute/types/msgs_test.go
@@ -21,8 +21,8 @@ var (
 // test ValidateBasic for TestMsgAddAttribute
 func TestMsgAddAttribute(t *testing.T) {
 	tests := []struct {
-		account   string
-		owner     sdk.AccAddress
+		account            string
+		owner              sdk.AccAddress
 		name, proposalType string
 		proposalValue      string
 		expectPass         bool
@@ -55,15 +55,15 @@ func TestMsgAddAttribute(t *testing.T) {
 // test ValidateBasic for TestMsgUpdateAttribute
 func TestMsgUpdateAttribute(t *testing.T) {
 	tests := []struct {
-		account        string
-		owner          sdk.AccAddress
-		name           string
-		originalValue  []byte
-		originalType   AttributeType
-		updateValue    []byte
-		updateType     AttributeType
-		expectPass     bool
-		expectedError  string
+		account       string
+		owner         sdk.AccAddress
+		name          string
+		originalValue []byte
+		originalType  AttributeType
+		updateValue   []byte
+		updateType    AttributeType
+		expectPass    bool
+		expectedError string
 	}{
 		{addrs[0].String(), addrs[1], "example", []byte("original"), AttributeType_String, []byte("update"), AttributeType_Bytes, true, ""},
 		{"", addrs[1], "example", []byte("original"), AttributeType_String, []byte("update"), AttributeType_Bytes, false, ""},

--- a/x/attribute/types/msgs_test.go
+++ b/x/attribute/types/msgs_test.go
@@ -84,15 +84,16 @@ func TestMsgUpdateAttribute(t *testing.T) {
 // test ValidateBasic for TestMsgDeleteDistinctAttribute
 func TestMsgDeleteDistinctAttribute(t *testing.T) {
 	tests := []struct {
-		account, owner sdk.AccAddress
-		name           string
-		value          []byte
-		attrType       AttributeType
-		expectPass     bool
+		account    string
+		owner      sdk.AccAddress
+		name       string
+		value      []byte
+		attrType   AttributeType
+		expectPass bool
 	}{
-		{addrs[0], addrs[1], "example", []byte("original"), AttributeType_String, true},
-		{nil, addrs[1], "example", []byte("original"), AttributeType_String, false},
-		{addrs[0], nil, "example", []byte(""), AttributeType_String, false},
+		{addrs[0].String(), addrs[1], "example", []byte("original"), AttributeType_String, true},
+		{"", addrs[1], "example", []byte("original"), AttributeType_String, false},
+		{addrs[0].String(), nil, "example", []byte(""), AttributeType_String, false},
 	}
 
 	for _, tc := range tests {

--- a/x/attribute/wasm/encode.go
+++ b/x/attribute/wasm/encode.go
@@ -84,11 +84,10 @@ func (params *AddAttributeParams) Encode(contract sdk.AccAddress) ([]sdk.Msg, er
 // Encode creates a MsgDeleteAttribute.
 // The contract must be the owner of the name of the attribute being deleted.
 func (params *DeleteAttributeParams) Encode(contract sdk.AccAddress) ([]sdk.Msg, error) {
-	address, err := sdk.AccAddressFromBech32(params.Address)
-	if err != nil {
+	if err := types.ValidateAttributeAddress(params.Address); err != nil {
 		return nil, fmt.Errorf("wasm: invalid address: %w", err)
 	}
-	msg := types.NewMsgDeleteAttributeRequest(address, contract, params.Name)
+	msg := types.NewMsgDeleteAttributeRequest(params.Address, contract, params.Name)
 	return []sdk.Msg{msg}, nil
 }
 

--- a/x/attribute/wasm/encode.go
+++ b/x/attribute/wasm/encode.go
@@ -68,12 +68,11 @@ func Encoder(contract sdk.AccAddress, msg json.RawMessage, version string) ([]sd
 // Encode creates a MsgAddAttribute.
 // The contract must be the owner of the name of the attribute being added.
 func (params *AddAttributeParams) Encode(contract sdk.AccAddress) ([]sdk.Msg, error) {
-	address, err := sdk.AccAddressFromBech32(params.Address)
-	if err != nil {
+	if err := types.ValidateAttributeAddress(params.Address); err != nil {
 		return nil, fmt.Errorf("wasm: invalid address: %w", err)
 	}
 	msg := types.NewMsgAddAttributeRequest(
-		address,
+		params.Address,
 		contract,
 		params.Name,
 		encodeType(params.ValueType),

--- a/x/attribute/wasm/query.go
+++ b/x/attribute/wasm/query.go
@@ -61,33 +61,33 @@ func Querier(keeper keeper.Keeper) provwasm.Querier {
 
 // Run queries for account attributes by address and name.
 func (params *GetAttributesParams) Run(ctx sdk.Context, keeper keeper.Keeper) ([]byte, error) {
-	address, err := sdk.AccAddressFromBech32(params.Address)
+	err := types.ValidateAttributeAddress(params.Address)
 	if err != nil {
 		return nil, fmt.Errorf("wasm: invalid address: %w", err)
 	}
-	attrs, err := keeper.GetAttributes(ctx, address, params.Name)
+	attrs, err := keeper.GetAttributes(ctx, params.Address, params.Name)
 	if err != nil {
 		return nil, fmt.Errorf("wasm: attribute query failed: %w", err)
 	}
-	return createResponse(address, attrs)
+	return createResponse(params.Address, attrs)
 }
 
 // Run queries for account attributes by address.
 func (params *GetAllAttributesParams) Run(ctx sdk.Context, keeper keeper.Keeper) ([]byte, error) {
-	address, err := sdk.AccAddressFromBech32(params.Address)
+	err := types.ValidateAttributeAddress(params.Address)
 	if err != nil {
 		return nil, fmt.Errorf("wasm: invalid address: %w", err)
 	}
-	attrs, err := keeper.GetAllAttributes(ctx, address)
+	attrs, err := keeper.GetAllAttributes(ctx, params.Address)
 	if err != nil {
 		return nil, fmt.Errorf("wasm: attribute query failed: %w", err)
 	}
-	return createResponse(address, attrs)
+	return createResponse(params.Address, attrs)
 }
 
 // Create a JSON response from the results of a account attribute query.
-func createResponse(address sdk.AccAddress, attrs []types.Attribute) ([]byte, error) {
-	res := AttributeResponse{Address: address.String()}
+func createResponse(address string, attrs []types.Attribute) ([]byte, error) {
+	res := AttributeResponse{Address: address}
 	for _, a := range attrs {
 		attr := Attribute{
 			Name:  a.Name,


### PR DESCRIPTION
## Description

Updates validation and handling of the `Attribute.Address` field to allow it to be a scope metadata address.

closes: #631 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
