### PR TITLE
Limit the running of the rosetta github workflow test

### DIFF
--- a/.github/workflows/rosetta.yml
+++ b/.github/workflows/rosetta.yml
@@ -12,8 +12,17 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
+      - uses: technote-space/get-diff-action@v6.1.0
+        with:
+          PATTERNS: |
+            **/**.go
+            go.mod
+            go.sum
+            .github/workflows/rosetta.yml
       - name: Go mod vendor
+        if: ${{ env.GIT_DIFF }}
         run: |
           go mod vendor
       - name: rosetta
+        if: ${{ env.GIT_DIFF }}
         run: make test-rosetta


### PR DESCRIPTION
## Description

The Rosetta workflow is required to pass before a PR can be merged. But in some cases, there's nothing changing that might alter the outcome. So, similar to when we skip the unit tests, also skip the rosetta test.

Since it's a required step, the workflow can't be skipped completely; we still need a success from it. But if there aren't any code changes, skip the actual test part.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
