### PR TITLE
Update codeowners to use the blockchain-core group.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,6 @@
 # most precedence.
 
 # Primary repo maintainers
-*       @provenance-io/blockchain-core
+*       @provenance-io/blockchain-core @channa-figure @egaxhaj-figure
 
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,6 @@
 # most precedence.
 
 # Primary repo maintainers
-*       @provenance-io/blockchain-core @channa-figure
+*       @provenance-io/blockchain-core
 
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,13 +1,9 @@
 # CODEOWNERS: https://help.github.com/articles/about-codeowners/
 
-# NOTE: Order is important; the last matching pattern takes the 
+# NOTE: Order is important; the last matching pattern takes the
 # most precedence.
 
-# Secondary repo maintainers, substitutes of the primary
-# maintainers when they become MIA
-*       @mtps @jdfigure
-
 # Primary repo maintainers
-*       @iramiller @channa-figure @nullpointer0x00 @dwedul-figure @arnabmitra @derekadams @egaxhaj-figure @egaxhaj @taztingo
+*       @provenance-io/blockchain-core
 
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,6 @@
 # most precedence.
 
 # Primary repo maintainers
-*       @provenance-io/blockchain-core @channa-figure @egaxhaj-figure
+*       @provenance-io/blockchain-core @channa-figure
 
 


### PR DESCRIPTION
## Description

Update the codeowners file to use the `@provenance-io/blockchain-core` group. The `@egaxhaj-figure` entry is not part of the group, and is being removed because it's no longer needed. The `@channa-figure` entry is not yet part of the group, but will be added to the group.

This will add the following users as codeowners: `@SpicyLemon` (me), `@jazzy-figure`, `@ktally-figure`.

It also removes the "secondary" entry containing `@mtps`, and `@jdfigure`. The `*` at the start of those lines is a glob for file matching. The last match is the one that gets used. So that line would only ever get used if the primary entry below it were completely removed.

Here's a link to the group members: https://github.com/orgs/provenance-io/teams/blockchain-core/members

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
