### PR TITLE
Update marker denom regex to size 83

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,11 +70,11 @@ Ref: https://keepachangelog.com/en/1.0.0/
   * `provenance.metadata.v1.MsgWriteScopeRequest`  10 hash (10,000,000,000 nhash)
   * `provenance.metadata.v1.MsgP8eMemorializeContractRequest` 10 hash (10,000,000,000 nhash)
 * When the `start` command encounters an error, it no longer outputs command usage [#670](https://github.com/provenance-io/provenance/issues/670)
-
+* Change max length on marker unresticted denom from 64 to 83 [#719](https://github.com/provenance-io/provenance/issues/719)
 ### Client Breaking
 
 * Enforce a maximum gas limit on individual transactions so that at least 20 can fit in any given block. [#681](https://github.com/provenance-io/provenance/issues/681)
-  Previously transactions were only limited by their size in bytes as well as the overall gas limit on a given block.  
+  Previously transactions were only limited by their size in bytes as well as the overall gas limit on a given block.
 
   _With this update transactions must be no more than 5% of the maximum amount of gas allowed per block when a gas limit
   per block is set (this restriction has no effect when a gas limit has not been set).  The current limits on Provenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
   * `provenance.metadata.v1.MsgP8eMemorializeContractRequest` 10 hash (10,000,000,000 nhash)
 * When the `start` command encounters an error, it no longer outputs command usage [#670](https://github.com/provenance-io/provenance/issues/670)
 * Change max length on marker unresticted denom from 64 to 83 [#719](https://github.com/provenance-io/provenance/issues/719)
+  
 ### Client Breaking
 
 * Enforce a maximum gas limit on individual transactions so that at least 20 can fit in any given block. [#681](https://github.com/provenance-io/provenance/issues/681)

--- a/cmd/provenanced/cmd/init.go
+++ b/cmd/provenanced/cmd/init.go
@@ -240,7 +240,7 @@ func createAndExportGenesisFile(
 		moduleName := markertypes.ModuleName
 		var markerGenState markertypes.GenesisState
 		cdc.MustUnmarshalJSON(appGenState[moduleName], &markerGenState)
-		markerGenState.Params.UnrestrictedDenomRegex = `[a-zA-Z][a-zA-Z0-9\-\.]{7,64}`
+		markerGenState.Params.UnrestrictedDenomRegex = `[a-zA-Z][a-zA-Z0-9\-\.]{7,83}`
 		appGenState[moduleName] = cdc.MustMarshalJSON(&markerGenState)
 	}
 

--- a/x/marker/spec/09_params.md
+++ b/x/marker/spec/09_params.md
@@ -9,7 +9,7 @@ Param module and available for control via Governance proposal to change paramet
 |------------------------|----------|-----------------------------------|
 | MaxTotalSupply         | `uint64` | `"259200000000000"`               |
 | EnableGovernance       | `bool`   | `true`                            |
-| UnrestrictedDenomRegex | `string` | `"[a-zA-Z][a-zA-Z0-9\-\.]{7,64}"` |
+| UnrestrictedDenomRegex | `string` | `"[a-zA-Z][a-zA-Z0-9\-\.]{7,83}"` |
 
 
 ## Definitions

--- a/x/marker/types/params.go
+++ b/x/marker/types/params.go
@@ -15,7 +15,7 @@ const (
 	// DefaultMaxTotalSupply is the upper bound to enforce on supply for markers.
 	DefaultMaxTotalSupply = uint64(100000000000)
 	// DefaultUnrestrictedDenomRegex is a regex that denoms created by normal requests must pass.
-	DefaultUnrestrictedDenomRegex = `[a-zA-Z][a-zA-Z0-9\-\.]{2,64}`
+	DefaultUnrestrictedDenomRegex = `[a-zA-Z][a-zA-Z0-9\-\.]{2,83}`
 )
 
 var (

--- a/x/marker/types/params_test.go
+++ b/x/marker/types/params_test.go
@@ -38,7 +38,7 @@ func TestParamString(t *testing.T) {
 	p := DefaultParams()
 	require.Equal(t, `maxtotalsupply: 100000000000
 enablegovernance: true
-unrestricteddenomregex: '[a-zA-Z][a-zA-Z0-9\-\.]{2,64}'
+unrestricteddenomregex: '[a-zA-Z][a-zA-Z0-9\-\.]{2,83}'
 `, p.String())
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Changes the default unrestricted denom size from 64 to 83.  This add the new size to the generated genesis file.

closes: #719 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
