### PR TITLE
Allow authz grants to work for scope value owners.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * When the `start` command encounters an error, it no longer outputs command usage [#670](https://github.com/provenance-io/provenance/issues/670)
 * Add integration tests for smart contracts [#392](https://github.com/provenance-io/provenance/issues/392)
 * Change max length on marker unresticted denom from 64 to 83 [#719](https://github.com/provenance-io/provenance/issues/719)
+* Allow authz grants to work on scope value owners [#755](https://github.com/provenance-io/provenance/issues/755)
 
 ### Client Breaking
 

--- a/x/metadata/keeper/scope_test.go
+++ b/x/metadata/keeper/scope_test.go
@@ -3,8 +3,12 @@ package keeper_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 
 	simapp "github.com/provenance-io/provenance/app"
 	markertypes "github.com/provenance-io/provenance/x/marker/types"
@@ -15,11 +19,8 @@ import (
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/cosmos/cosmos-sdk/x/authz"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 )
 
 type ScopeKeeperTestSuite struct {
@@ -183,6 +184,14 @@ func (s *ScopeKeeperTestSuite) TestValidateScopeUpdate() {
 	scopeID := types.ScopeMetadataAddress(uuid.New())
 	scopeID2 := types.ScopeMetadataAddress(uuid.New())
 
+	// Give user 3 authority to sign for user 1 for scope updates.
+	now := s.ctx.BlockHeader().Time
+	s.Require().NotNil(now)
+	granter := s.user1Addr
+	grantee := s.user3Addr
+	a := authz.NewGenericAuthorization(types.TypeURLMsgWriteScopeRequest)
+	s.Require().NoError(s.app.AuthzKeeper.SaveGrant(s.ctx, grantee, granter, a, now.Add(time.Hour)), "authz SaveGrant user1 to user3")
+
 	cases := []struct {
 		name     string
 		existing types.Scope
@@ -323,11 +332,53 @@ func (s *ScopeKeeperTestSuite) TestValidateScopeUpdate() {
 			signers:  []string{s.user1},
 			errorMsg: fmt.Sprintf("scope specification %s not found", types.ScopeSpecMetadataAddress(s.scopeUUID)),
 		},
+		{
+			name:     "adding data access with authz grant should be successful",
+			existing: types.Scope{scopeID, scopeSpecID, ownerPartyList(s.user1), []string{}, s.user1},
+			proposed: types.Scope{scopeID, scopeSpecID, ownerPartyList(s.user1), []string{s.user2}, s.user1},
+			signers:  []string{s.user3}, // user 1 has granted scope-write to user 3
+			errorMsg: "",
+		},
+		{
+			name:     "multi owner adding data access with authz grant should be successful",
+			existing: types.Scope{scopeID, scopeSpecID, ownerPartyList(s.user1, s.user2), []string{}, s.user1},
+			proposed: types.Scope{scopeID, scopeSpecID, ownerPartyList(s.user1, s.user2), []string{s.user2}, s.user1},
+			signers:  []string{s.user2, s.user3}, // user 1 has granted scope-write to user 3
+			errorMsg: "",
+		},
+		{
+			name:     "changing value owner with authz grant should be successful",
+			existing: types.Scope{scopeID, scopeSpecID, ownerPartyList(s.user1), []string{}, s.user1},
+			proposed: types.Scope{scopeID, scopeSpecID, ownerPartyList(s.user1), []string{}, s.user2},
+			signers:  []string{s.user3}, // user 1 has granted scope-write to user 3
+			errorMsg: "",
+		},
+		{
+			name:     "changing value owner by authz granter should be successful",
+			existing: types.Scope{scopeID, scopeSpecID, ownerPartyList(s.user1), []string{}, s.user1},
+			proposed: types.Scope{scopeID, scopeSpecID, ownerPartyList(s.user1), []string{}, s.user2},
+			signers:  []string{s.user1},
+			errorMsg: "",
+		},
+		{
+			name:     "changing value owner by non-authz grantee should fail",
+			existing: types.Scope{scopeID, scopeSpecID, ownerPartyList(s.user1), []string{}, s.user1},
+			proposed: types.Scope{scopeID, scopeSpecID, ownerPartyList(s.user1), []string{}, s.user2},
+			signers:  []string{s.user2},
+			errorMsg: fmt.Sprintf("missing signature from existing value owner %s", s.user1),
+		},
+		{
+			name:     "changing value owner from non-authz granter with different signer should fail",
+			existing: types.Scope{scopeID, scopeSpecID, ownerPartyList(s.user1), []string{}, s.user2},
+			proposed: types.Scope{scopeID, scopeSpecID, ownerPartyList(s.user1), []string{}, s.user1},
+			signers:  []string{s.user3},
+			errorMsg: fmt.Sprintf("missing signature from existing value owner %s", s.user2),
+		},
 	}
 
 	for _, tc := range cases {
 		s.T().Run(tc.name, func(t *testing.T) {
-			err = s.app.MetadataKeeper.ValidateScopeUpdate(s.ctx, tc.existing, tc.proposed, tc.signers, types.TypeMsgWriteScopeRequest)
+			err = s.app.MetadataKeeper.ValidateScopeUpdate(s.ctx, tc.existing, tc.proposed, tc.signers, types.TypeURLMsgWriteScopeRequest)
 			if len(tc.errorMsg) > 0 {
 				assert.EqualError(t, err, tc.errorMsg, "ValidateScopeUpdate expected error")
 			} else {

--- a/x/metadata/keeper/scope_test.go
+++ b/x/metadata/keeper/scope_test.go
@@ -374,6 +374,13 @@ func (s *ScopeKeeperTestSuite) TestValidateScopeUpdate() {
 			signers:  []string{s.user3},
 			errorMsg: fmt.Sprintf("missing signature from existing value owner %s", s.user2),
 		},
+		{
+			name:     "setting value owner from nothing to non-owner only signed by non-owner should fail",
+			existing: types.Scope{scopeID, scopeSpecID, ownerPartyList(s.user1), []string{}, ""},
+			proposed: types.Scope{scopeID, scopeSpecID, ownerPartyList(s.user1), []string{}, s.user2},
+			signers:  []string{s.user2},
+			errorMsg: fmt.Sprintf("missing signature from [%s (PARTY_TYPE_OWNER)]", s.user1),
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Description

Allow authz grants to work for non-marker scope value owners.

closes: #755

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
