### PR TITLE
Create command that provides analysis of application database key usage statistics 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,6 +234,17 @@ build-dbmigrate: validate-go-version go.sum
 	mkdir -p $(BUILDDIR)
 	CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" $(GO) build -o $(BUILDDIR)/ $(BUILD_FLAGS) ./cmd/dbmigrate
 
+#############################
+# Build DB Analysis Tools   #
+#############################
+
+install-dbanalyze: go.sum
+	CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" $(GO) install $(BUILD_FLAGS) ./cmd/dbanalyze
+
+build-dbanalyze: validate-go-version go.sum
+	mkdir -p $(BUILDDIR)
+	CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" $(GO) build -o $(BUILDDIR)/ $(BUILD_FLAGS) ./cmd/dbanalyze
+
 ##############################
 # Release artifacts and plan #
 ##############################

--- a/cmd/dbanalyze/cmd/analyzer.go
+++ b/cmd/dbanalyze/cmd/analyzer.go
@@ -1,0 +1,161 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/cosmos/cosmos-sdk/types/errors"
+	tmlog "github.com/tendermint/tendermint/libs/log"
+
+	"golang.org/x/exp/constraints"
+	"golang.org/x/exp/maps"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	dbm "github.com/tendermint/tm-db"
+
+	"regexp"
+	"strings"
+)
+
+// Analyzer is used to analyze the application database.
+type Analyzer struct {
+	// HomePath is the path to the home directory (should contain the config and data directories).
+	HomePath string
+}
+
+// Initialize prepares this Migrator by doing the following:
+//  1. Calls ApplyDefaults()
+//  2. Checks ValidateBasic()
+//  3. Calls ReadSourceDataDir()
+func (m *Analyzer) Initialize() error {
+	m.ApplyDefaults()
+	var err error
+	if err = m.ValidateBasic(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ApplyDefaults fills in the defaults that it can, for values that aren't set yet.
+func (m *Analyzer) ApplyDefaults() {
+}
+
+// ValidateBasic makes sure that everything is set in this Migrator.
+func (m Analyzer) ValidateBasic() error {
+	return nil
+}
+
+// Execute database analysis functionality.
+func (m *Analyzer) Analyze(logger tmlog.Logger) error {
+	dataPath := fmt.Sprintf("%s/data", m.HomePath)
+	logger.Info(fmt.Sprintf("Analyzing application database in: %s", dataPath))
+	db, err := dbm.NewDB("application", dbm.GoLevelDBBackend, dataPath)
+	if err != nil {
+		return errors.ErrIO.Wrapf("unable to open application database: %v", err)
+	}
+	defer db.Close()
+
+	goLevelDB, ok := db.(*dbm.GoLevelDB)
+	if !ok {
+		return errors.ErrInvalidType.Wrapf("invalid logical DB type; expected: %T, got: %T", &dbm.GoLevelDB{}, db)
+	}
+
+	// print native stats
+	levelDBStats, err := goLevelDB.DB().GetProperty("leveldb.stats")
+	if err != nil {
+		logger.Error("failed to get LevelDB stats: %v", err)
+	}
+
+	logger.Info(fmt.Sprintf("%s\n", levelDBStats))
+	RenderTable(goLevelDB)
+
+	return nil
+}
+
+func RenderTable(goLevelDB *dbm.GoLevelDB) {
+	var (
+		totalKeys    int
+		totalKeySize int
+		totalValSize int
+
+		moduleStats = make(map[string][]int)
+		moduleRe    = regexp.MustCompile(`s\/k:(\w+)\/`)
+	)
+
+	iter := goLevelDB.DB().NewIterator(nil, nil)
+	for iter.Next() {
+		keySize := len(iter.Key())
+		valSize := len(iter.Value())
+
+		totalKeys++
+		totalKeySize += keySize
+		totalValSize += valSize
+
+		var statKey string
+
+		keyStr := string(iter.Key())
+		if strings.HasPrefix(keyStr, "s/k:") {
+			tokens := moduleRe.FindStringSubmatch(keyStr)
+			statKey = tokens[1]
+		} else {
+			statKey = "misc"
+		}
+
+		if moduleStats[statKey] == nil {
+			// XXX/TODO: Move this into a struct
+			//
+			// 0: total set size
+			// 1: total key size
+			// 2: total value size
+			moduleStats[statKey] = make([]int, 3)
+		}
+
+		moduleStats[statKey][0]++
+		moduleStats[statKey][1] += keySize
+		moduleStats[statKey][2] += valSize
+	}
+
+	// print application-specific stats
+	t := table.NewWriter()
+	t.SetOutputMirror(os.Stdout)
+	t.AppendHeader(table.Row{"Module", "Avg Key Size", "Avg Value Size", "Total Key Size", "Total Value Size", "Total Key Pairs"})
+
+	modules := maps.Keys(moduleStats)
+	SortSlice(modules)
+
+	for _, m := range modules {
+		stats := moduleStats[m]
+		t.AppendRow([]interface{}{
+			m,
+			ByteCountDecimal(stats[1] / stats[0]),
+			ByteCountDecimal(stats[2] / stats[0]),
+			ByteCountDecimal(stats[1]),
+			ByteCountDecimal(stats[2]),
+			stats[0],
+		})
+	}
+
+	t.AppendFooter(table.Row{"Total", "", "", ByteCountDecimal(totalKeySize), ByteCountDecimal(totalValSize), totalKeys})
+
+	t.Render()
+}
+
+func SortSlice[T constraints.Ordered](s []T) {
+	sort.Slice(s, func(i, j int) bool {
+		return s[i] < s[j]
+	})
+}
+
+func ByteCountDecimal(b int) string {
+	const unit = 1000
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := int64(b) / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "kMGTPE"[exp])
+}

--- a/cmd/dbanalyze/cmd/dbanalyze.go
+++ b/cmd/dbanalyze/cmd/dbanalyze.go
@@ -13,7 +13,6 @@ import (
 	tmcli "github.com/tendermint/tendermint/libs/cli"
 
 	"github.com/provenance-io/provenance/app"
-	"github.com/provenance-io/provenance/cmd/dbanalyze/utils"
 	"github.com/provenance-io/provenance/cmd/provenanced/config"
 )
 
@@ -72,7 +71,7 @@ Provides an overview of the application database broken down by modules and subk
 			return nil
 		},
 		RunE: func(command *cobra.Command, args []string) error {
-			migrator := &utils.Analyzer{
+			migrator := &Analyzer{
 				HomePath: client.GetClientContextFromCmd(command).HomeDir,
 			}
 
@@ -102,7 +101,7 @@ func Execute(command *cobra.Command) error {
 }
 
 // DoMigrateCmd does all the work associated with the dbmigrate command (assuming that inputs have been validated).
-func DoAnalyzeCommand(command *cobra.Command, analyzer *utils.Analyzer) error {
+func DoAnalyzeCommand(command *cobra.Command, analyzer *Analyzer) error {
 	logger := server.GetServerContextFromCmd(command).Logger
 	logger.Info("Initializing analyzer.")
 	err := analyzer.Initialize()

--- a/cmd/dbanalyze/cmd/dbanalyze.go
+++ b/cmd/dbanalyze/cmd/dbanalyze.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"context"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/server"
+
+	tmcli "github.com/tendermint/tendermint/libs/cli"
+
+	"github.com/provenance-io/provenance/app"
+	"github.com/provenance-io/provenance/cmd/dbanalyze/utils"
+	"github.com/provenance-io/provenance/cmd/provenanced/config"
+)
+
+// NewDBAnalyzeCmd creates a command for analyzing the keys/values stored in the application database.
+func NewDBAnalyzeCmd() *cobra.Command {
+	// Creating the client context early because the WithViper function
+	// creates a new Viper instance which wipes out the existing global one.
+	// Technically, it's not needed for the dbmigrate stuff, but having it
+	// makes loading all the rest of the config stuff easier.
+	clientCtx := client.Context{}.
+		WithInput(os.Stdin).
+		WithHomeDir(app.DefaultNodeHome).
+		WithViper("PIO")
+
+	// Allow a user to define the log_level and log_format of this utility through the environment variables
+	// DBM_LOG_LEVEL and DBM_LOG_FORMAT. Otherwise, we want to default them to info and plain.
+	// Without this, the config's log_level and log_format are used.
+	// So, for example, if the config has log_level = error, this utility wouldn't output anything unless it hits an error.
+	// But that setting is desired mostly for the constant running of a node, as opposed to the single-time run of this utility.
+	logLevel := "info"
+	logFormat := "plain"
+	if v := os.Getenv("DBA_LOG_LEVEL"); v != "" {
+		logLevel = v
+	}
+	if v := os.Getenv("DBA_LOG_FORMAT"); v != "" {
+		logLevel = logFormat
+	}
+	// Ignoring any errors here. If we can't set an environment variable, oh well.
+	// Using the values from the config file isn't the end of the world, and is preferable to not allowing execution.
+	_ = os.Setenv("PIO_LOG_LEVEL", logLevel)
+	_ = os.Setenv("PIO_LOG_FORMAT", logFormat)
+
+	rv := &cobra.Command{
+		Use:   "dbanalyze",
+		Short: "Provenance Blockchain Database Analysis Tool",
+		Long: `Provenance Blockchain Database Analysis Tool
+Provides an overview of the application database broken down by modules and subkeys.
+`,
+		Args: cobra.NoArgs,
+		PersistentPreRunE: func(command *cobra.Command, args []string) error {
+			command.SetOut(command.OutOrStdout())
+			command.SetErr(command.ErrOrStderr())
+
+			if command.Flags().Changed(flags.FlagHome) {
+				homeDir, _ := command.Flags().GetString(flags.FlagHome)
+				clientCtx = clientCtx.WithHomeDir(homeDir)
+			}
+
+			if err := client.SetCmdClientContext(command, clientCtx); err != nil {
+				return err
+			}
+			if err := config.InterceptConfigsPreRunHandler(command); err != nil {
+				return err
+			}
+
+			return nil
+		},
+		RunE: func(command *cobra.Command, args []string) error {
+			migrator := &utils.Analyzer{
+				HomePath: client.GetClientContextFromCmd(command).HomeDir,
+			}
+
+			err := DoAnalyzeCommand(command, migrator)
+			if err != nil {
+				server.GetServerContextFromCmd(command).Logger.Error(err.Error())
+				// If this returns an error, the help is printed. But that isn't wanted here.
+				// But since we got an error, it shouldn't exit with code 0 either.
+				// So we exit 1 here instead of returning an error and letting the caller handle the exit.
+				os.Exit(1)
+			}
+			return nil
+		},
+	}
+	return rv
+}
+
+// Execute sets up and executes the provided command.
+func Execute(command *cobra.Command) error {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, client.ClientContextKey, &client.Context{})
+	ctx = context.WithValue(ctx, server.ServerContextKey, server.NewDefaultContext())
+
+	command.PersistentFlags().String(tmcli.HomeFlag, app.DefaultNodeHome, "directory for config and data")
+
+	return command.ExecuteContext(ctx)
+}
+
+// DoMigrateCmd does all the work associated with the dbmigrate command (assuming that inputs have been validated).
+func DoAnalyzeCommand(command *cobra.Command, analyzer *utils.Analyzer) error {
+	logger := server.GetServerContextFromCmd(command).Logger
+	logger.Info("Initializing analyzer.")
+	err := analyzer.Initialize()
+	if err != nil {
+		return err
+	}
+	logger.Info("Starting analysis...")
+	err = analyzer.Analyze(logger)
+	if err != nil {
+		return err
+	}
+
+	logger.Info("Finished analysis.")
+	return nil
+}

--- a/cmd/dbanalyze/main.go
+++ b/cmd/dbanalyze/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"errors"
+	"os"
+
+	"github.com/cosmos/cosmos-sdk/server"
+
+	"github.com/provenance-io/provenance/cmd/dbanalyze/cmd"
+)
+
+func main() {
+	rootCmd := cmd.NewDBAnalyzeCmd()
+	if err := cmd.Execute(rootCmd); err != nil {
+		var srvErr *server.ErrorCode
+		switch {
+		case errors.As(err, &srvErr):
+			os.Exit(srvErr.Code)
+		default:
+			os.Exit(1)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
+	github.com/jedib0t/go-pretty/v6 v6.4.0
 	github.com/otiai10/copy v1.7.0
 	github.com/pkg/errors v0.9.1
 	github.com/rakyll/statik v0.1.7
@@ -26,6 +27,7 @@ require (
 	github.com/stretchr/testify v1.8.0
 	github.com/tendermint/tendermint v0.34.21
 	github.com/tendermint/tm-db v0.6.7
+	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
 	google.golang.org/genproto v0.0.0-20220725144611-272f38e5d71b
 	google.golang.org/grpc v1.48.0
 	google.golang.org/protobuf v1.28.1
@@ -92,6 +94,7 @@ require (
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mimoo/StrobeGo v0.0.0-20181016162300-f8f6d4d2b643 // indirect
 	github.com/minio/highwayhash v1.0.2 // indirect
@@ -106,6 +109,7 @@ require (
 	github.com/prometheus/common v0.34.0 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rs/cors v1.8.2 // indirect
 	github.com/sasha-s/go-deadlock v0.2.1-0.20190427202633-1595213edefa // indirect
 	github.com/spf13/afero v1.8.2 // indirect
@@ -118,7 +122,6 @@ require (
 	github.com/zondax/hid v0.9.0 // indirect
 	go.etcd.io/bbolt v1.3.6 // indirect
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect
-	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
 	golang.org/x/net v0.0.0-20220726230323-06994584191e // indirect
 	golang.org/x/sys v0.0.0-20220727055044-e65921a090b8 // indirect
 	golang.org/x/term v0.0.0-20220722155259-a9ba230a4035 // indirect

--- a/go.sum
+++ b/go.sum
@@ -486,6 +486,8 @@ github.com/influxdata/roaring v0.4.13-0.20180809181101-fc520f41fab6/go.mod h1:bS
 github.com/influxdata/tdigest v0.0.0-20181121200506-bf2b5ad3c0a9/go.mod h1:Js0mqiSBE6Ffsg94weZZ2c+v/ciT8QRHFOap7EKDrR0=
 github.com/influxdata/usage-client v0.0.0-20160829180054-6d3895376368/go.mod h1:Wbbw6tYNvwa5dlB6304Sd+82Z3f7PmVZHVKU637d4po=
 github.com/jackpal/go-nat-pmp v1.0.2-0.20160603034137-1fa385a6f458/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
+github.com/jedib0t/go-pretty/v6 v6.4.0 h1:YlI/2zYDrweA4MThiYMKtGRfT+2qZOO65ulej8GTcVI=
+github.com/jedib0t/go-pretty/v6 v6.4.0/go.mod h1:MgmISkTWDSFu0xOqiZ0mKNntMQ2mDgOcwOkwBEkMDJI=
 github.com/jedisct1/go-minisign v0.0.0-20190909160543-45766022959e/go.mod h1:G1CVv03EnqU1wYL2dFwXxW2An0az9JTl/ZsqXQeBlkU=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
@@ -579,6 +581,8 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
+github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104/go.mod h1:XPvLUNfbS4fJH25nqRHfWLMa1ONC8Amw+mIA639KxkE=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -689,6 +693,7 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
+github.com/pkg/profile v1.6.0/go.mod h1:qBsxPvzyUincmltOk6iyRVxHYg4adc0OFOv72ZdLa18=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/pkg/term v0.0.0-20180730021639-bffc007b7fd5/go.mod h1:eCbImbZ95eXtAUIbLAuAVnBnwf83mjf6QIVH8SHYwqQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -745,6 +750,8 @@ github.com/regen-network/cosmos-proto v0.3.1/go.mod h1:jO0sVX6a1B36nmE8C9xBFXpNw
 github.com/regen-network/protobuf v1.3.3-alpha.regen.1 h1:OHEc+q5iIAXpqiqFKeLpu5NwTIkVXUs48vFMwzqpqY4=
 github.com/regen-network/protobuf v1.3.3-alpha.regen.1/go.mod h1:2DjTFR1HhMQhiWC5sZ4OhQ3+NtdbZ6oBDKQwq5Ou+FI=
 github.com/retailnext/hllpp v1.0.1-0.20180308014038-101a6d2f8b52/go.mod h1:RDpi1RftBQPUCDRw6SmxeaREsAaRKnOclghuzp/WRzc=
+github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rjeczalik/notify v0.9.1/go.mod h1:rKwnCoCGeuQnwBtTSPL9Dad03Vh2n40ePRrjvIXnJho=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
@@ -820,6 +827,7 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
+github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.4.0 h1:yAzM1+SmVcz5R4tXGsNMu1jUl2aOJXoiWUCEwwnGrvs=


### PR DESCRIPTION
## Description

Add a command that provides analysis of application database key/value usage at a per-module level in order to better debug size changes in the database and quicksyncs.

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
