### PR TITLE
In paua, increase validators' commission max change rates to 5%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+### Improvements
+
+* Increase all validators' max commission change rate to 5% [PR 1360](https://github.com/provenance-io/provenance/pull/1360).
+
 ### Bug Fixes
 
 * Correctly log streaming plugin loading errors [PR 1356](https://github.com/provenance-io/provenance/pull/1356).
@@ -84,8 +88,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * Add validate basic check to msg router service [#1308](https://github.com/provenance-io/provenance/issues/1308).
 * Removed legacy-amino [#1275](https://github.com/provenance-io/provenance/issues/1275).
 * Opened port 9091 on ibcnet container ibc1 to allow for reaching GRPC [PR 1314](https://github.com/provenance-io/provenance/pull/1314).
-* Increase all validator's max commission to 100% [PR 1333](https://github.com/provenance-io/provenance/pull/1333).
-* Increase max gas per block to 120,000,000 (from 60,000,000) [PR 1335](https://github.com/provenance-io/provenance/pull/1335).
+* Increase all validators' max commission to 100% [PR 1333](https://github.com/provenance-io/provenance/pull/1333).
+* In testnet only, increase max gas per block to 120,000,000 (from 60,000,000) [PR 1335](https://github.com/provenance-io/provenance/pull/1335).
 
 ### Bug Fixes
 

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -201,11 +201,17 @@ func UpgradeICA(ctx sdk.Context, app *App, versionMap *module.VersionMap) {
 }
 
 func IncreaseMaxCommissions(ctx sdk.Context, app *App) {
-	minMaxCom := sdk.OneDec()
+	oneHundredPct := sdk.OneDec()
+	fivePct := sdk.MustNewDecFromStr("0.05")
 	validators := app.StakingKeeper.GetAllValidators(ctx)
-	ctx.Logger().Info("Increasing all validator's max commission to 100%", "count", len(validators))
+	ctx.Logger().Info("Increasing all validator's max commission to 100% and max change rate to 5%", "count", len(validators))
 	for _, validator := range validators {
-		validator.Commission.MaxRate = minMaxCom
+		validator.Commission.MaxRate = oneHundredPct
+		// Note: This MaxChangeRate bump was added after paua-rc1 was run on testnet.
+		// But it doesn't matter that much on testnet, so it won't be run there.
+		if validator.Commission.MaxChangeRate.LT(fivePct) {
+			validator.Commission.MaxChangeRate = fivePct
+		}
 		app.StakingKeeper.SetValidator(ctx, validator)
 	}
 }

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -208,7 +208,8 @@ func IncreaseMaxCommissions(ctx sdk.Context, app *App) {
 	for _, validator := range validators {
 		validator.Commission.MaxRate = oneHundredPct
 		// Note: This MaxChangeRate bump was added after paua-rc1 was run on testnet.
-		// But it doesn't matter that much on testnet, so it won't be run there.
+		// So, even though it's called by the paua-rc1 upgrade handler now,
+		// it wasn't part of the actual paua-rc1 upgrade that was performed on testnet.
 		if validator.Commission.MaxChangeRate.LT(fivePct) {
 			validator.Commission.MaxChangeRate = fivePct
 		}


### PR DESCRIPTION
## Description

Increase each validator's max commission change rate to 5% (if it's currently less than that).

Note: Even though this is technically being added to both `paua` and `paua-rc1` upgrades, it's unlikely that we will cut a new software `rc` before the `paua-rc1` upgrade is performed on `testnet`. That means that this change will not be applied to `testnet`, but will be applied during the `paua` upgrade on `mainnet`.

As of writing this, `testnet` has 6 validators. 5/6 of them have a max change rate of 100%. The other validator has a max change rate of 1% (`validator-us-west1-0`). But it's `testnet` and I figure we don't care that much about commission stuff on there.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
