### PR TITLE
Bump Cosmos-SDK to v0.45.4-pio-2 (from v0.45.4-pio-1) (release/v1.11.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+### Bug Fixes
+
+* Update Cosmos-SDK to v0.45.4-pio-2 to fix a non-deterministic map iteration
+
+---
+
 ## [v1.11.1-rc4](https://github.com/provenance-io/provenance/releases/tag/v1.11.1-rc4) - 2022-06-23
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
-* Update Cosmos-SDK to v0.45.4-pio-2 to fix a non-deterministic map iteration
+* Update Cosmos-SDK to v0.45.4-pio-2 to fix a non-deterministic map iteration [PR 928](https://github.com/provenance-io/provenance/pull/928)
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ replace google.golang.org/grpc => google.golang.org/grpc v1.33.2
 
 replace github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
-replace github.com/cosmos/cosmos-sdk => github.com/provenance-io/cosmos-sdk v0.45.4-pio-1
+replace github.com/cosmos/cosmos-sdk => github.com/provenance-io/cosmos-sdk v0.45.4-pio-2
 
 replace github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
 

--- a/go.sum
+++ b/go.sum
@@ -977,8 +977,8 @@ github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.6.2-0.20190402121629-4f204dcbc150/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/provenance-io/cosmos-sdk v0.45.4-pio-1 h1:f8ztQYjSfTzRa66lbwMimPYcotGy+1LOJWZeQvEjYiQ=
-github.com/provenance-io/cosmos-sdk v0.45.4-pio-1/go.mod h1:ZeOVyLFgW6jdzLcLak2mYso+tNIpRQXot7D4ZNyG4Zg=
+github.com/provenance-io/cosmos-sdk v0.45.4-pio-2 h1:D10PXjpo4pKWvmAm1biBYxQ8GSES2ruECFWHD+XTIHE=
+github.com/provenance-io/cosmos-sdk v0.45.4-pio-2/go.mod h1:ZeOVyLFgW6jdzLcLak2mYso+tNIpRQXot7D4ZNyG4Zg=
 github.com/rakyll/statik v0.1.7 h1:OF3QCZUuyPxuGEP7B4ypUa7sB/iHtqOTDYZXGM8KOdQ=
 github.com/rakyll/statik v0.1.7/go.mod h1:AlZONWzMtEnMs7W4e/1LURLiI49pIMmp6V9Unghqrcc=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=


### PR DESCRIPTION
## Description

Bump Cosmos-SDK to v0.45.4-pio-2 (from v0.45.4-pio-1) to fix a non-deterministic map iteration.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
