### PR TITLE
Disable mac binary notarization.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,25 +77,9 @@ jobs:
           go-version: ${{ needs.build_init.outputs.go_version }}
       - name: Build osx binary
         run: |
-          make WITH_CLEVELDB=false WITH_ROCKSDB=false VERSION=${{ needs.build_init.outputs.version }} build-release-bin build-release-libwasm
+          make WITH_CLEVELDB=false WITH_ROCKSDB=false VERSION=${{ needs.build_init.outputs.version }} build-release-zip
       - name: Provenanced version
         run: build/provenanced version --long
-      - name: Import Code-Signing Certificates
-        uses: Apple-Actions/import-codesign-certs@v1
-        with:
-          p12-file-base64: ${{ secrets.CODESIGNING_P12_BASE64 }}
-          p12-password: ${{ secrets.CODESIGNING_P12_PASSWORD }}
-      - name: Sign the mac binaries with Gon
-        # TODO: Remove this if line before final release. This is just a temporary workaround because notorization is failing auth.
-        if: true == false
-        env:
-          AC_USERNAME: ${{ secrets.AC_USERNAME }}
-          AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
-        run: |
-          gon -log-level=info -log-json ./gon.json
-      - name: Fix zip structure for cosmovisor
-        run: |
-          make VERSION=${{ needs.build_init.outputs.version }} build-release-rezip
       - uses: actions/upload-artifact@v3
         with:
           name: osx-zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,8 @@ jobs:
           p12-file-base64: ${{ secrets.CODESIGNING_P12_BASE64 }}
           p12-password: ${{ secrets.CODESIGNING_P12_PASSWORD }}
       - name: Sign the mac binaries with Gon
+        # TODO: Remove this if line before final release. This is just a temporary workaround because notorization is failing auth.
+        if: true == false
         env:
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}


### PR DESCRIPTION
## Description

Sometime between Thursday June 23 and This morning (Monday June 27), the mac notarization step stopped working. This PR disables that step so we can get this RC out and tested.

This is one of the very rare cases where merging into the release branch is appropriate. We hope to have the root cause of the failure ironed out by the time the actual release happens. By merging it into this the `release/v1.11.1-rc4` branch, we don't have to worry about undoing it in the `.x` branch before release. However, it's a change that might need to be applied to any other RC branches, but I'm hopeful this will be our last RC for this branch.


---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
