### PR TITLE
update docker images from buster to bullseye

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * Update the swagger files (including third-party changes). [#728](https://github.com/provenance-io/provenance/issues/728)
 * Bump IBC to 2.3.0 and update third-party protos [PR 868](https://github.com/provenance-io/provenance/pull/868)
+* Update docker images from `buster` to b`bullseye` [#963](https://github.com/provenance-io/provenance/issues/963)
 
 ### Bug Fixes
 

--- a/client/rosetta/rosetta-ci/Dockerfile
+++ b/client/rosetta/rosetta-ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-buster as build
+FROM golang:1.17-bullseye as build
 ARG VERSION
 
 WORKDIR /go/src/github.com/provenance-io/provenance
@@ -27,7 +27,7 @@ WORKDIR /testrosetta
 RUN provenanced testnet -t --v 1 -o . --starting-ip-address=0.0.0.0 --keyring-backend=test --chain-id=chain-local
 
 ###
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 ENV LOCALNET=1
 
 RUN apt-get update && \

--- a/docker/blockchain/Dockerfile
+++ b/docker/blockchain/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-buster as build
+FROM golang:1.17-bullseye as build
 ARG VERSION
 
 WORKDIR /go/src/github.com/provenance-io/provenance
@@ -26,7 +26,7 @@ ENV VERSION=$VERSION
 RUN make VERSION=${VERSION} install
 
 ###
-FROM debian:buster-slim as run
+FROM debian:bullseye-slim as run
 
 RUN apt-get update && \
     apt-get upgrade -y && \

--- a/networks/dev/blockchain-dev/Dockerfile
+++ b/networks/dev/blockchain-dev/Dockerfile
@@ -1,7 +1,7 @@
 # This docker file builds a test image using binaries built locally.
 # Use `make docker-build-local` to build or `make localnet-start` to
 # start the test network and `make localnet-stop` to stop it.
-FROM golang:1.17-buster as build
+FROM golang:1.17-bullseye as build
 WORKDIR /go/src/github.com/provenance-io/provenance
 ENV GOPRIVATE=github.com/provenance-io
 RUN apt-get update && apt-get upgrade -y && apt-get install -y libleveldb-dev
@@ -21,7 +21,7 @@ RUN go build -mod vendor \
     -o /go/bin/ ./cmd/...
 
 ###
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 ENV LOCALNET=1
 
 RUN apt-get update && \

--- a/networks/local/blockchain-local/Dockerfile
+++ b/networks/local/blockchain-local/Dockerfile
@@ -3,7 +3,7 @@
 # start the test network and `make localnet-stop` to stop it.
 
 ## Build provenance for x86_64
-FROM golang:1.17-buster as build-x86_64
+FROM golang:1.17-bullseye as build-x86_64
 WORKDIR /go/src/github.com/provenance-io/provenance
 ENV GOPRIVATE=github.com/provenance-io
 RUN apt-get update && apt-get upgrade -y && apt-get install -y libleveldb-dev
@@ -20,7 +20,7 @@ COPY vendor/ ./vendor/
 RUN go build -mod vendor -tags=cleveldb -ldflags '-w -s -X github.com/cosmos/cosmos-sdk/version.Name=Provenance-Blockchain' -o /go/bin/ ./cmd/...
 
 ## Run provenance for x86_64
-FROM debian:buster-slim as provenance-x86_64
+FROM debian:bullseye-slim as provenance-x86_64
 ENV LOCALNET=1
 ENV LD_LIBRARY_PATH="/usr/local/lib"
 
@@ -52,7 +52,7 @@ CMD ["start"]
 
 
 ## Build provenance for ARM
-FROM golang:1.17-buster as build-arm64
+FROM golang:1.17-bullseye as build-arm64
 WORKDIR /go/src/github.com/provenance-io/provenance
 ENV GOPRIVATE=github.com/provenance-io
 RUN apt-get update && apt-get upgrade -y && apt-get install -y libleveldb-dev
@@ -72,7 +72,7 @@ RUN git clone --depth 1 --branch v1.8.2 https://github.com/edenhill/librdkafka.g
 RUN go build -mod vendor -tags=cleveldb,dynamic -ldflags '-w -s -X github.com/cosmos/cosmos-sdk/version.Name=Provenance-Blockchain' -o /go/bin/ ./cmd/...
 
 ## Run provenance for ARM
-FROM debian:buster-slim as provenance-arm64
+FROM debian:bullseye-slim as provenance-arm64
 ENV LOCALNET=1
 ENV LD_LIBRARY_PATH="/usr/local/lib"
 # This is for M1 to find package config


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Currently the "buster" image is in use in many docker files, this needs to be replaced with "bullseye" as the current security updates for "buster" end July 2022.

closes: #963 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
