### PR TITLE
Bump cosmos-sdk to v0.46.6-pio-2 (from v0.46.6-pio-2).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,9 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
-* nothing
+### Improvements
+
+* Updated Cosmos-SDK to `v0.46.6-pio-2` (from `v0.46.6-pio-1`) [PR 1272](https://github.com/provenance-io/provenance/pull/1272).
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -164,7 +164,7 @@ require (
 
 replace github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
-replace github.com/cosmos/cosmos-sdk => github.com/provenance-io/cosmos-sdk v0.46.6-pio-1
+replace github.com/cosmos/cosmos-sdk => github.com/provenance-io/cosmos-sdk v0.46.6-pio-2
 
 // Part of dragonberry fix.
 // TODO: Remove (and bump ics23 above) once github.com/confio/ics23/go releases a fixed version.

--- a/go.sum
+++ b/go.sum
@@ -871,8 +871,8 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/provenance-io/cosmos-sdk v0.46.6-pio-1 h1:R8JnSdRH6sWx5HJAH7HXilKdy3tuxq7cDTtABr1yZHw=
-github.com/provenance-io/cosmos-sdk v0.46.6-pio-1/go.mod h1:vhrWBQ1bSSyuGfbS6BD1H4lJbnZwBcDbQhBQTmZxiSs=
+github.com/provenance-io/cosmos-sdk v0.46.6-pio-2 h1:ZPitZjzquNyhlTTHmexTh5hdhTHwiMitIipsJ2Iu84M=
+github.com/provenance-io/cosmos-sdk v0.46.6-pio-2/go.mod h1:vhrWBQ1bSSyuGfbS6BD1H4lJbnZwBcDbQhBQTmZxiSs=
 github.com/provenance-io/ibc-go/v5 v5.0.0-pio-2 h1:c8JQupz4x+TyI6iYfJS/UCP8Kfl03PkV65Ivpg8OdE8=
 github.com/provenance-io/ibc-go/v5 v5.0.0-pio-2/go.mod h1:Wqsguq98Iuns8tgTv8+xaGYbC+Q8zJfbpjzT6IgMJbs=
 github.com/provenance-io/wasmd v0.29.0-pio-1 h1:vH7tyRf+SjZl/jHBnmcXaXtWpGenfDa6in2yKdREnEs=


### PR DESCRIPTION
## Description

Bump cosmos-sdk to v0.46.6-pio-2 (from v0.46.6-pio-1).

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
