### PR TITLE
Fix gov proposal end-of-voting-period consensus failure.

### DIFF
--- a/internal/antewrapper/ante.go
+++ b/internal/antewrapper/ante.go
@@ -30,7 +30,7 @@ func (r FeeMeterContextDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulat
 func GetFeeTx(tx sdk.Tx) (sdk.FeeTx, error) {
 	feeTx, ok := tx.(sdk.FeeTx)
 	if !ok {
-		return nil, sdkerrors.ErrTxDecode.Wrap("Tx must be a FeeTx")
+		return nil, sdkerrors.ErrTxDecode.Wrapf("Tx must be a FeeTx: %T", tx)
 	}
 	return feeTx, nil
 }
@@ -39,7 +39,7 @@ func GetFeeTx(tx sdk.Tx) (sdk.FeeTx, error) {
 func GetFeeGasMeter(ctx sdk.Context) (*FeeGasMeter, error) {
 	feeGasMeter, ok := ctx.GasMeter().(*FeeGasMeter)
 	if !ok {
-		return nil, sdkerrors.ErrLogic.Wrap("gas meter is not a FeeGasMeter")
+		return nil, sdkerrors.ErrLogic.Wrapf("gas meter is not a FeeGasMeter: %T", ctx.GasMeter())
 	}
 	return feeGasMeter, nil
 }

--- a/internal/handlers/msg_service_router.go
+++ b/internal/handlers/msg_service_router.go
@@ -165,7 +165,11 @@ func noopInterceptor(_ context.Context, _ interface{}, _ *grpc.UnaryServerInfo, 
 func (msr *PioMsgServiceRouter) consumeMsgFees(ctx sdk.Context, req sdk.Msg) error {
 	feeGasMeter, err := antewrapper.GetFeeGasMeter(ctx)
 	if err != nil {
-		panic(err)
+		// The x/gov module calls the message service router for proposal messages that have passed.
+		// In such cases, the antehandler is not run, so the gas meter will not be a fee gas meter.
+		// But those messages were voted on and have passed, so they should be processed regardless of msg fees.
+		// So in here, if there's an error getting the fee gas meter, we skip all this msg fee consumption.
+		return nil
 	}
 
 	tx, err := msr.decoder(ctx.TxBytes())


### PR DESCRIPTION
## Description

closes: #1099

This fix bypasses the `consumeMsgFees` stuff in the message service router when the gas meter isn't a fee gas meter. Basically, before this PR, an error was returned in that case, which turned into a panic. After this PR, nil is returned in that case (and no attempts are made to consume any message-based fees).

Similar to #1102, no unit test for it, but I tested this in the same way (`make clean build run-config && ./scripts/upgrade-config.sh && make run` then use the script from #1097). Again, it now makes it to the upgrade height and (expectedly) halts for the upgrade.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
