### PR TITLE
Update Cosmos SDK to v0.45.3-pio-2 for 11707 bugfix

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -96,7 +96,6 @@ var handlers = map[string]appUpgrade{
 		}, // upgrade for pio-testnet-1 from v1.8.0-rc8 to v1.8.0-rc9
 	},
 	"kahlua": {}, // upgrade for pio-testnet-1 from v1.8.0-rc9 to v1.8.0
-	"v1.0.0": {}, // required to bypass SDK issue.
 	// TODO - Add new upgrade definitions here.
 }
 

--- a/go.mod
+++ b/go.mod
@@ -129,7 +129,7 @@ replace google.golang.org/grpc => google.golang.org/grpc v1.33.2
 
 replace github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
-replace github.com/cosmos/cosmos-sdk => github.com/provenance-io/cosmos-sdk v0.45.3-pio
+replace github.com/cosmos/cosmos-sdk => github.com/provenance-io/cosmos-sdk v0.45.3-pio-2
 
 replace github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
 

--- a/go.sum
+++ b/go.sum
@@ -835,8 +835,8 @@ github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.6.2-0.20190402121629-4f204dcbc150/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/provenance-io/cosmos-sdk v0.45.3-pio h1:jNhiPrdPEtyuSsxV3dV5oKHuvgUD9HV2DQHts/6XviI=
-github.com/provenance-io/cosmos-sdk v0.45.3-pio/go.mod h1:PjsF1aATbY6endgLbdNswiOfwoLvrNNZzdJ37kzrNbw=
+github.com/provenance-io/cosmos-sdk v0.45.3-pio-2 h1:qLdEQtwLFfHwAwL0505gkBlJ/fO/i2jXG9qQ7EZeHQw=
+github.com/provenance-io/cosmos-sdk v0.45.3-pio-2/go.mod h1:PjsF1aATbY6endgLbdNswiOfwoLvrNNZzdJ37kzrNbw=
 github.com/provenance-io/wasmd v0.22.0-pio-address-fix h1:oMgJkRT3nq1l58VcP56G39fLsKSQ1Nq44D9fafbdIh4=
 github.com/provenance-io/wasmd v0.22.0-pio-address-fix/go.mod h1:kNDnMAQDJyVek9k6SxCNijMCzOROzzUGBRT8r/vr7oY=
 github.com/rakyll/statik v0.1.7 h1:OF3QCZUuyPxuGEP7B4ypUa7sB/iHtqOTDYZXGM8KOdQ=


### PR DESCRIPTION
## Description

Update Cosmos SDK (0.45.3-pio-2) to fix bug with detecting last upgrade. Also removed unused upgrade handler originally added to bypass panic caused by bug.

Addresses [#11707](https://github.com/cosmos/cosmos-sdk/issues/11707)

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
