### PR TITLE
Fix gov proposal end-of-voting-period consensus failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 * Remove the workaround for the index-events configuration field (now fixed in the SDK). [#995](https://github.com/provenance-io/provenance/issues/995)
+* Fix consensus failure at the end of gov voting periods. [#1099](https://github.com/provenance-io/provenance/issues/1099)
 
 ### Client Breaking
 

--- a/app/app.go
+++ b/app/app.go
@@ -863,11 +863,21 @@ func (app *App) Name() string { return app.BaseApp.Name() }
 
 // BeginBlocker application updates every begin block
 func (app *App) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) abci.ResponseBeginBlock {
+	// Make sure the gas meter is a fee gas meter.
+	// https://github.com/provenance-io/provenance/issues/1099
+	if _, err := antewrapper.GetFeeGasMeter(ctx); err != nil {
+		ctx = ctx.WithGasMeter(antewrapper.NewFeeGasMeterWrapper(ctx.Logger(), ctx.GasMeter(), false))
+	}
 	return app.mm.BeginBlock(ctx, req)
 }
 
 // EndBlocker application updates every end block
 func (app *App) EndBlocker(ctx sdk.Context, req abci.RequestEndBlock) abci.ResponseEndBlock {
+	// Make sure the gas meter is a fee gas meter.
+	// https://github.com/provenance-io/provenance/issues/1099
+	if _, err := antewrapper.GetFeeGasMeter(ctx); err != nil {
+		ctx = ctx.WithGasMeter(antewrapper.NewFeeGasMeterWrapper(ctx.Logger(), ctx.GasMeter(), false))
+	}
 	return app.mm.EndBlock(ctx, req)
 }
 

--- a/internal/antewrapper/fee_gas_meter.go
+++ b/internal/antewrapper/fee_gas_meter.go
@@ -49,6 +49,13 @@ func NewFeeGasMeterWrapper(logger log.Logger, baseMeter sdkgas.GasMeter, isSimul
 	}
 }
 
+// WithSimulate returns this FeeGasMeter with the provided simulate flag value.
+// Note: It does not change the simulate flag of this.
+func (g FeeGasMeter) WithSimulate(isSimulate bool) sdkgas.GasMeter {
+	g.simulate = isSimulate
+	return &g
+}
+
 var _ sdkgas.GasMeter = &FeeGasMeter{}
 
 // GasConsumed reports the amount of gas consumed at Log.Info level


### PR DESCRIPTION
## Description

In the begin and end blockers, wrap the gas meter as a fee gas meter if it isn't already a fee gas meter.

In the new gov stuff, when voting ends on a gov proposal, the end block triggers handles the sending of successfully voted-on proposals, and does so through the message service router. Our custom message service router expects the gas meter to be a fee gas meter though. So, in order for the new gov stuff to have the right gas meter, it needs to be wrapped in our end block so that it's wrapped in the gov module's end block which can then call our message service router without blowing up.

closes: #1099

Note: I put together this PR without any integration tests on it because writing such an integration test is going to take quite a bit longer. I am working on it though.

I did test this by `make clean build run-config && ./scripts/upgrade-config.sh && make run`, then in another window, I ran the script from #1097 with the color "brown". Before this PR, the chain halted at the end of the voting period (with the not-a-fee-gas-meter error). After this PR, it got past the end of the voting period and instead (expectedly) halted at the upgrade height.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
