### PR TITLE
Assign port 9091 for ibcnet ibc1 to allow reaching grpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * Update adding of marker to do additional checks for ibc denoms [#1289](https://github.com/provenance-io/provenance/issues/1289).
 * Add validate basic check to msg router service [#1308](https://github.com/provenance-io/provenance/issues/1308).
 * Removed legacy-amino [#1275] (https://github.com/provenance-io/provenance/issues/1275).
-* Opened port 9091 on ibcnet container ibc1 to allow for reaching GRPC [#1314](https://github.com/provenance-io/provenance/pull/1314).
+* Opened port 9091 on ibcnet container ibc1 to allow for reaching GRPC [PR 1314](https://github.com/provenance-io/provenance/pull/1314).
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * Update adding of marker to do additional checks for ibc denoms [#1289](https://github.com/provenance-io/provenance/issues/1289).
 * Add validate basic check to msg router service [#1308](https://github.com/provenance-io/provenance/issues/1308).
 * Removed legacy-amino [#1275] (https://github.com/provenance-io/provenance/issues/1275).
+* Opened port 9091 on ibcnet container ibc1 to allow for reaching GRPC [#1314](https://github.com/provenance-io/provenance/pull/1314).
 
 ### Bug Fixes
 

--- a/networks/ibc/docker-compose.yml
+++ b/networks/ibc/docker-compose.yml
@@ -24,6 +24,7 @@ services:
     image: "provenance-io/blockchain-ibc"
     ports:
       - "26659-26660:26656-26657"
+      - "9091:9090"
     environment:
       - ID=1
       - LOG=${LOG:-provenanced.log}


### PR DESCRIPTION
## Description

Add a port forward for the ibc1 docker container to allow reaching its grpc port. This is intended to better allow testing for apps that need to talk to both a private and public zone directly.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [X] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
