### PR TITLE
Update the paua upgrades to set the sanction params.

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -85,16 +85,16 @@ var handlers = map[string]appUpgrade{
 		Added: []string{quarantine.ModuleName, sanction.ModuleName},
 		Handler: func(ctx sdk.Context, app *App, plan upgradetypes.Plan) (module.VersionMap, error) {
 			ctx.Logger().Info("Starting migrations. This may take a significant amount of time to complete. Do not restart node.")
-			IncreaseMaxCommissions(ctx, app)
-			IncreaseMaxGas(ctx, app)
 			versionMap, err := app.mm.RunMigrations(ctx, app.configurator, app.UpgradeKeeper.GetModuleVersionMap(ctx))
 			if err != nil {
 				return nil, err
 			}
-			err = SetSanctionParams(ctx, app)
+			err = SetSanctionParams(ctx, app) // Needs to happen after RunMigrations adds the sanction module.
 			if err != nil {
 				return nil, err
 			}
+			IncreaseMaxCommissions(ctx, app)
+			IncreaseMaxGas(ctx, app)
 			return versionMap, err
 		},
 	},
@@ -102,16 +102,16 @@ var handlers = map[string]appUpgrade{
 		Added: []string{quarantine.ModuleName, sanction.ModuleName},
 		Handler: func(ctx sdk.Context, app *App, plan upgradetypes.Plan) (module.VersionMap, error) {
 			ctx.Logger().Info("Starting migrations. This may take a significant amount of time to complete. Do not restart node.")
-			IncreaseMaxCommissions(ctx, app)
-			IncreaseMaxGas(ctx, app)
 			versionMap, err := app.mm.RunMigrations(ctx, app.configurator, app.UpgradeKeeper.GetModuleVersionMap(ctx))
 			if err != nil {
 				return nil, err
 			}
-			err = SetSanctionParams(ctx, app)
+			err = SetSanctionParams(ctx, app) // Needs to happen after RunMigrations adds the sanction module.
 			if err != nil {
 				return nil, err
 			}
+			IncreaseMaxCommissions(ctx, app)
+			IncreaseMaxGas(ctx, app)
 			return versionMap, err
 		},
 	},

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -87,11 +87,14 @@ var handlers = map[string]appUpgrade{
 			ctx.Logger().Info("Starting migrations. This may take a significant amount of time to complete. Do not restart node.")
 			IncreaseMaxCommissions(ctx, app)
 			IncreaseMaxGas(ctx, app)
+			versionMap, err := app.mm.RunMigrations(ctx, app.configurator, app.UpgradeKeeper.GetModuleVersionMap(ctx))
+			if err != nil {
+				return nil, err
+			}
 			if err := SetSanctionParams(ctx, app); err != nil {
 				return nil, err
 			}
-			versionMap := app.UpgradeKeeper.GetModuleVersionMap(ctx)
-			return app.mm.RunMigrations(ctx, app.configurator, versionMap)
+			return versionMap, err
 		},
 	},
 	"paua": { // upgrade for v1.14.0
@@ -103,8 +106,14 @@ var handlers = map[string]appUpgrade{
 			if err := SetSanctionParams(ctx, app); err != nil {
 				return nil, err
 			}
-			versionMap := app.UpgradeKeeper.GetModuleVersionMap(ctx)
-			return app.mm.RunMigrations(ctx, app.configurator, versionMap)
+			versionMap, err := app.mm.RunMigrations(ctx, app.configurator, app.UpgradeKeeper.GetModuleVersionMap(ctx))
+			if err != nil {
+				return nil, err
+			}
+			if err := SetSanctionParams(ctx, app); err != nil {
+				return nil, err
+			}
+			return versionMap, err
 		},
 	},
 	// TODO - Add new upgrade definitions here.

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -91,7 +91,8 @@ var handlers = map[string]appUpgrade{
 			if err != nil {
 				return nil, err
 			}
-			if err := SetSanctionParams(ctx, app); err != nil {
+			err = SetSanctionParams(ctx, app)
+			if err != nil {
 				return nil, err
 			}
 			return versionMap, err
@@ -110,7 +111,8 @@ var handlers = map[string]appUpgrade{
 			if err != nil {
 				return nil, err
 			}
-			if err := SetSanctionParams(ctx, app); err != nil {
+			err = SetSanctionParams(ctx, app)
+			if err != nil {
 				return nil, err
 			}
 			return versionMap, err

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -104,9 +104,6 @@ var handlers = map[string]appUpgrade{
 			ctx.Logger().Info("Starting migrations. This may take a significant amount of time to complete. Do not restart node.")
 			IncreaseMaxCommissions(ctx, app)
 			IncreaseMaxGas(ctx, app)
-			if err := SetSanctionParams(ctx, app); err != nil {
-				return nil, err
-			}
 			versionMap, err := app.mm.RunMigrations(ctx, app.configurator, app.UpgradeKeeper.GetModuleVersionMap(ctx))
 			if err != nil {
 				return nil, err

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -111,7 +111,7 @@ var handlers = map[string]appUpgrade{
 				return nil, err
 			}
 			IncreaseMaxCommissions(ctx, app)
-			IncreaseMaxGas(ctx, app)
+			// Skipping IncreaseMaxGas(ctx, app) in mainnet for now.
 			return versionMap, err
 		},
 	},


### PR DESCRIPTION
## Description

Update the `paua-rc1` and `paua` upgrades to set the sanction module's params.

Immediate sanction and unsanction require a 1,000,000 hash deposit.

This PR also updates the `paua` (mainnet) upgrade to NOT increase the max gas per block. That increase is still in the `paua-rc1` upgrade though.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
