### PR TITLE
Prevent usage from being printed when the start command encounters an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * Add Java distribution tag to workflow [#624](https://github.com/provenance-io/provenance/issues/624)
 * Fix maven publish release version number reference [#650](https://github.com/provenance-io/provenance/issues/650)
 * String "v" from Jar artifact version number [#653](https://github.com/provenance-io/provenance/issues/653)
+* Add `iterator` as feature for wasm [#658](https://github.com/provenance-io/provenance/issues/658)
 
 ## [v1.7.6](https://github.com/provenance-io/provenance/releases/tag/v1.7.6) - 2021-12-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
   * `provenance.attribute.v1.MsgAddAttributeRequest` 10 hash (10,000,000,000 nhash)
   * `provenance.metadata.v1.MsgWriteScopeRequest`  10 hash (10,000,000,000 nhash)
   * `provenance.metadata.v1.MsgP8eMemorializeContractRequest` 10 hash (10,000,000,000 nhash)
+* When the `start` command encounteres an error, it no longer outputs command usage [#670](https://github.com/provenance-io/provenance/issues/670)
 
 ### Bug Fixes
 

--- a/app/app.go
+++ b/app/app.go
@@ -457,7 +457,7 @@ func New(
 	querierRegistry.RegisterQuerier(metadatatypes.RouterKey, metadatawasm.Querier(app.MetadataKeeper))
 
 	// Add the staking feature and indicate that provwasm contracts can be run on this chain.
-	supportedFeatures := "staking,provenance,stargate"
+	supportedFeatures := "staking,provenance,stargate,iterator"
 
 	wasmMessageRouter := MessageRouterFunc(func(msg sdk.Msg) baseapp.MsgServiceHandler {
 		return pioMsgFeesRouter.Handler(msg)

--- a/cmd/provenanced/cmd/root.go
+++ b/cmd/provenanced/cmd/root.go
@@ -161,7 +161,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 	// Disable usage when the start command returns an error.
 	startCmd, _, err := rootCmd.Find([]string{"start"})
 	if err != nil {
-		panic(fmt.Errorf("start command not found: %w", err.Error()))
+		panic(fmt.Errorf("start command not found: %w", err))
 	}
 	startCmd.SilenceUsage = true
 }

--- a/cmd/provenanced/cmd/root.go
+++ b/cmd/provenanced/cmd/root.go
@@ -156,6 +156,13 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 
 	// Add Rosetta command
 	rootCmd.AddCommand(server.RosettaCommand(encodingConfig.InterfaceRegistry, encodingConfig.Marshaler))
+
+	// Disable usage when the start command returns an error.
+	startCmd, _, err := rootCmd.Find([]string{"start"})
+	if err != nil {
+		panic(fmt.Errorf("start command not found: %w", err.Error()))
+	}
+	startCmd.SilenceUsage = true
 }
 
 func addModuleInitFlags(startCmd *cobra.Command) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #670

When an error is encountered during `provenanced start`:
* Before this change: the error is printed, then usage is printed, then the program exits.
* After this change: the error is printed, then the program exits.

You can still get usage info for the command using either `provenanced help start` or `provenanced start --help`.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
