### PR TITLE
Update fee event to contain total charge and emit send coin events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,11 +54,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
   * Refactored the `ProvenanceDeductFeeDecorator`. It now makes sure the payer has enough in their account to cover the additional fees. It also now deducts/consumes the `floor gas price * gas`.
   * Added the `fee_payer` attribute to events of type `tx` involving fees (i.e. the ones with attributes `fee`, `min_fee_charged`, `additionalfee` and/or `baseFee`).
   * Moved the additional fees calculation logic into the msgfees keeper.
-<<<<<<< HEAD
-  * Update `fee` event with amount charged even on failure and emit SendCoin events from `DeductFeesDistributions` [#1092](https://github.com/provenance-io/provenance/issues/1092)
-=======
+* Update `fee` event with amount charged even on failure and emit SendCoin events from `DeductFeesDistributions` [#1092](https://github.com/provenance-io/provenance/issues/1092)
 * Bump IBC to `5.0.0-pio-1` (from `v2.3.0`) to add a check for SendEnabled [#1100](https://github.com/provenance-io/provenance/issues/1100)
->>>>>>> main
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
   * Refactored the `ProvenanceDeductFeeDecorator`. It now makes sure the payer has enough in their account to cover the additional fees. It also now deducts/consumes the `floor gas price * gas`.
   * Added the `fee_payer` attribute to events of type `tx` involving fees (i.e. the ones with attributes `fee`, `min_fee_charged`, `additionalfee` and/or `baseFee`).
   * Moved the additional fees calculation logic into the msgfees keeper.
+  * Update `fee` event with amount charged even on failure and emit SendCoin events from `DeductFeesDistributions` [#1092](https://github.com/provenance-io/provenance/issues/1092)
 
 ### Bug Fixes
 

--- a/app/app.go
+++ b/app/app.go
@@ -813,6 +813,7 @@ func New(
 	app.SetEndBlocker(app.EndBlocker)
 
 	app.SetAggregateEventsFunc(piohandlers.AggregateEvents)
+
 	// Add upgrade plans for each release. This must be done before the baseapp seals via LoadLatestVersion() down below.
 	InstallCustomUpgradeHandlers(app)
 

--- a/app/app.go
+++ b/app/app.go
@@ -812,6 +812,7 @@ func New(
 
 	app.SetEndBlocker(app.EndBlocker)
 
+	app.SetAggregateEventsFunc(piohandlers.AggregateEvents)
 	// Add upgrade plans for each release. This must be done before the baseapp seals via LoadLatestVersion() down below.
 	InstallCustomUpgradeHandlers(app)
 

--- a/go.mod
+++ b/go.mod
@@ -157,7 +157,7 @@ require (
 
 replace github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
-replace github.com/cosmos/cosmos-sdk => github.com/provenance-io/cosmos-sdk v0.46.1-pio-1-rc1
+replace github.com/cosmos/cosmos-sdk => github.com/provenance-io/cosmos-sdk v0.46.1-poi-events-1
 
 replace github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
 

--- a/go.sum
+++ b/go.sum
@@ -842,8 +842,8 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/provenance-io/cosmos-sdk v0.46.1-pio-1-rc1 h1:9Wza2hHp/qYiqk3pIc/YkN0mDvpzz1zv6n4Ohlwr8BM=
-github.com/provenance-io/cosmos-sdk v0.46.1-pio-1-rc1/go.mod h1:2+o8Qw8qnE02V+lQVZDJFQ8tri/hsiA5GmWaPERqVa0=
+github.com/provenance-io/cosmos-sdk v0.46.1-poi-events-1 h1:R9xgpxVquEIpOAylCijatrP9J15QsYNbZhlSy5edMBs=
+github.com/provenance-io/cosmos-sdk v0.46.1-poi-events-1/go.mod h1:2+o8Qw8qnE02V+lQVZDJFQ8tri/hsiA5GmWaPERqVa0=
 github.com/provenance-io/wasmd v0.28.0-pio-1-rc1 h1:DERjP29HvGFNcKoS/papiZXeLfblLXMwCSouwpKWIkk=
 github.com/provenance-io/wasmd v0.28.0-pio-1-rc1/go.mod h1:5AaHfNWcEjNB61PRwm6bL093ocTVlJrDvOrkQKw3/YI=
 github.com/rakyll/statik v0.1.7 h1:OF3QCZUuyPxuGEP7B4ypUa7sB/iHtqOTDYZXGM8KOdQ=

--- a/internal/antewrapper/provenance_fee.go
+++ b/internal/antewrapper/provenance_fee.go
@@ -134,9 +134,10 @@ func (dfd ProvenanceDeductFeeDecorator) checkDeductBaseFee(ctx sdk.Context, feeT
 		feeGasMeter.ConsumeBaseFee(baseFeeToConsume)
 	}
 
+	feeEventValue := feeTx.GetFee().String()
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(sdk.EventTypeTx,
-			sdk.NewAttribute(sdk.AttributeKeyFee, feeTx.GetFee().String()),
+			sdk.NewAttribute(sdk.AttributeKeyFee, feeEventValue),
 			sdk.NewAttribute(sdk.AttributeKeyFeePayer, deductFeesFrom.String()),
 		),
 		sdk.NewEvent(sdk.EventTypeTx,

--- a/internal/antewrapper/provenance_fee.go
+++ b/internal/antewrapper/provenance_fee.go
@@ -134,10 +134,9 @@ func (dfd ProvenanceDeductFeeDecorator) checkDeductBaseFee(ctx sdk.Context, feeT
 		feeGasMeter.ConsumeBaseFee(baseFeeToConsume)
 	}
 
-	feeEventValue := feeTx.GetFee().String()
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(sdk.EventTypeTx,
-			sdk.NewAttribute(sdk.AttributeKeyFee, feeEventValue),
+			sdk.NewAttribute(sdk.AttributeKeyFee, feeTx.GetFee().String()),
 			sdk.NewAttribute(sdk.AttributeKeyFeePayer, deductFeesFrom.String()),
 		),
 		sdk.NewEvent(sdk.EventTypeTx,

--- a/internal/handlers/aggregate_events.go
+++ b/internal/handlers/aggregate_events.go
@@ -1,0 +1,40 @@
+package handlers
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+// AggregateEvents is called in the baseapp after a transaction has completed
+// This is used to modify the events that are emitted for a transaction.
+// anteEvents will be populated on failure and success
+// resultEvents will only be populated on success
+func AggregateEvents(anteEvents []abci.Event, resultEvents []abci.Event) ([]abci.Event, []abci.Event, error) {
+	if len(resultEvents) == 0 { // tx failed...fix fee event to have the exact fee charged
+		var err error
+		var txFee sdk.Coins
+		var feeIndex int
+		var feeFound, spenderFound bool
+		for i, event := range anteEvents {
+			if !feeFound && event.Type == sdk.EventTypeTx && string(event.Attributes[0].Key) == sdk.AttributeKeyFee {
+				feeFound = true
+				feeIndex = i
+			}
+			// first spent coin event is the coin sent to fee module for tx
+			if !spenderFound && event.Type == banktypes.EventTypeCoinSpent && string(event.Attributes[0].Key) == banktypes.AttributeKeySpender && len(anteEvents) >= i+3 {
+				txFee, err = sdk.ParseCoinsNormalized(string(event.Attributes[1].Value))
+				if err != nil {
+					return nil, nil, err
+				}
+				spenderFound = true
+			}
+		}
+		if feeFound && spenderFound {
+			anteEvents[feeIndex].Attributes[0].Value = []byte(txFee.String())
+		}
+	}
+
+	return anteEvents, resultEvents, nil
+}

--- a/internal/handlers/aggregate_events_test.go
+++ b/internal/handlers/aggregate_events_test.go
@@ -1,0 +1,7 @@
+package handlers_test
+
+import "testing"
+
+func TestAggregateEvents(tt *testing.T) {
+
+}

--- a/internal/handlers/aggregate_events_test.go
+++ b/internal/handlers/aggregate_events_test.go
@@ -1,7 +1,46 @@
 package handlers_test
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	abci "github.com/tendermint/tendermint/abci/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	piohandlers "github.com/provenance-io/provenance/internal/handlers"
+)
 
 func TestAggregateEvents(tt *testing.T) {
+	originalFeeEvent := NewEvent(sdk.EventTypeTx,
+		NewAttribute(sdk.AttributeKeyFee, "100111stake"),
+		NewAttribute(sdk.AttributeKeyFeePayer, "payer"))
 
+	anteEvents := []abci.Event{
+		originalFeeEvent,
+	}
+
+	actualAnte, actualResultEvents := piohandlers.AggregateEvents(anteEvents, nil)
+	assert.Nil(tt, actualResultEvents, "should not have any resultEvents since this is a failed tx case")
+	assert.Equal(tt, anteEvents, actualAnte, "should return original anteevents since first spent_event not found")
+
+	sendCoinsEvent := CreateSendCoinEvents("from", "to", sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 100000)))
+	sendCoinsEvent = append(sendCoinsEvent, CreateSendCoinEvents("from", "to", sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 40)))...)
+	expectedFeeEvent := []abci.Event{NewEvent(sdk.EventTypeTx,
+		NewAttribute(sdk.AttributeKeyFee, "100000stake"),
+		NewAttribute(sdk.AttributeKeyFeePayer, "payer")),
+	}
+
+	expectedAnteEvents := append(expectedFeeEvent, sendCoinsEvent...)
+	anteEvents = append(anteEvents, sendCoinsEvent...)
+
+	actualAnte, actualResultEvents = piohandlers.AggregateEvents(anteEvents, nil)
+	assert.Nil(tt, actualResultEvents, "should not have any resultEvents since this is a failed tx case")
+	assert.Equal(tt, expectedAnteEvents, actualAnte, "should return new ante events with fee amount from first send coins")
+
+	// test when the result events are sent in...this should be a no-op for now
+	actualAnte, actualResultEvents = piohandlers.AggregateEvents(anteEvents, anteEvents)
+	assert.NotNil(tt, actualResultEvents, "should have resultEvents since this is a successful tx case")
+	assert.Equal(tt, anteEvents, actualAnte, "should return original anteevents since successful tx is a noop")
+	assert.Equal(tt, anteEvents, actualResultEvents, "should return original anteevents since successful tx is a noop")
 }

--- a/internal/handlers/msg_fee_invoker.go
+++ b/internal/handlers/msg_fee_invoker.go
@@ -79,8 +79,8 @@ func (afd MsgFeeInvoker) Invoke(ctx sdk.Context, simulate bool) (sdk.Coins, sdk.
 
 		// If there's fees left to collect, or there were consumed fees, deduct/distribute them now.
 		if !unchargedFees.IsZero() || !consumedFees.IsZero() {
-			ctx = ctx.WithEventManager(sdk.NewEventManager())
-			err = afd.msgFeeKeeper.DeductFeesDistributions(afd.bankKeeper, ctx, deductFeesFromAcc, unchargedFees, feeGasMeter.FeeConsumedDistributions())
+			eventCtx := ctx.WithEventManager(sdk.NewEventManager())
+			err = afd.msgFeeKeeper.DeductFeesDistributions(afd.bankKeeper, eventCtx, deductFeesFromAcc, unchargedFees, feeGasMeter.FeeConsumedDistributions())
 			if err != nil {
 				return nil, nil, err
 			}

--- a/internal/handlers/msg_fee_invoker.go
+++ b/internal/handlers/msg_fee_invoker.go
@@ -6,6 +6,9 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+
+	abci "github.com/tendermint/tendermint/abci/types"
 
 	"github.com/provenance-io/provenance/internal/antewrapper"
 	msgfeestypes "github.com/provenance-io/provenance/x/msgfees/types"
@@ -79,10 +82,12 @@ func (afd MsgFeeInvoker) Invoke(ctx sdk.Context, simulate bool) (sdk.Coins, sdk.
 
 		// If there's fees left to collect, or there were consumed fees, deduct/distribute them now.
 		if !unchargedFees.IsZero() || !consumedFees.IsZero() {
+			ctx = ctx.WithEventManager(sdk.NewEventManager())
 			err = afd.msgFeeKeeper.DeductFeesDistributions(afd.bankKeeper, ctx, deductFeesFromAcc, unchargedFees, feeGasMeter.FeeConsumedDistributions())
 			if err != nil {
 				return nil, nil, err
 			}
+			eventsToReturn = append(eventsToReturn, ctx.EventManager().Events()...)
 		}
 		// the uncharged fees have now been charged.
 		chargedFees = chargedFees.Add(unchargedFees...)
@@ -109,3 +114,89 @@ func (afd MsgFeeInvoker) Invoke(ctx sdk.Context, simulate bool) (sdk.Coins, sdk.
 
 	return chargedFees, eventsToReturn, nil
 }
+
+func AggregateEvents(anteEvents []abci.Event, resultEvents []abci.Event) ([]abci.Event, []abci.Event) {
+	if len(resultEvents) == 0 { // tx failed...fix fee event to have charged fee
+		var err error
+		var txFee sdk.Coins
+		var feeIndex int
+		var feeFound, spenderFound bool
+		for i, event := range anteEvents {
+			if !feeFound && event.Type == sdk.EventTypeTx && string(event.Attributes[0].Key) == sdk.AttributeKeyFee {
+				feeFound = true
+				feeIndex = i
+			}
+			// first spent coin event is the coin sent to fee module for tx
+			if !spenderFound && event.Type == banktypes.EventTypeCoinSpent && string(event.Attributes[0].Key) == banktypes.AttributeKeySpender && len(anteEvents) >= i+3 {
+				txFee, err = sdk.ParseCoinsNormalized(string(event.Attributes[1].Value))
+				if err != nil {
+					return nil, nil
+				}
+				spenderFound = true
+			}
+		}
+		if feeFound && spenderFound {
+			anteEvents[feeIndex].Attributes[0].Value = []byte(txFee.String())
+		}
+	}
+
+	return anteEvents, resultEvents
+}
+
+// func AggregateEventsOld(resultEvents []abci.Event, feeEvents []abci.Event) ([]abci.Event, error) {
+// 	var baseFee sdk.Coins
+// 	var additionalFee sdk.Coins
+
+// 	// 1.) Find amount in coins passed into the tx as a fee
+// 	var txFee sdk.Coins
+// 	var feeIndex int
+// 	var feeFound, spenderFound bool
+// 	for i, event := range resultEvents {
+// 		if !feeFound && event.Type == sdk.EventTypeTx && string(event.Attributes[0].Key) == sdk.AttributeKeyFee {
+// 			txFee, _ = sdk.ParseCoinsNormalized(string(event.Attributes[0].Value))
+// 			feeFound = true
+// 			feeIndex = i
+// 		}
+// 		if !spenderFound && event.Type == banktypes.EventTypeCoinSpent && string(event.Attributes[0].Key) == banktypes.AttributeKeySpender && len(resultEvents) >= i+3 {
+// 			amount, _ := sdk.ParseCoinsNormalized(string(event.Attributes[0].Value))
+// 			if !amount.IsEqual(txFee) { //
+// 				hadOverage = true
+// 			}
+// 			spenderFound = true
+// 		}
+// 	}
+
+// 	// 2.) Find any additional fees paid
+// 	for _, event := range feeEvents {
+// 		if event.Type == sdk.EventTypeTx && string(event.Attributes[0].Key) == antewrapper.AttributeKeyAdditionalFee {
+// 			additionalFee, _ = sdk.ParseCoinsNormalized(string(event.Attributes[0].Value))
+// 		}
+// 	}
+
+// 	// 3.) Calculate the total base fee
+// 	baseFee = txFee.Sub(additionalFee...)
+
+// 	// 4.)
+// 	value := fmt.Sprintf("%v %v %v %v", txFee, feeIndex, baseFee, additionalFee)
+// 	println(value)
+
+// 	// var feemoduleAddress string
+// 	// var hadOverage bool
+// 	// var processedFeePay bool
+// 	// // first coin_spent address is fee module account
+// 	// for i, event := range resultEvents {
+// 	// 	if event.Type == banktypes.EventTypeCoinSpent && string(event.Attributes[0].Key) == banktypes.AttributeKeySpender && len(resultEvents) >= i+3 {
+// 	// 		feePayer := string(event.Attributes[0].Value)
+// 	// 		amount, _ := sdk.ParseCoinsNormalized(string(event.Attributes[0].Value))
+// 	// 		if !amount.IsEqual(txFee) { //
+// 	// 			hadOverage = true
+// 	// 		}
+// 	// 	}
+// 	// }
+
+// 	// if hadOverage && resultEvents[feeIndex].Type == sdk.EventTypeTx && string(resultEvents[feeIndex].Attributes[0].Key) == sdk.AttributeKeyFee {
+// 	// 	resultEvents[feeIndex].Attributes[0].Value = []byte(txFee.String())
+// 	// }
+
+// 	return append(resultEvents, feeEvents...), nil
+// }

--- a/internal/handlers/msg_fee_invoker.go
+++ b/internal/handlers/msg_fee_invoker.go
@@ -84,7 +84,7 @@ func (afd MsgFeeInvoker) Invoke(ctx sdk.Context, simulate bool) (sdk.Coins, sdk.
 			if err != nil {
 				return nil, nil, err
 			}
-			eventsToReturn = append(eventsToReturn, ctx.EventManager().Events()...)
+			eventsToReturn = append(eventsToReturn, eventCtx.EventManager().Events()...)
 		}
 		// the uncharged fees have now been charged.
 		chargedFees = chargedFees.Add(unchargedFees...)

--- a/internal/handlers/msg_fee_invoker.go
+++ b/internal/handlers/msg_fee_invoker.go
@@ -6,9 +6,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
-	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-
-	abci "github.com/tendermint/tendermint/abci/types"
 
 	"github.com/provenance-io/provenance/internal/antewrapper"
 	msgfeestypes "github.com/provenance-io/provenance/x/msgfees/types"
@@ -114,89 +111,3 @@ func (afd MsgFeeInvoker) Invoke(ctx sdk.Context, simulate bool) (sdk.Coins, sdk.
 
 	return chargedFees, eventsToReturn, nil
 }
-
-func AggregateEvents(anteEvents []abci.Event, resultEvents []abci.Event) ([]abci.Event, []abci.Event) {
-	if len(resultEvents) == 0 { // tx failed...fix fee event to have charged fee
-		var err error
-		var txFee sdk.Coins
-		var feeIndex int
-		var feeFound, spenderFound bool
-		for i, event := range anteEvents {
-			if !feeFound && event.Type == sdk.EventTypeTx && string(event.Attributes[0].Key) == sdk.AttributeKeyFee {
-				feeFound = true
-				feeIndex = i
-			}
-			// first spent coin event is the coin sent to fee module for tx
-			if !spenderFound && event.Type == banktypes.EventTypeCoinSpent && string(event.Attributes[0].Key) == banktypes.AttributeKeySpender && len(anteEvents) >= i+3 {
-				txFee, err = sdk.ParseCoinsNormalized(string(event.Attributes[1].Value))
-				if err != nil {
-					return nil, nil
-				}
-				spenderFound = true
-			}
-		}
-		if feeFound && spenderFound {
-			anteEvents[feeIndex].Attributes[0].Value = []byte(txFee.String())
-		}
-	}
-
-	return anteEvents, resultEvents
-}
-
-// func AggregateEventsOld(resultEvents []abci.Event, feeEvents []abci.Event) ([]abci.Event, error) {
-// 	var baseFee sdk.Coins
-// 	var additionalFee sdk.Coins
-
-// 	// 1.) Find amount in coins passed into the tx as a fee
-// 	var txFee sdk.Coins
-// 	var feeIndex int
-// 	var feeFound, spenderFound bool
-// 	for i, event := range resultEvents {
-// 		if !feeFound && event.Type == sdk.EventTypeTx && string(event.Attributes[0].Key) == sdk.AttributeKeyFee {
-// 			txFee, _ = sdk.ParseCoinsNormalized(string(event.Attributes[0].Value))
-// 			feeFound = true
-// 			feeIndex = i
-// 		}
-// 		if !spenderFound && event.Type == banktypes.EventTypeCoinSpent && string(event.Attributes[0].Key) == banktypes.AttributeKeySpender && len(resultEvents) >= i+3 {
-// 			amount, _ := sdk.ParseCoinsNormalized(string(event.Attributes[0].Value))
-// 			if !amount.IsEqual(txFee) { //
-// 				hadOverage = true
-// 			}
-// 			spenderFound = true
-// 		}
-// 	}
-
-// 	// 2.) Find any additional fees paid
-// 	for _, event := range feeEvents {
-// 		if event.Type == sdk.EventTypeTx && string(event.Attributes[0].Key) == antewrapper.AttributeKeyAdditionalFee {
-// 			additionalFee, _ = sdk.ParseCoinsNormalized(string(event.Attributes[0].Value))
-// 		}
-// 	}
-
-// 	// 3.) Calculate the total base fee
-// 	baseFee = txFee.Sub(additionalFee...)
-
-// 	// 4.)
-// 	value := fmt.Sprintf("%v %v %v %v", txFee, feeIndex, baseFee, additionalFee)
-// 	println(value)
-
-// 	// var feemoduleAddress string
-// 	// var hadOverage bool
-// 	// var processedFeePay bool
-// 	// // first coin_spent address is fee module account
-// 	// for i, event := range resultEvents {
-// 	// 	if event.Type == banktypes.EventTypeCoinSpent && string(event.Attributes[0].Key) == banktypes.AttributeKeySpender && len(resultEvents) >= i+3 {
-// 	// 		feePayer := string(event.Attributes[0].Value)
-// 	// 		amount, _ := sdk.ParseCoinsNormalized(string(event.Attributes[0].Value))
-// 	// 		if !amount.IsEqual(txFee) { //
-// 	// 			hadOverage = true
-// 	// 		}
-// 	// 	}
-// 	// }
-
-// 	// if hadOverage && resultEvents[feeIndex].Type == sdk.EventTypeTx && string(resultEvents[feeIndex].Attributes[0].Key) == sdk.AttributeKeyFee {
-// 	// 	resultEvents[feeIndex].Attributes[0].Value = []byte(txFee.String())
-// 	// }
-
-// 	return append(resultEvents, feeEvents...), nil
-// }

--- a/internal/handlers/msg_service_router_test.go
+++ b/internal/handlers/msg_service_router_test.go
@@ -32,7 +32,6 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	authztypes "github.com/cosmos/cosmos-sdk/x/authz"
 	"github.com/cosmos/cosmos-sdk/x/bank/testutil"
-	"github.com/cosmos/cosmos-sdk/x/bank/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	govtypesv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
@@ -267,7 +266,7 @@ func TestFailedTx(tt *testing.T) {
 				NewAttribute(antewrapper.AttributeKeyMinFeeCharged, "100000stake"),
 				NewAttribute(sdk.AttributeKeyFeePayer, addr1.String())),
 		}
-		expEvents = append(expEvents, createSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 100000)))...)
+		expEvents = append(expEvents, CreateSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 100000)))...)
 
 		assertEventsContains(t, res.Events, expEvents)
 	})
@@ -306,41 +305,10 @@ func TestFailedTx(tt *testing.T) {
 				NewAttribute(antewrapper.AttributeKeyMinFeeCharged, "100000stake"),
 				NewAttribute(sdk.AttributeKeyFeePayer, addr1.String())),
 		}
-		expEvents = append(expEvents, createSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 100000)))...)
+		expEvents = append(expEvents, CreateSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 100000)))...)
 
 		assertEventsContains(t, res.Events, expEvents)
 	})
-}
-
-// creates the sequence of events that are created on bankkeeper.SendCoins
-func createSendCoinEvents(fromAddress, toAddress string, amt sdk.Coins) []abci.Event {
-	events := sdk.NewEventManager().Events()
-	// subUnlockedCoins event `coin_spent`
-	events = events.AppendEvent(sdk.NewEvent(
-		banktypes.EventTypeCoinSpent,
-		sdk.NewAttribute(banktypes.AttributeKeySpender, fromAddress),
-		sdk.NewAttribute(sdk.AttributeKeyAmount, amt.String()),
-	))
-	// addCoins event
-	events = events.AppendEvent(sdk.NewEvent(
-		banktypes.EventTypeCoinReceived,
-		sdk.NewAttribute(banktypes.AttributeKeyReceiver, toAddress),
-		sdk.NewAttribute(sdk.AttributeKeyAmount, amt.String()),
-	))
-
-	// SendCoins function
-	events = events.AppendEvent(sdk.NewEvent(
-		types.EventTypeTransfer,
-		sdk.NewAttribute(types.AttributeKeyRecipient, toAddress),
-		sdk.NewAttribute(types.AttributeKeySender, fromAddress),
-		sdk.NewAttribute(sdk.AttributeKeyAmount, amt.String()),
-	))
-	events = events.AppendEvent(sdk.NewEvent(
-		sdk.EventTypeMessage,
-		sdk.NewAttribute(types.AttributeKeySender, fromAddress),
-	))
-
-	return events.ToABCIEvents()
 }
 
 func TestMsgService(tt *testing.T) {
@@ -394,7 +362,7 @@ func TestMsgService(tt *testing.T) {
 				NewAttribute(sdk.AttributeKeyFeePayer, addr1.String())),
 		}
 		// fee charge in antehandler
-		expEvents = append(expEvents, createSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 100000)))...)
+		expEvents = append(expEvents, CreateSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 100000)))...)
 
 		assertEventsContains(t, res.Events, expEvents)
 	})
@@ -435,11 +403,11 @@ func TestMsgService(tt *testing.T) {
 				NewAttribute("msg_fees", jsonArrayJoin(msgFeesMsgSendEventJSON(1, 800, "hotdog", "")))),
 		}
 		// fee charge in antehandler
-		expEvents = append(expEvents, createSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 100000)))...)
+		expEvents = append(expEvents, CreateSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 100000)))...)
 		// fee charged for msg based fee
-		expEvents = append(expEvents, createSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin("hotdog", 800)))...)
+		expEvents = append(expEvents, CreateSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin("hotdog", 800)))...)
 		// swept fee amount
-		expEvents = append(expEvents, createSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 100)))...)
+		expEvents = append(expEvents, CreateSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 100)))...)
 
 		assertEventsContains(t, res.Events, expEvents)
 	})
@@ -477,11 +445,11 @@ func TestMsgService(tt *testing.T) {
 				NewAttribute("msg_fees", jsonArrayJoin(msgFeesMsgSendEventJSON(1, 10, "stake", "")))),
 		}
 		// fee charge in antehandler
-		expEvents = append(expEvents, createSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 100000)))...)
+		expEvents = append(expEvents, CreateSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 100000)))...)
 		// fee charged for msg based fee
-		expEvents = append(expEvents, createSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 10)))...)
+		expEvents = append(expEvents, CreateSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 10)))...)
 		// swept fee amount
-		expEvents = append(expEvents, createSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 101)))...)
+		expEvents = append(expEvents, CreateSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 101)))...)
 
 		assertEventsContains(t, res.Events, expEvents)
 	})
@@ -542,11 +510,11 @@ func TestMsgServiceMsgFeeWithRecipient(t *testing.T) {
 				jsonArrayJoin(msgFeesMsgSendEventJSON(1, 200, "hotdog", ""), msgFeesMsgSendEventJSON(1, 600, "hotdog", addr2.String())))),
 	}
 	// fee charge in antehandler
-	expEvents = append(expEvents, createSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 100000)))...)
+	expEvents = append(expEvents, CreateSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 100000)))...)
 	// fee charged for msg based fee
-	expEvents = append(expEvents, createSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin("hotdog", 200)))...)
+	expEvents = append(expEvents, CreateSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin("hotdog", 200)))...)
 	// fee charged for msg based fee
-	expEvents = append(expEvents, createSendCoinEvents(addr1.String(), addr2.String(), sdk.NewCoins(sdk.NewInt64Coin("hotdog", 600)))...)
+	expEvents = append(expEvents, CreateSendCoinEvents(addr1.String(), addr2.String(), sdk.NewCoins(sdk.NewInt64Coin("hotdog", 600)))...)
 
 	assertEventsContains(t, res.Events, expEvents)
 }
@@ -622,9 +590,9 @@ func TestMsgServiceAuthz(tt *testing.T) {
 				NewAttribute("msg_fees", jsonArrayJoin(msgFeesMsgSendEventJSON(1, 800, "hotdog", "")))),
 		}
 		// fee charge in antehandler
-		expEvents = append(expEvents, createSendCoinEvents(addr2.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 100000)))...)
+		expEvents = append(expEvents, CreateSendCoinEvents(addr2.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 100000)))...)
 		// fee charged for msg based fee
-		expEvents = append(expEvents, createSendCoinEvents(addr2.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin("hotdog", 800)))...)
+		expEvents = append(expEvents, CreateSendCoinEvents(addr2.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin("hotdog", 800)))...)
 		assertEventsContains(t, res.Events, expEvents)
 	})
 
@@ -661,9 +629,9 @@ func TestMsgServiceAuthz(tt *testing.T) {
 				NewAttribute("msg_fees", jsonArrayJoin(msgFeesMsgSendEventJSON(2, 1600, "hotdog", "")))),
 		}
 		// fee charge in antehandler
-		expEvents = append(expEvents, createSendCoinEvents(addr2.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 200000)))...)
+		expEvents = append(expEvents, CreateSendCoinEvents(addr2.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 200000)))...)
 		// fee charged for msg based fee
-		expEvents = append(expEvents, createSendCoinEvents(addr2.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin("hotdog", 1600)))...)
+		expEvents = append(expEvents, CreateSendCoinEvents(addr2.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin("hotdog", 1600)))...)
 
 		assertEventsContains(t, res.Events, expEvents)
 	})
@@ -751,13 +719,13 @@ func TestMsgServiceAssessMsgFee(tt *testing.T) {
 					msgFeesEventJSON("/provenance.msgfees.v1.MsgAssessCustomMsgFeeRequest", 1, 87500000, "nhash", addr2.String())))),
 		}
 		// fee charge in antehandler
-		expEvents = append(expEvents, createSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin("nhash", 1015500001)))...)
+		expEvents = append(expEvents, CreateSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin("nhash", 1015500001)))...)
 		// fee charged for msg based fee to fee module on assess msg split
-		expEvents = append(expEvents, createSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin("nhash", 87500000)))...)
+		expEvents = append(expEvents, CreateSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin("nhash", 87500000)))...)
 		// fee charged for msg based fee to recipient from assess msg split
-		expEvents = append(expEvents, createSendCoinEvents(addr1.String(), addr2.String(), sdk.NewCoins(sdk.NewInt64Coin("nhash", 87500000)))...)
+		expEvents = append(expEvents, CreateSendCoinEvents(addr1.String(), addr2.String(), sdk.NewCoins(sdk.NewInt64Coin("nhash", 87500000)))...)
 		// swept amount
-		expEvents = append(expEvents, createSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin("nhash", 1015500001)))...)
+		expEvents = append(expEvents, CreateSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin("nhash", 1015500001)))...)
 
 		assertEventsContains(t, res.Events, expEvents)
 	})
@@ -3063,4 +3031,35 @@ func NewTestGasLimit() uint64 {
 
 func NewTestRewardsGasLimit() uint64 {
 	return 200000
+}
+
+// CreateSendCoinEvents creates the sequence of events that are created on bankkeeper.SendCoins
+func CreateSendCoinEvents(fromAddress, toAddress string, amt sdk.Coins) []abci.Event {
+	events := sdk.NewEventManager().Events()
+	// subUnlockedCoins event `coin_spent`
+	events = events.AppendEvent(sdk.NewEvent(
+		banktypes.EventTypeCoinSpent,
+		sdk.NewAttribute(banktypes.AttributeKeySpender, fromAddress),
+		sdk.NewAttribute(sdk.AttributeKeyAmount, amt.String()),
+	))
+	// addCoins event
+	events = events.AppendEvent(sdk.NewEvent(
+		banktypes.EventTypeCoinReceived,
+		sdk.NewAttribute(banktypes.AttributeKeyReceiver, toAddress),
+		sdk.NewAttribute(sdk.AttributeKeyAmount, amt.String()),
+	))
+
+	// SendCoins function
+	events = events.AppendEvent(sdk.NewEvent(
+		banktypes.EventTypeTransfer,
+		sdk.NewAttribute(banktypes.AttributeKeyRecipient, toAddress),
+		sdk.NewAttribute(banktypes.AttributeKeySender, fromAddress),
+		sdk.NewAttribute(sdk.AttributeKeyAmount, amt.String()),
+	))
+	events = events.AppendEvent(sdk.NewEvent(
+		sdk.EventTypeMessage,
+		sdk.NewAttribute(banktypes.AttributeKeySender, fromAddress),
+	))
+
+	return events.ToABCIEvents()
 }

--- a/internal/handlers/msg_service_router_test.go
+++ b/internal/handlers/msg_service_router_test.go
@@ -296,7 +296,7 @@ func TestFailedTx(tt *testing.T) {
 		// Make sure a couple events are in the list.
 		expEvents := []abci.Event{
 			NewEvent(sdk.EventTypeTx,
-				NewAttribute(sdk.AttributeKeyFee, "100010stake"),
+				NewAttribute(sdk.AttributeKeyFee, "100000stake"),
 				NewAttribute(sdk.AttributeKeyFeePayer, addr1.String())),
 			NewEvent(sdk.EventTypeTx,
 				NewAttribute(antewrapper.AttributeKeyMinFeeCharged, "100000stake"),

--- a/internal/handlers/msg_service_router_test.go
+++ b/internal/handlers/msg_service_router_test.go
@@ -32,6 +32,7 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	authztypes "github.com/cosmos/cosmos-sdk/x/authz"
 	"github.com/cosmos/cosmos-sdk/x/bank/testutil"
+	"github.com/cosmos/cosmos-sdk/x/bank/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	govtypesv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
@@ -231,6 +232,7 @@ func TestFailedTx(tt *testing.T) {
 	)
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{ChainID: "msgfee-testing"})
 	app.AccountKeeper.SetParams(ctx, authtypes.DefaultParams())
+	feeModuleAccount := app.AccountKeeper.GetModuleAccount(ctx, authtypes.FeeCollectorName)
 
 	// Check both account balances before we begin.
 	addr1beforeBalance := app.BankKeeper.GetAllBalances(ctx, addr1).String()
@@ -265,6 +267,8 @@ func TestFailedTx(tt *testing.T) {
 				NewAttribute(antewrapper.AttributeKeyMinFeeCharged, "100000stake"),
 				NewAttribute(sdk.AttributeKeyFeePayer, addr1.String())),
 		}
+		expEvents = append(expEvents, createSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 100000)))...)
+
 		assertEventsContains(t, res.Events, expEvents)
 	})
 
@@ -302,8 +306,41 @@ func TestFailedTx(tt *testing.T) {
 				NewAttribute(antewrapper.AttributeKeyMinFeeCharged, "100000stake"),
 				NewAttribute(sdk.AttributeKeyFeePayer, addr1.String())),
 		}
+		expEvents = append(expEvents, createSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 100000)))...)
+
 		assertEventsContains(t, res.Events, expEvents)
 	})
+}
+
+// creates the sequence of events that are created on bankkeeper.SendCoins
+func createSendCoinEvents(fromAddress, toAddress string, amt sdk.Coins) []abci.Event {
+	events := sdk.NewEventManager().Events()
+	// subUnlockedCoins event `coin_spent`
+	events = events.AppendEvent(sdk.NewEvent(
+		banktypes.EventTypeCoinSpent,
+		sdk.NewAttribute(banktypes.AttributeKeySpender, fromAddress),
+		sdk.NewAttribute(sdk.AttributeKeyAmount, amt.String()),
+	))
+	// addCoins event
+	events = events.AppendEvent(sdk.NewEvent(
+		banktypes.EventTypeCoinReceived,
+		sdk.NewAttribute(banktypes.AttributeKeyReceiver, toAddress),
+		sdk.NewAttribute(sdk.AttributeKeyAmount, amt.String()),
+	))
+
+	// SendCoins function
+	events = events.AppendEvent(sdk.NewEvent(
+		types.EventTypeTransfer,
+		sdk.NewAttribute(types.AttributeKeyRecipient, toAddress),
+		sdk.NewAttribute(types.AttributeKeySender, fromAddress),
+		sdk.NewAttribute(sdk.AttributeKeyAmount, amt.String()),
+	))
+	events = events.AppendEvent(sdk.NewEvent(
+		sdk.EventTypeMessage,
+		sdk.NewAttribute(types.AttributeKeySender, fromAddress),
+	))
+
+	return events.ToABCIEvents()
 }
 
 func TestMsgService(tt *testing.T) {
@@ -319,6 +356,7 @@ func TestMsgService(tt *testing.T) {
 	)
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{ChainID: "msgfee-testing"})
 	app.AccountKeeper.SetParams(ctx, authtypes.DefaultParams())
+	feeModuleAccount := app.AccountKeeper.GetModuleAccount(ctx, authtypes.FeeCollectorName)
 
 	// Check both account balances before we begin.
 	addr1beforeBalance := app.BankKeeper.GetAllBalances(ctx, addr1).String()
@@ -355,6 +393,9 @@ func TestMsgService(tt *testing.T) {
 				NewAttribute(antewrapper.AttributeKeyMinFeeCharged, "100000stake"),
 				NewAttribute(sdk.AttributeKeyFeePayer, addr1.String())),
 		}
+		// fee charge in antehandler
+		expEvents = append(expEvents, createSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 100000)))...)
+
 		assertEventsContains(t, res.Events, expEvents)
 	})
 
@@ -393,6 +434,13 @@ func TestMsgService(tt *testing.T) {
 			NewEvent("provenance.msgfees.v1.EventMsgFees",
 				NewAttribute("msg_fees", jsonArrayJoin(msgFeesMsgSendEventJSON(1, 800, "hotdog", "")))),
 		}
+		// fee charge in antehandler
+		expEvents = append(expEvents, createSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 100000)))...)
+		// fee charged for msg based fee
+		expEvents = append(expEvents, createSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin("hotdog", 800)))...)
+		// swept fee amount
+		expEvents = append(expEvents, createSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 100)))...)
+
 		assertEventsContains(t, res.Events, expEvents)
 	})
 
@@ -428,6 +476,13 @@ func TestMsgService(tt *testing.T) {
 			NewEvent("provenance.msgfees.v1.EventMsgFees",
 				NewAttribute("msg_fees", jsonArrayJoin(msgFeesMsgSendEventJSON(1, 10, "stake", "")))),
 		}
+		// fee charge in antehandler
+		expEvents = append(expEvents, createSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 100000)))...)
+		// fee charged for msg based fee
+		expEvents = append(expEvents, createSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 10)))...)
+		// swept fee amount
+		expEvents = append(expEvents, createSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 101)))...)
+
 		assertEventsContains(t, res.Events, expEvents)
 	})
 }
@@ -445,6 +500,7 @@ func TestMsgServiceMsgFeeWithRecipient(t *testing.T) {
 	)
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{ChainID: "msgfee-testing"})
 	app.AccountKeeper.SetParams(ctx, authtypes.DefaultParams())
+	feeModuleAccount := app.AccountKeeper.GetModuleAccount(ctx, authtypes.FeeCollectorName)
 
 	// Check both account balances before transaction
 	addr1beforeBalance := app.BankKeeper.GetAllBalances(ctx, addr1).String()
@@ -485,6 +541,13 @@ func TestMsgServiceMsgFeeWithRecipient(t *testing.T) {
 			NewAttribute("msg_fees",
 				jsonArrayJoin(msgFeesMsgSendEventJSON(1, 200, "hotdog", ""), msgFeesMsgSendEventJSON(1, 600, "hotdog", addr2.String())))),
 	}
+	// fee charge in antehandler
+	expEvents = append(expEvents, createSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 100000)))...)
+	// fee charged for msg based fee
+	expEvents = append(expEvents, createSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin("hotdog", 200)))...)
+	// fee charged for msg based fee
+	expEvents = append(expEvents, createSendCoinEvents(addr1.String(), addr2.String(), sdk.NewCoins(sdk.NewInt64Coin("hotdog", 600)))...)
+
 	assertEventsContains(t, res.Events, expEvents)
 }
 
@@ -505,6 +568,7 @@ func TestMsgServiceAuthz(tt *testing.T) {
 	)
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{ChainID: "msgfee-testing"})
 	app.AccountKeeper.SetParams(ctx, authtypes.DefaultParams())
+	feeModuleAccount := app.AccountKeeper.GetModuleAccount(ctx, authtypes.FeeCollectorName)
 
 	// Create an authz grant from addr1 to addr2 for 500hotdog.
 	now := ctx.BlockHeader().Time
@@ -557,6 +621,10 @@ func TestMsgServiceAuthz(tt *testing.T) {
 			NewEvent("provenance.msgfees.v1.EventMsgFees",
 				NewAttribute("msg_fees", jsonArrayJoin(msgFeesMsgSendEventJSON(1, 800, "hotdog", "")))),
 		}
+		// fee charge in antehandler
+		expEvents = append(expEvents, createSendCoinEvents(addr2.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 100000)))...)
+		// fee charged for msg based fee
+		expEvents = append(expEvents, createSendCoinEvents(addr2.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin("hotdog", 800)))...)
 		assertEventsContains(t, res.Events, expEvents)
 	})
 
@@ -592,6 +660,11 @@ func TestMsgServiceAuthz(tt *testing.T) {
 			NewEvent("provenance.msgfees.v1.EventMsgFees",
 				NewAttribute("msg_fees", jsonArrayJoin(msgFeesMsgSendEventJSON(2, 1600, "hotdog", "")))),
 		}
+		// fee charge in antehandler
+		expEvents = append(expEvents, createSendCoinEvents(addr2.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 200000)))...)
+		// fee charged for msg based fee
+		expEvents = append(expEvents, createSendCoinEvents(addr2.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin("hotdog", 1600)))...)
+
 		assertEventsContains(t, res.Events, expEvents)
 	})
 
@@ -632,6 +705,7 @@ func TestMsgServiceAssessMsgFee(tt *testing.T) {
 	)
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{ChainID: "msgfee-testing"})
 	app.AccountKeeper.SetParams(ctx, authtypes.DefaultParams())
+	feeModuleAccount := app.AccountKeeper.GetModuleAccount(ctx, authtypes.FeeCollectorName)
 
 	// Check both account balances before we start.
 	addr1beforeBalance := app.BankKeeper.GetAllBalances(ctx, addr1).String()
@@ -639,7 +713,6 @@ func TestMsgServiceAssessMsgFee(tt *testing.T) {
 	assert.Equal(tt, "1000hotdog,1190500001nhash,101000stake", addr1beforeBalance, "addr1beforeBalance")
 	assert.Equal(tt, "", addr2beforeBalance, "addr2beforeBalance")
 	stopIfFailed(tt)
-
 	tt.Run("assess custom msg fee", func(t *testing.T) {
 		msgFeeCoin := sdk.NewInt64Coin(msgfeestypes.UsdDenom, 7)
 		msg := msgfeestypes.NewMsgAssessCustomMsgFeeRequest("test", msgFeeCoin, addr2.String(), addr1.String())
@@ -677,6 +750,15 @@ func TestMsgServiceAssessMsgFee(tt *testing.T) {
 					msgFeesEventJSON("/provenance.msgfees.v1.MsgAssessCustomMsgFeeRequest", 1, 87500000, "nhash", ""),
 					msgFeesEventJSON("/provenance.msgfees.v1.MsgAssessCustomMsgFeeRequest", 1, 87500000, "nhash", addr2.String())))),
 		}
+		// fee charge in antehandler
+		expEvents = append(expEvents, createSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin("nhash", 1015500001)))...)
+		// fee charged for msg based fee to fee module on assess msg split
+		expEvents = append(expEvents, createSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin("nhash", 87500000)))...)
+		// fee charged for msg based fee to recipient from assess msg split
+		expEvents = append(expEvents, createSendCoinEvents(addr1.String(), addr2.String(), sdk.NewCoins(sdk.NewInt64Coin("nhash", 87500000)))...)
+		// swept amount
+		expEvents = append(expEvents, createSendCoinEvents(addr1.String(), feeModuleAccount.GetAddress().String(), sdk.NewCoins(sdk.NewInt64Coin("nhash", 1015500001)))...)
+
 		assertEventsContains(t, res.Events, expEvents)
 	})
 }

--- a/x/msgfees/keeper/keeper.go
+++ b/x/msgfees/keeper/keeper.go
@@ -176,10 +176,12 @@ func (k Keeper) DeductFeesDistributions(bankKeeper bankkeeper.Keeper, ctx sdk.Co
 	if neg {
 		return sdkerrors.ErrInsufficientFunds.Wrapf("negative balance after sending coins to accounts and fee collector: remainingFees: %q, sentCoins: %q, distribution: %v", remainingFees, sentCoins, fees)
 	}
-	// sweep the rest of the fees to module
-	err := bankKeeper.SendCoinsFromAccountToModule(ctx, acc.GetAddress(), k.feeCollectorName, unsentFee)
-	if err != nil {
-		return sdkerrors.ErrInsufficientFunds.Wrap(err.Error())
+	if unsentFee.IsAllPositive() {
+		// sweep the rest of the fees to module
+		err := bankKeeper.SendCoinsFromAccountToModule(ctx, acc.GetAddress(), k.feeCollectorName, unsentFee)
+		if err != nil {
+			return sdkerrors.ErrInsufficientFunds.Wrap(err.Error())
+		}
 	}
 
 	return nil

--- a/x/msgfees/keeper/keeper.go
+++ b/x/msgfees/keeper/keeper.go
@@ -176,7 +176,7 @@ func (k Keeper) DeductFeesDistributions(bankKeeper bankkeeper.Keeper, ctx sdk.Co
 	if neg {
 		return sdkerrors.ErrInsufficientFunds.Wrapf("negative balance after sending coins to accounts and fee collector: remainingFees: %q, sentCoins: %q, distribution: %v", remainingFees, sentCoins, fees)
 	}
-	if unsentFee.IsAllPositive() {
+	if !unsentFee.IsZero() {
 		// sweep the rest of the fees to module
 		err := bankKeeper.SendCoinsFromAccountToModule(ctx, acc.GetAddress(), k.feeCollectorName, unsentFee)
 		if err != nil {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Versions <= v1.12 have a fee event that is dispatched at the beginning of the transaction that is unreliable.  This is due to the fact that it is emitting the total amount of fee that is sent with the transaction.  The case where this fails to be accurate is when the transaction fails at the ante handler level.  This is because only gas_wanted * min_gas_cost is charged.
  
This PR also dispatches the events from the distribution of msg based fees and sweeping of the remained fees.  These where suppressed in versions <= 1.12
 
closes: #1092

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Review `Codecov Report` in the comment section below once CI passes
