### PR TITLE
Create Mango rc2 handler.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 * Add new `msgfees` `NhashPerUsdMil`  default param to param space store on upgrade (PR [#875](https://github.com/provenance-io/provenance/issues/875))
-* Add `mango-2` upgrade handler to do a couple migration pieces that were missed in v1.11.1-rc1, but needed [PR 888](https://github.com/provenance-io/provenance/pull/888).
+* Add `mango-rc2` upgrade handler to do a couple migration pieces that were missed in v1.11.1-rc1, but needed [PR 888](https://github.com/provenance-io/provenance/pull/888).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 * Add new `msgfees` `NhashPerUsdMil`  default param to param space store on upgrade (PR [#875](https://github.com/provenance-io/provenance/issues/875))
-* Add `mango-2` upgrade handler to do a couple migration pieces that were missed [PR 888](https://github.com/provenance-io/provenance/pull/888).
+* Add `mango-2` upgrade handler to do a couple migration pieces that were missed in v1.11.1-rc1, but needed [PR 888](https://github.com/provenance-io/provenance/pull/888).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 * Add new `msgfees` `NhashPerUsdMil`  default param to param space store on upgrade (PR [#875](https://github.com/provenance-io/provenance/issues/875))
+* Add `mango-2` upgrade handler to do a couple migration pieces that were missed [PR 888](https://github.com/provenance-io/provenance/pull/888).
 
 ---
 

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -27,15 +27,17 @@ type appUpgrade struct {
 }
 
 var handlers = map[string]appUpgrade{
-	"lava": {}, // upgrade for 1.10.0
-	"mango": {
+	"lava":  {}, // upgrade for 1.10.0
+	"mango": {}, // upgrade for 1.11.1-rc1
+	"mango-rc2": {
 		Handler: func(app *App, ctx sdk.Context, plan upgradetypes.Plan) (module.VersionMap, error) {
 			params := app.MsgFeesKeeper.GetParams(ctx)
 			app.MsgFeesKeeper.SetParams(ctx, params)
 			versionMap := app.UpgradeKeeper.GetModuleVersionMap(ctx)
 			return versionMap, nil
 		},
-	}, // upgrade for 1.11.x
+	}, // upgrade for 1.11.1-rc2
+
 	// TODO - Add new upgrade definitions here.
 }
 

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -27,8 +27,15 @@ type appUpgrade struct {
 }
 
 var handlers = map[string]appUpgrade{
-	"lava":  {}, // upgrade for 1.10.0
-	"mango": {}, // upgrade for 1.11.1-rc1
+	"lava": {}, // upgrade for 1.10.0
+	"mango": {
+		Handler: func(app *App, ctx sdk.Context, plan upgradetypes.Plan) (module.VersionMap, error) {
+			params := app.MsgFeesKeeper.GetParams(ctx)
+			app.MsgFeesKeeper.SetParams(ctx, params)
+			versionMap := app.UpgradeKeeper.GetModuleVersionMap(ctx)
+			return versionMap, nil
+		},
+	}, // upgrade for 1.11.x
 	"mango-rc2": {
 		Handler: func(app *App, ctx sdk.Context, plan upgradetypes.Plan) (module.VersionMap, error) {
 			params := app.MsgFeesKeeper.GetParams(ctx)


### PR DESCRIPTION
## Description

Create a `mango-rc2` upgrade handler and make create an empty `mango` upgrade.
Version 1.11.1-rc1 shipped with an empty `mango` upgrade, but there's a migration in the bank module that's needed as well as setting the default conversion rate. So we need a `mango-rc2` to do that so that it can be applied just to testnet. But the mainnet upgrade can still be just `mango` because it's got the code too.

This isn't needed in the `main` branch because the `mango` handler there is sufficient. We only need this `mango-rc2` one here because `mango` shipped to testnet with `v1.11.1-rc1` but it was empty.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
