### PR TITLE
Remove the Added module list from the ochre-rc2 upgrade plan since th…

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -48,7 +48,6 @@ var handlers = map[string]appUpgrade{
 		},
 	},
 	"ochre-rc2": { // upgrade for 1.13.0-rc5
-		Added: []string{group.ModuleName, rewardtypes.ModuleName, icacontrollertypes.StoreKey, icahosttypes.StoreKey},
 		Handler: func(ctx sdk.Context, app *App, plan upgradetypes.Plan) (module.VersionMap, error) {
 			versionMap := app.UpgradeKeeper.GetModuleVersionMap(ctx)
 


### PR DESCRIPTION
## Description

Remove the `Added` field from the `ochre-rc2` upgrade plan since those modules were added with `ochre-rc1`. And listing them again broke things with an error like `failed to load latest version: failed to load store: initial version set to 11467068, but found earlier version 11309999`.

This PR is going directly to `release/v1.13.x` because it doesn't cause any problems if it doesn't make it back to `main`. It probably will (and should) along with the changelog once v1.13.0-rc5 is tagged though.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
