### PR TITLE
Updated Makefile to check for M1 dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ all: build format lint test
 install: go.sum
 	CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" $(GO) install $(BUILD_FLAGS) ./cmd/provenanced
 
-build: validate-go-version go.sum
+build: validate-m1-dependencies validate-go-version go.sum
 	mkdir -p $(BUILDDIR)
 	CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" $(GO) build -o $(BUILDDIR)/ $(BUILD_FLAGS) ./cmd/provenanced
 
@@ -386,6 +386,12 @@ validate-go-version: ## Validates the installed version of go against Provenance
 	elif [ $(GO_MINOR_VERSION) -lt $(MINIMUM_SUPPORTED_GO_MINOR_VERSION) ] ; then \
 		echo '$(GO_VERSION_VALIDATION_ERR_MSG)';\
 		exit 1; \
+	fi
+
+validate-m1-dependencies: ## Validates all the dependencies by M1 are installed or setup
+	@if [[ $(UNAME_S) == darwin && $(UNAME_M) == arm64 ]]; then \
+		output=$$(scripts/m1-dependency-check.sh); \
+		if [[ $$? == 1 ]]; then echo "\x1B[31m>> Build halted\x1B[39m"; echo "\x1B[31m>> $$output\x1B[39m"; exit 1; fi; \
 	fi
 
 download-smart-contracts:

--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ all: build format lint test
 install: go.sum
 	CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" $(GO) install $(BUILD_FLAGS) ./cmd/provenanced
 
-build: validate-m1-dependencies validate-go-version go.sum
+build: validate-os-dependencies validate-go-version go.sum
 	mkdir -p $(BUILDDIR)
 	CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" $(GO) build -o $(BUILDDIR)/ $(BUILD_FLAGS) ./cmd/provenanced
 
@@ -388,7 +388,7 @@ validate-go-version: ## Validates the installed version of go against Provenance
 		exit 1; \
 	fi
 
-validate-m1-dependencies: ## Validates all the dependencies by M1 are installed or setup
+validate-os-dependencies: ## Validates all the dependencies needed by a specific os
 	@if [[ $(UNAME_S) == darwin && $(UNAME_M) == arm64 ]]; then \
 		output=$$(scripts/m1-dependency-check.sh); \
 		if [[ $$? == 1 ]]; then echo "\x1B[31m>> Build halted\x1B[39m"; echo "\x1B[31m>> $$output\x1B[39m"; exit 1; fi; \

--- a/scripts/m1-dependency-check.sh
+++ b/scripts/m1-dependency-check.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Install dependency with brew
+# Requires the name of the package to install
+has_dependency() {
+    if brew list $1 &>/dev/null; then
+        return 1
+    else
+        return 0
+    fi
+}
+
+# Ensure homebrew is installed
+if [[ $(command -v brew) == "" ]]; then
+    echo "This script requires Homebrew. Please install and run again..."
+    exit 1
+fi
+
+# Check dependencies
+kafka_dependencies=( librdkafka openssl pkg-config )
+for dependency in "${kafka_dependencies[@]}"
+do
+    has_dependency $dependency
+    status=$?
+    if [[ $status == 0 ]]; then
+        echo "Missing $dependency. Recommened to run: make librdkafka"
+        exit 1
+    fi
+done
+
+# Check that PKG_CONFIG_PATH is set
+case ":$PKG_CONFIG_PATH:" in
+  *:"$( brew --prefix openssl )/lib/pkgconfig":*) : ;;
+  *) echo "PKG_CONFIG_PATH is missing openssl. Recommended to run: export PKG_CONFIG_PATH=\"\$( brew --prefix openssl )\"/lib/pkgconfig\"\${PKG_CONFIG_PATH:+:\$PKG_CONFIG_PATH}\""; exit 1;
+esac
+exit 0


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

The build command for Makefile has been updated to validate dependencies for all os before building. The only logic we currently have is to check for librdkafka dependencies. If not all the dependencies are met then the build will be halted and an action will be recommended to the user.

Example output when missing PKG_CONFIG_PATH:
>> Build halted
>> PKG_CONFIG_PATH is missing openssl. Recommended to run: export PKG_CONFIG_PATH="$( brew --prefix openssl )"/lib/pkgconfig"${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
make: *** [validate-os-dependencies] Error 1

Example output when missing librdkafka:
>> Build halted
>> Missing librdkafka. Recommened to run: make librdkafka

Example output when missing openssl
>> Build halted
>> Missing openssl. Recommened to run: make librdkafka

Example output when missing pkg-config
>> Build halted
>> Missing pkg-config. Recommened to run: make librdkafka

closes: #884

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
