### PR TITLE
removing debug loggers.

### DIFF
--- a/internal/antewrapper/msg_fees_decorator.go
+++ b/internal/antewrapper/msg_fees_decorator.go
@@ -43,8 +43,6 @@ type MsgFeesDistribution struct {
 // then z = x + y
 // This Fee Decorator makes sure that z is >= to x + y
 func (mfd MsgFeesDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
-	ctx.Logger().Debug("In MsgFeesDecorator", "GasConsumed", ctx.GasMeter().GasConsumed())
-
 	feeTx, err := GetFeeTx(tx)
 	if err != nil {
 		return ctx, err

--- a/internal/antewrapper/provenance_fee.go
+++ b/internal/antewrapper/provenance_fee.go
@@ -46,8 +46,6 @@ func NewProvenanceDeductFeeDecorator(
 }
 
 func (dfd ProvenanceDeductFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
-	ctx.Logger().Debug("In ProvenanceDeductFeeDecorator", "GasConsumed", ctx.GasMeter().GasConsumed())
-
 	feeTx, err := GetFeeTx(tx)
 	if err != nil {
 		return ctx, err


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #1110
lot's of logs coming from

ctx.Logger().Debug("In ProvenanceDeductFeeDecorator", "GasConsumed", ctx.GasMeter().GasConsumed())
a proper fix would be for the fee gas meter to inherit the log level of the caller but easier fix is just to remove them

Fee gas meter logs every-time it is called

// GasConsumed reports the amount of gas consumed at Log.Info level
func (g *FeeGasMeter) GasConsumed() sdkgas.Gas {
	usage := "tracingGasMeter:\n  Purpose"
	for i, d := range g.used {
		usage = fmt.Sprintf("%s\n   - %s (x%d) = %d", usage, i, g.calls[i], d)
	}
	usage = fmt.Sprintf("%s\n  Total: %d gas", usage, g.base.GasConsumed())

	g.log.Info(usage)
	return g.base.GasConsumed()
}
Removing those logs would lead to saner logs

10:14PM INF tracingGasMeter:
  Purpose
   - ReadFlat (x36) = 36000
   - ReadPerByte (x72) = 6141
   - txSize (x2) = 3580
   - ante verify: secp256k1 (x1) = 1000
   - WriteFlat (x4) = 8000
   - WritePerByte (x8) = 9060
   - Has (x6) = 6000
  Total: 69781 gas
10:14PM INF tracingGasMeter:
  Purpose
   - WritePerByte (x8) = 8940
   - ante verify: secp256k1 (x1) = 1000
   - Has (x5) = 5000
   - ReadFlat (x33) = 33000
   - ReadPerByte (x66) = 5778
   - txSize (x1) = 3240
   - WriteFlat (x4) = 8000
  Total: 64958 gas

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
