### PR TITLE
Remove mac binary release artifact.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,33 +65,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install osx tools
-        run: |
-          brew tap mitchellh/gon
-          brew install mitchellh/gon/gon
       - name: Setup go
         uses: actions/setup-go@v3
         with:
           go-version: ${{ needs.build_init.outputs.go_version }}
       - name: Build osx binary
         run: |
-          make WITH_CLEVELDB=false WITH_ROCKSDB=false VERSION=${{ needs.build_init.outputs.version }} build-release-bin build-release-libwasm
+          export VERSION=${{ needs.build_init.outputs.version }}
+          export WITH_CLEVELDB=false
+          export WITH_ROCKSDB=false
+          make build-release-zip
       - name: Provenanced version
         run: build/provenanced version --long
-      - name: Import Code-Signing Certificates
-        uses: Apple-Actions/import-codesign-certs@v1
-        with:
-          p12-file-base64: ${{ secrets.CODESIGNING_P12_BASE64 }}
-          p12-password: ${{ secrets.CODESIGNING_P12_PASSWORD }}
-      - name: Sign the mac binaries with Gon
-        env:
-          AC_USERNAME: ${{ secrets.AC_USERNAME }}
-          AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
-        run: |
-          gon -log-level=info -log-json ./gon.json
-      - name: Fix zip structure for cosmovisor
-        run: |
-          make VERSION=${{ needs.build_init.outputs.version }} build-release-rezip
       - uses: actions/upload-artifact@v3
         with:
           name: osx-zip
@@ -117,10 +102,6 @@ jobs:
           sudo apt-get install -y libgflags-dev libsnappy-dev zlib1g-dev libbz2-dev liblz4-dev libzstd-dev
       - name: Build and install cleveldb
         run: make cleveldb
-      - name: Setup go
-        uses: actions/setup-go@v2.1.5
-        with:
-          go-version: ${{ needs.build_init.outputs.go_version }}
       - name: Build linux binary
         run: |
           export VERSION=${{ needs.build_init.outputs.version }}
@@ -196,7 +177,6 @@ jobs:
   create_release:
     needs:
       - build_init
-      - build_osx
       - build_linux
       - build_dbmigrate
     if: needs.build_init.outputs.is_release == 'true'
@@ -243,25 +223,10 @@ jobs:
         with:
           name: dbmigrate-zip
           path: build/
-      - name: Download osx zip artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: osx-zip
-          path: build/
       - name: Create release items
         id: create-items
         run: |
           make VERSION=${{ needs.build_init.outputs.version }} build-release-checksum build-release-plan build-release-proto
-      - name: Upload osx zip artifact
-        if: always() && steps.create-items.outcome == 'success'
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.release_url }}
-          asset_path: ./build/provenance-darwin-amd64-${{ needs.build_init.outputs.version }}.zip
-          asset_name: provenance-darwin-amd64-${{ needs.build_init.outputs.version }}.zip
-          asset_content_type: application/octet-stream
       - name: Upload linux zip artifact
         if: always() && steps.create-items.outcome == 'success'
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
## Description

This PR updates the release github action. The mac binary will no longer be signed, and it will no longer be part of the release artifacts or upgrade plan.

Reasons for this change:
1. The signing was being done by a account that should no longer be doing so.
2. The Provenance Blockchain Foundation doesn't yet have an Apple Developer ID, and the only reason it would get one is for this signing (there are no other Mac/IOS apps).
3. The mac binary is primarily for use by developers who can hopefully build from source without issues, which doesn't require signing.
4. While I can't say for certain that there aren't any validator nodes running the mac binary, I feel like that's a very good probability. MacOS servers aren't very common, even in the cloud world.
5. Fewer macs are running AMD chipsets these days. Github does not have standard ARM runners though, only AMD. So the compiled mac binary is for older hardware and might not even run on current hardware.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
