### PR TITLE
Build dbmigrate as an artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,45 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: linux-zip
-          path: build/*.zip
+          path: build/provenance*.zip
+
+  build_dbmigrate:
+    runs-on: ubuntu-20.04
+    needs:
+      - build_init
+    name: Build dbmigrate
+    env:
+      LD_LIBRARY_PATH: /usr/local/lib:/usr/local/lib/x86_64-linux-gnu
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ needs.build_init.outputs.go_version }}
+      - name: Install deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgflags-dev libsnappy-dev zlib1g-dev libbz2-dev liblz4-dev libzstd-dev
+      - name: Build and install cleveldb
+        run: make cleveldb
+      - name: Setup go
+        uses: actions/setup-go@v2.1.5
+        with:
+          go-version: ${{ needs.build_init.outputs.go_version }}
+      - name: Build dbmigrate binary
+        run: |
+          export VERSION=${{ needs.build_init.outputs.version }}
+          export WITH_CLEVELDB=true
+          export WITH_ROCKSDB=false
+          export WITH_BADGERDB=false
+          make build-dbmigrate-zip
+      - name: dbmigrate --help
+        run: build/dbmigrate --help
+      - uses: actions/upload-artifact@v3
+        with:
+          name: dbmigrate-zip
+          path: build/dbmigrate*.zip
 
   buf_push:
     needs:
@@ -160,6 +198,7 @@ jobs:
       - build_init
       - build_osx
       - build_linux
+      - build_dbmigrate
     if: needs.build_init.outputs.is_release == 'true'
     runs-on: ubuntu-latest
     name: Create Release
@@ -188,32 +227,33 @@ jobs:
     runs-on: ubuntu-latest
     name: Attach Release Artifacts
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
-      -
-        name: Setup go
+      - name: Setup go
         uses: actions/setup-go@v3
         with:
           go-version: ${{ needs.build_init.outputs.go_version }}
-      -
-        name: Download linux zip artifact
+      - name: Download linux zip artifact
         uses: actions/download-artifact@v3
         with:
           name: linux-zip
           path: build/
-      -
-        name: Download osx zip artifact
+      - name: Download dbmigrate zip artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: dbmigrate-zip
+          path: build/
+      - name: Download osx zip artifact
         uses: actions/download-artifact@v3
         with:
           name: osx-zip
           path: build/
-      -
-        name: Create release items
+      - name: Create release items
+        id: create-items
         run: |
           make VERSION=${{ needs.build_init.outputs.version }} build-release-checksum build-release-plan build-release-proto
-      -
-        name: Upload osx zip artifact
+      - name: Upload osx zip artifact
+        if: always() && steps.create-items.outcome == 'success'
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -222,8 +262,8 @@ jobs:
           asset_path: ./build/provenance-darwin-amd64-${{ needs.build_init.outputs.version }}.zip
           asset_name: provenance-darwin-amd64-${{ needs.build_init.outputs.version }}.zip
           asset_content_type: application/octet-stream
-      -
-        name: Upload linux zip artifact
+      - name: Upload linux zip artifact
+        if: always() && steps.create-items.outcome == 'success'
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -232,8 +272,18 @@ jobs:
           asset_path: ./build/provenance-linux-amd64-${{ needs.build_init.outputs.version }}.zip
           asset_name: provenance-linux-amd64-${{ needs.build_init.outputs.version }}.zip
           asset_content_type: application/octet-stream
-      -
-        name: Upload release checksum
+      - name: Upload dbmigrate zip artifact
+        if: always() && steps.create-items.outcome == 'success'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.release_url }}
+          asset_path: ./build/dbmigrate-linux-amd64-${{ needs.build_init.outputs.version }}.zip
+          asset_name: dbmigrate-linux-amd64-${{ needs.build_init.outputs.version }}.zip
+          asset_content_type: application/octet-stream
+      - name: Upload release checksum
+        if: always() && steps.create-items.outcome == 'success'
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -242,8 +292,8 @@ jobs:
           asset_path: ./build/sha256sum.txt
           asset_name: sha256sum.txt
           asset_content_type: application/octet-stream
-      -
-        name: Upload release plan
+      - name: Upload release plan
+        if: always() && steps.create-items.outcome == 'success'
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -252,8 +302,8 @@ jobs:
           asset_path: ./build/plan-${{ needs.build_init.outputs.version }}.json
           asset_name: plan-${{ needs.build_init.outputs.version }}.json
           asset_content_type: application/octet-stream
-      -
-        name: Upload release protos
+      - name: Upload release protos
+        if: always() && steps.create-items.outcome == 'success'
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Improvements
 
 * Added assess msg fees spec documentation [#1172](https://github.com/provenance-io/provenance/issues/1172).
+* Build dbmigrate and include it as an artifact with releases [#1264](https://github.com/provenance-io/provenance/issues/1264).
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,8 @@ else ifeq ($(UNAME_S),linux)
 	endif
 endif
 
-ifeq ($(UNAME_M),x86_64)
+ARCH=$(UNAME_M)
+ifeq (ARCH,x86_64)
 	ARCH=amd64
 endif
 
@@ -258,10 +259,14 @@ RELEASE_PIO=$(RELEASE_BIN)/provenanced
 RELEASE_ZIP_BASE=provenance-$(UNAME_S)-$(ARCH)
 RELEASE_ZIP_NAME=$(RELEASE_ZIP_BASE)-$(VERSION).zip
 RELEASE_ZIP=$(BUILDDIR)/$(RELEASE_ZIP_NAME)
+DBMIGRATE=$(BUILDDIR)/dbmigrate
+DBMIGRATE_ZIP_BASE=dbmigrate-$(UNAME_S)-$(ARCH)
+DBMIGRATE_ZIP_NAME=$(DBMIGRATE_ZIP_BASE)-$(VERSION).zip
+DBMIGRATE_ZIP=$(BUILDDIR)/$(DBMIGRATE_ZIP_NAME)
 
 .PHONY: build-release-clean
 build-release-clean:
-	rm -rf $(RELEASE_BIN) $(RELEASE_PLAN) $(RELEASE_CHECKSUM) $(RELEASE_ZIP)
+	rm -rf $(RELEASE_BIN) $(RELEASE_PLAN) $(RELEASE_CHECKSUM) $(RELEASE_ZIP) $(DBMIGRATE_ZIP)
 
 .PHONY: build-release-checksum
 build-release-checksum: $(RELEASE_CHECKSUM)
@@ -300,6 +305,17 @@ build-release-zip: $(RELEASE_ZIP)
 $(RELEASE_ZIP): $(RELEASE_PIO) $(RELEASE_WASM)
 	cd $(BUILDDIR) && \
 	  zip -u $(RELEASE_ZIP_NAME) bin/$(LIBWASMVM) bin/provenanced && \
+	cd ..
+
+$(DBMIGRATE):
+	$(MAKE) build-dbmigrate
+
+.PHONY: build-dbmigrate-zip
+build-dbmigrate-zip: $(DBMIGRATE_ZIP)
+
+$(DBMIGRATE_ZIP): $(DBMIGRATE)
+	cd $(BUILDDIR) && \
+	  zip -u $(DBMIGRATE_ZIP_NAME) dbmigrate && \
 	cd ..
 
 # gon packages the zip wrong. need bin/provenanced and bin/libwasmvm

--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,7 @@ else ifeq ($(UNAME_S),linux)
 endif
 
 ARCH=$(UNAME_M)
-ifeq (ARCH,x86_64)
+ifeq ($(ARCH),x86_64)
 	ARCH=amd64
 endif
 


### PR DESCRIPTION
## Description

closes: #1264 

This updates the "Provenance Build and Release" Github Action to include a job that builds dbmigrate as an artifact and includes it in the release artifiacts. A few `Makefile` targets are added to help facilitate this.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
