### PR TITLE
In paua, increase max gas per block to 120,000,000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * Bump Cosmos-SDK to v0.46.8-pio-2 (from [v0.46.8-pio-1](https://github.com/provenance-io/cosmos-sdk/compare/v0.46.8-pio-1...v0.46.8-pio-2)) [#1332](https://github.com/provenance-io/provenance/issues/1332).
   See its [RELEASE_NOTES.md](https://github.com/provenance-io/cosmos-sdk/blob/v0.46.8-pio-2/RELEASE_NOTES.md) for details.
   * Enable ADR-038 State Listening in Provenance
+* Increase max gas per block to 120,000,000 (from 60,000,000) [PR 1335](https://github.com/provenance-io/provenance/pull/1335).
 
 ### Bug Fixes
 

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -86,6 +86,7 @@ var handlers = map[string]appUpgrade{
 		Handler: func(ctx sdk.Context, app *App, plan upgradetypes.Plan) (module.VersionMap, error) {
 			ctx.Logger().Info("Starting migrations. This may take a significant amount of time to complete. Do not restart node.")
 			IncreaseMaxCommissions(ctx, app)
+			IncreaseMaxGas(ctx, app)
 			versionMap := app.UpgradeKeeper.GetModuleVersionMap(ctx)
 			return app.mm.RunMigrations(ctx, app.configurator, versionMap)
 		},
@@ -95,6 +96,7 @@ var handlers = map[string]appUpgrade{
 		Handler: func(ctx sdk.Context, app *App, plan upgradetypes.Plan) (module.VersionMap, error) {
 			ctx.Logger().Info("Starting migrations. This may take a significant amount of time to complete. Do not restart node.")
 			IncreaseMaxCommissions(ctx, app)
+			IncreaseMaxGas(ctx, app)
 			versionMap := app.UpgradeKeeper.GetModuleVersionMap(ctx)
 			return app.mm.RunMigrations(ctx, app.configurator, versionMap)
 		},
@@ -192,4 +194,11 @@ func IncreaseMaxCommissions(ctx sdk.Context, app *App) {
 		validator.Commission.MaxRate = minMaxCom
 		app.StakingKeeper.SetValidator(ctx, validator)
 	}
+}
+
+func IncreaseMaxGas(ctx sdk.Context, app *App) {
+	ctx.Logger().Info("Increasing max gas per block to 120,000,000")
+	params := app.GetConsensusParams(ctx)
+	params.Block.MaxGas = 120_000_000
+	app.StoreConsensusParams(ctx, params)
 }


### PR DESCRIPTION
## Description

In the `paua-rc1` and `paua` upgrades, increase max gas per block to 120,000,000

closes: #1299

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
