### PR TITLE
Fix contract address length support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * Fix maven publish release version number reference [#650](https://github.com/provenance-io/provenance/issues/650)
 * Add `iterator` as feature for wasm [#658](https://github.com/provenance-io/provenance/issues/658)
 * String "v" from Jar artifact version number [#653](https://github.com/provenance-io/provenance/issues/653)
-* Fix `wasm` contract migration failure to find contract history #662
+* Fix `wasm` contract migration failure to find contract history [#662](https://github.com/provenance-io/provenance/issues/662)
 
 ## [v1.7.6](https://github.com/provenance-io/provenance/releases/tag/v1.7.6) - 2021-12-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * Fix maven publish release version number reference [#650](https://github.com/provenance-io/provenance/issues/650)
 * Add `iterator` as feature for wasm [#658](https://github.com/provenance-io/provenance/issues/658)
 * String "v" from Jar artifact version number [#653](https://github.com/provenance-io/provenance/issues/653)
+* Fix `wasm` contract migration failure to find contract history #662
 
 ## [v1.7.6](https://github.com/provenance-io/provenance/releases/tag/v1.7.6) - 2021-12-15
 

--- a/go.mod
+++ b/go.mod
@@ -139,3 +139,7 @@ replace github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.0
 // Dockerfile also needs a reference that will need removing
 // TODO Remove it: https://github.com/CosmWasm/cosmwasm/pull/1223
 replace github.com/CosmWasm/wasmvm => github.com/CosmWasm/wasmvm v1.0.0-beta6
+
+// Fixes address length issue to support contract address of length 20 (pre v1.8.0) with current length 22
+// TODO Remove it when fixed upstream
+replace github.com/CosmWasm/wasmd => github.com/provenance-io/wasmd v0.22.0-pio-address-fix

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,6 @@ github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d h1:nalkkPQcITbvhmL4+C4cKA87NW0tfm3Kl9VXRoPywFg=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
-github.com/CosmWasm/wasmd v0.22.0 h1:6Bn2DDjHvLwZJkYXL+/PRQ9bSll0ReX2IZqRt/BQkhg=
-github.com/CosmWasm/wasmd v0.22.0/go.mod h1:kNDnMAQDJyVek9k6SxCNijMCzOROzzUGBRT8r/vr7oY=
 github.com/CosmWasm/wasmvm v1.0.0-beta6 h1:JYh9Z7qF6h9a2sOOx9hZRwCVS4aFdd+aiwrIXznLn8k=
 github.com/CosmWasm/wasmvm v1.0.0-beta6/go.mod h1:mtwKxbmsko1zdwpaKiRkRwxijMmIAtnLaX5/UT2nPFk=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
@@ -918,6 +916,8 @@ github.com/prometheus/tsdb v0.6.2-0.20190402121629-4f204dcbc150/go.mod h1:qhTCs0
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/provenance-io/cosmos-sdk v0.45.0-pio-1 h1:b3m1PVb9CvcD0xiKNvK1gDSfAPtdd3qYKntrJF1eQ24=
 github.com/provenance-io/cosmos-sdk v0.45.0-pio-1/go.mod h1:XXS/asyCqWNWkx2rW6pSuen+EVcpAFxq6khrhnZgHaQ=
+github.com/provenance-io/wasmd v0.22.0-pio-address-fix h1:oMgJkRT3nq1l58VcP56G39fLsKSQ1Nq44D9fafbdIh4=
+github.com/provenance-io/wasmd v0.22.0-pio-address-fix/go.mod h1:kNDnMAQDJyVek9k6SxCNijMCzOROzzUGBRT8r/vr7oY=
 github.com/rakyll/statik v0.1.7 h1:OF3QCZUuyPxuGEP7B4ypUa7sB/iHtqOTDYZXGM8KOdQ=
 github.com/rakyll/statik v0.1.7/go.mod h1:AlZONWzMtEnMs7W4e/1LURLiI49pIMmp6V9Unghqrcc=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This PR pulls in the provenance fork of wasmd.  This will ensure that old contract addresses of length 20 (< v1.8.0) are still supported.  

Changes on wasmd fork: https://github.com/CosmWasm/wasmd/compare/v0.22.0...provenance-io:v0.22.0-pio-address-fix?expand=1

closes: #662 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
