### PR TITLE
Fix proto-update-deps script

### DIFF
--- a/scripts/proto-update-deps.sh
+++ b/scripts/proto-update-deps.sh
@@ -13,7 +13,7 @@ EXT_PROTO_DIR="$dir"/third_party
 #rm -rf "${EXT_PROTO_DIR:?}/"*
 
 # Retrieve versions from go.mod (single source of truth)
-CONFIO_PROTO_URL=https://raw.githubusercontent.com/confio/ics23/$(go list -m github.com/confio/ics23/go | sed 's:.* ::')/proofs.proto
+CONFIO_PROTO_URL=https://raw.githubusercontent.com/confio/ics23/go/$(go list -m github.com/confio/ics23/go | sed 's:.* ::')/proofs.proto
 GOGO_PROTO_URL=https://raw.githubusercontent.com/regen-network/protobuf/$(go list -m github.com/gogo/protobuf | sed 's:.* ::')/gogoproto/gogo.proto
 COSMOS_PROTO_URL=https://raw.githubusercontent.com/regen-network/cosmos-proto/master/cosmos.proto
 COSMWASM_TARBALL_URL=github.com/CosmWasm/wasmd/tarball/v0.17.0  # Backwards compatibility. Needed to serialize/deserialize older wasmd protos.
@@ -23,19 +23,19 @@ COSMOS_TARBALL_URL=$(go list -m github.com/cosmos/cosmos-sdk | sed 's:.* => ::' 
 TM_TARBALL_URL=$(go list -m github.com/tendermint/tendermint | sed 's:.* => ::' | sed 's/ /\/tarball\//')
 
 # Download third_party protos
-mkdir -p "$EXT_PROTO_DIR"/proto || exit $?
+mkdir -p "$EXT_PROTO_DIR"/proto
 #cp -r "$dir"/third_party/proto/google "$EXT_PROTO_DIR"/proto || exit $?
-cd "$EXT_PROTO_DIR" || exit $?
+cd "$EXT_PROTO_DIR"
 PROTO_EXPR="*/proto/**/*.proto"
-curl -sSL "$CONFIO_PROTO_URL" -o proto/proofs.proto.orig --create-dirs || exit $?
-curl -sSL "$GOGO_PROTO_URL" -o proto/gogoproto/gogo.proto --create-dirs || exit $?
-curl -sSL "$COSMOS_PROTO_URL" -o proto/cosmos_proto/cosmos.proto --create-dirs || exit $?
-curl -sSL "$COSMWASM_TARBALL_URL" | tar zx --strip-components 1 --exclude="*/third_party" "$PROTO_EXPR" || exit $?
-curl -sSL "$COSMWASM_TARBALL_URL" | tar zx --strip-components 1 --exclude="*/third_party" "$PROTO_EXPR" || exit $?
-curl -sSL "$WASMD_TARBALL_URL" | tar zx --strip-components 1 --exclude="*/third_party" --exclude="*/proto/ibc" "$PROTO_EXPR" || exit $?
-curl -sSL "$IBC_GO_TARBALL_URL" | tar zx --strip-components 1 --exclude="*/third_party" "$PROTO_EXPR" || exit $?
-curl -sSL "$COSMOS_TARBALL_URL" | tar zx --strip-components 1 --exclude="*/third_party" --exclude="*/testutil" "$PROTO_EXPR" || exit $?
-curl -sSL "$TM_TARBALL_URL" | tar zx --strip-components 1 --exclude="*/third_party" "$PROTO_EXPR" || exit $?
+curl -f -sSL "$CONFIO_PROTO_URL" -o proto/proofs.proto.orig --create-dirs
+curl -f -sSL "$GOGO_PROTO_URL" -o proto/gogoproto/gogo.proto --create-dirs
+curl -f -sSL "$COSMOS_PROTO_URL" -o proto/cosmos_proto/cosmos.proto --create-dirs
+curl -f -sSL "$COSMWASM_TARBALL_URL" | tar zx --strip-components 1 --exclude="*/third_party" "$PROTO_EXPR"
+curl -f -sSL "$COSMWASM_TARBALL_URL" | tar zx --strip-components 1 --exclude="*/third_party" "$PROTO_EXPR"
+curl -f -sSL "$WASMD_TARBALL_URL" | tar zx --strip-components 1 --exclude="*/third_party" --exclude="*/proto/ibc" "$PROTO_EXPR"
+curl -f -sSL "$IBC_GO_TARBALL_URL" | tar zx --strip-components 1 --exclude="*/third_party" "$PROTO_EXPR"
+curl -f -sSL "$COSMOS_TARBALL_URL" | tar zx --strip-components 1 --exclude="*/third_party" --exclude="*/testutil" "$PROTO_EXPR"
+curl -f -sSL "$TM_TARBALL_URL" | tar zx --strip-components 1 --exclude="*/third_party" "$PROTO_EXPR"
 
 ## insert go, java package option into proofs.proto file
 ## Issue link: https://github.com/confio/ics23/issues/32 (instead of a simple sed we need 4 lines cause bsd sed -i is incompatible)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Conf.io changed their release naming for the ics123 library which `proofs.proto` comes from [as seen here](https://github.com/confio/ics23/releases). This change breaks the `proto-update-deps` script in the `scripts/` directory.  I have updated the path in the script. 

I also noticed that the bash script was not exiting correctly on error which was resulting in the `proofs.proto` file to be overwritten with `404: File Not Found`. I have updated the curl commands to use the `-f` flag and also removed the `|| exit` conditions since the bash script is already setup with `set -e` which will fail on any non 0 exits. 


---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
