### PR TITLE
Merge release/v1.11.x back into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,20 +40,18 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Improvements
 
 * Update the swagger files (including third-party changes). [#728](https://github.com/provenance-io/provenance/issues/728)
-
-### Bug Fixes
-
-* Add new `msgfees` `NhashPerUsdMil`  default param to param space store on upgrade PR [#875](https://github.com/provenance-io/provenance/issues/875)
-* Update Cosmos-SDK to v0.45.4-pio-2 to fix a non-deterministic map iteration [PR 929](https://github.com/provenance-io/provenance/pull/929)
-* Run the module migrations as part of the mango upgrade [PR 896](https://github.com/provenance-io/provenance/pull/896)
+* Bump IBC to 2.3.0 and update third-party protos [PR 868](https://github.com/provenance-io/provenance/pull/868)
 
 ---
 
-## [v1.11.1-rc1](https://github.com/provenance-io/provenance/releases/tag/v1.11.1-rc1) - 2022-06-14
+## [v1.11.1](https://github.com/provenance-io/provenance/releases/tag/v1.11.1) - 2022-07-13
 
 ### Bug Fixes
 
 * Add `mango` upgrade handler.
+* Add new `msgfees` `NhashPerUsdMil`  default param to param space store on upgrade (PR [#875](https://github.com/provenance-io/provenance/issues/875))
+* Run the module migrations as part of the mango upgrade [PR 896](https://github.com/provenance-io/provenance/pull/896)
+* Update Cosmos-SDK to v0.45.4-pio-2 to fix a non-deterministic map iteration [PR 928](https://github.com/provenance-io/provenance/pull/928)
 
 ---
 


### PR DESCRIPTION
## Description

Pull in all changes in the `release/v1.11.x` branch (just after creating release `v1.11.1`) back into `main`.

The only thing there is the changelog!

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
