### PR TITLE
Replace set-output uses in github actions.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,9 +51,13 @@ jobs:
           if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
             TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION}"
           fi
-          echo ::set-output name=version::${VERSION}
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo "Setting output: version=${VERSION}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Setting output: tags=${TAGS}"
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+          created="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          echo "Setting output: created=$created"
+          echo "created=$created" >> "$GITHUB_OUTPUT"
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -39,7 +39,8 @@ jobs:
             branch="$GITHUB_BASE_REF"
           fi
           echo "base-branch: [$branch]"
-          echo "::set-output name=base-branch::$branch"
+          echo "Setting output: base-branch=$branch"
+          echo "base-branch=$branch" >> "$GITHUB_OUTPUT"
       - uses: bufbuild/buf-setup-action@v1.14.0
       - uses: bufbuild/buf-lint-action@v1.0.3
         if: always()

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -38,7 +38,6 @@ jobs:
           if [ -n "$GITHUB_BASE_REF" ]; then
             branch="$GITHUB_BASE_REF"
           fi
-          echo "base-branch: [$branch]"
           echo "Setting output: base-branch=$branch"
           echo "base-branch=$branch" >> "$GITHUB_OUTPUT"
       - uses: bufbuild/buf-setup-action@v1.14.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,10 +134,6 @@ jobs:
           sudo apt-get install -y libgflags-dev libsnappy-dev zlib1g-dev libbz2-dev liblz4-dev libzstd-dev
       - name: Build and install cleveldb
         run: make cleveldb
-      - name: Setup go
-        uses: actions/setup-go@v2.1.5
-        with:
-          go-version: ${{ needs.build_init.outputs.go_version }}
       - name: Build dbmigrate binary
         run: |
           export VERSION=${{ needs.build_init.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,12 +45,12 @@ jobs:
           if [[ "$version" =~ -rc ]]; then
             prerelease=true
           fi
-          echo "version: '$version'"
-          echo "is_release: $is_release"
-          echo "prerelease: $prerelease"
-          echo "::set-output name=version::$version"
-          echo "::set-output name=is_release::$is_release"
-          echo "::set-output name=prerelease::$prerelease"
+          echo "Setting output: version=$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Setting output: is_release=$is_release"
+          echo "is_release=$is_release" >> "$GITHUB_OUTPUT"
+          echo "Setting output: prerelease=$prerelease"
+          echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
     outputs:
       version: ${{ steps.vars.outputs.version }}
       is_release: ${{ steps.vars.outputs.is_release }}

--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -38,9 +38,17 @@ jobs:
       - name: Define Variables
         id: def-vars
         run: |
-          echo "::set-output name=file-prefix::sim-test-${GITHUB_SHA:0:7}-${GITHUB_RUN_ATTEMPT}"
-          echo "::set-output name=db-cache-key-hash::${{ hashFiles('scripts/cleveldb_build_and_install.sh') }}"
-          echo "::set-output name=go-cache-key-hash::${{ hashFiles('go.sum') }}"
+          file_prefix="sim-test-${GITHUB_SHA:0:7}-${GITHUB_RUN_ATTEMPT}"
+          echo "Setting output: file-prefix=$file_prefix"
+          echo "file-prefix=$file_prefix" >> "$GITHUB_OUTPUT"
+
+          db_cache_key_hash="${{ hashFiles('scripts/cleveldb_build_and_install.sh') }}"
+          echo "Setting output: db-cache-key-hash=$db_cache_key_hash"
+          echo "db-cache-key-hash=$db_cache_key_hash" >> "$GITHUB_OUTPUT"
+
+          go_cache_key_hash="${{ hashFiles('go.sum') }}"
+          echo "Setting output: go-cache-key-hash=$go_cache_key_hash"
+          echo "go-cache-key-hash=$go_cache_key_hash" >> "$GITHUB_OUTPUT"
     outputs:
       go-version: 1.18
       should-run: ${{ env.GIT_DIFF }}
@@ -144,7 +152,10 @@ jobs:
           path: ${{ needs.setup.outputs.go-cache-path }}
       - name: Define test-logs
         id: test-logs
-        run: echo "::set-output name=test-logs::${{ needs.setup.outputs.file-prefix }}-${{ matrix.test }}-${{ matrix.db-backend }}-${{ matrix.os }}"
+        run: |
+          test_logs="${{ needs.setup.outputs.file-prefix }}-${{ matrix.test }}-${{ matrix.db-backend }}-${{ matrix.os }}"
+          echo "Setting output: test-logs=$test_logs"
+          echo "test-logs=$test_logs" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ needs.setup.outputs.go-version }}
@@ -205,7 +216,10 @@ jobs:
           path: ${{ needs.setup.outputs.go-cache-path }}
       - name: Define test-logs
         id: test-logs
-        run: echo "::set-output name=test-logs::${{ needs.setup.outputs.file-prefix }}-${{ matrix.test }}-${{ matrix.db-backend }}-${{ matrix.os }}"
+        run: |
+          test-logs="${{ needs.setup.outputs.file-prefix }}-${{ matrix.test }}-${{ matrix.db-backend }}-${{ matrix.os }}"
+          echo "Setting output: test-logs=$test_logs"
+          echo "test-logs=$test_logs" >> "$GITHUB_OUTPUT"
       - name: Install cleveldb
         if: matrix.db-backend == 'cleveldb'
         run: |
@@ -254,7 +268,10 @@ jobs:
           path: ${{ needs.setup.outputs.go-cache-path }}
       - name: Define test-logs
         id: test-logs
-        run: echo "::set-output name=test-logs::${{ needs.setup.outputs.file-prefix }}-${{ matrix.test }}-${{ matrix.os }}"
+        run: |
+          test-logs="${{ needs.setup.outputs.file-prefix }}-${{ matrix.test }}-${{ matrix.os }}"
+          echo "Setting output: test-logs=$test_logs"
+          echo "test-logs=$test_logs" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ needs.setup.outputs.go-version }}

--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -215,7 +215,7 @@ jobs:
       - name: Define test-logs
         id: test-logs
         run: |
-          test-logs="${{ needs.setup.outputs.file-prefix }}-${{ matrix.test }}-${{ matrix.db-backend }}-${{ matrix.os }}"
+          test_logs="${{ needs.setup.outputs.file-prefix }}-${{ matrix.test }}-${{ matrix.db-backend }}-${{ matrix.os }}"
           echo "Setting output: test-logs=$test_logs"
           echo "test-logs=$test_logs" >> "$GITHUB_OUTPUT"
       - name: Install cleveldb
@@ -267,7 +267,7 @@ jobs:
       - name: Define test-logs
         id: test-logs
         run: |
-          test-logs="${{ needs.setup.outputs.file-prefix }}-${{ matrix.test }}-${{ matrix.os }}"
+          test_logs="${{ needs.setup.outputs.file-prefix }}-${{ matrix.test }}-${{ matrix.os }}"
           echo "Setting output: test-logs=$test_logs"
           echo "test-logs=$test_logs" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-go@v3

--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -41,11 +41,9 @@ jobs:
           file_prefix="sim-test-${GITHUB_SHA:0:7}-${GITHUB_RUN_ATTEMPT}"
           echo "Setting output: file-prefix=$file_prefix"
           echo "file-prefix=$file_prefix" >> "$GITHUB_OUTPUT"
-
           db_cache_key_hash="${{ hashFiles('scripts/cleveldb_build_and_install.sh') }}"
           echo "Setting output: db-cache-key-hash=$db_cache_key_hash"
           echo "db-cache-key-hash=$db_cache_key_hash" >> "$GITHUB_OUTPUT"
-
           go_cache_key_hash="${{ hashFiles('go.sum') }}"
           echo "Setting output: go-cache-key-hash=$go_cache_key_hash"
           echo "go-cache-key-hash=$go_cache_key_hash" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,8 +34,12 @@ jobs:
       - name: Define Variables
         id: def-vars
         run: |
-          echo "::set-output name=cache-key::${{ runner.os }}-unit-tests-${{ hashFiles('scripts/cleveldb_build_and_install.sh', '.github/workflows/test.yml') }}"
-          echo "::set-output name=file-prefix::${GITHUB_SHA:0:7}-${GITHUB_RUN_ATTEMPT}"
+          cache_key="${{ runner.os }}-unit-tests-${{ hashFiles('scripts/cleveldb_build_and_install.sh', '.github/workflows/test.yml') }}"
+          echo "Setting output: cache-key=$cache_key"
+          echo "cache-key=$cache_key" >> "$GITHUB_OUTPUT"
+          file_prefix="${GITHUB_SHA:0:7}-${GITHUB_RUN_ATTEMPT}"
+          echo "Setting output: file-prefix=$file_prefix"
+          echo "file-prefix=$file_prefix" >> "$GITHUB_OUTPUT"
       - name: Create a file with all the pkgs
         run: go list ./... > pkgs.txt
       - uses: actions/upload-artifact@v3

--- a/scripts/protoball.sh
+++ b/scripts/protoball.sh
@@ -45,4 +45,5 @@ done
 
 # Formatted for gh workflow action
 echo
-echo "::set-output name=protos::$zip"
+echo "Setting output: protos=$zip"
+[ -n "$GITHUB_OUTPUT" ] && echo "protos=$zip" >> "$GITHUB_OUTPUT"

--- a/scripts/protoball.sh
+++ b/scripts/protoball.sh
@@ -46,4 +46,6 @@ done
 # Formatted for gh workflow action
 echo
 echo "Setting output: protos=$zip"
-[ -n "$GITHUB_OUTPUT" ] && echo "protos=$zip" >> "$GITHUB_OUTPUT"
+if [ -n "$GITHUB_OUTPUT" ]; then
+  echo "protos=$zip" >> "$GITHUB_OUTPUT"
+fi


### PR DESCRIPTION
## Description

closes: #1200 

Replace uses of the deprecated `set-output` github directive.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
