### PR TITLE
Ignore the home field when adding a config map to viper.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * Fix third party Protobuf workflow checks on Provenance release steps [#1339](https://github.com/provenance-io/provenance/issues/1339)
 * Fix committer email format in third party Protobuf workflow (for [#1339](https://github.com/provenance-io/provenance/issues/1339)) [PR 1385](https://github.com/provenance-io/provenance/pull/1385)
+* Fix `start` using default home directory [PR 1393](https://github.com/provenance-io/provenance/pull/1393).
 
 ---
 
@@ -75,11 +76,11 @@ The `paua` upgrade will increase all validators' max commission to 100% and max 
   [PR 1334](https://github.com/provenance-io/provenance/pull/1334),
   [PR 1348](https://github.com/provenance-io/provenance/pull/1348),
   [PR 1317](https://github.com/provenance-io/provenance/pull/1317),
-  [PR 1278](https://github.com/provenance-io/provenance/pull/1278).  
+  [PR 1278](https://github.com/provenance-io/provenance/pull/1278). \
   See the following `RELEASE_NOTES.md` for details:
   [v0.46.10-pio-1](https://github.com/provenance-io/cosmos-sdk/blob/v0.46.10-pio-1/RELEASE_NOTES.md),
   [v0.46.8-pio-3](https://github.com/provenance-io/cosmos-sdk/blob/v0.46.8-pio-3/RELEASE_NOTES.md),
-  [v0.46.7-pio-1](https://github.com/provenance-io/cosmos-sdk/blob/v0.46.7-pio-1/RELEASE_NOTES.md).  
+  [v0.46.7-pio-1](https://github.com/provenance-io/cosmos-sdk/blob/v0.46.7-pio-1/RELEASE_NOTES.md). \
   Full Commit History: https://github.com/provenance-io/cosmos-sdk/compare/v0.46.6-pio-1...v0.46.10-pio-1
 * Added assess msg fees spec documentation [#1172](https://github.com/provenance-io/provenance/issues/1172).
 * Build dbmigrate and include it as an artifact with releases [#1264](https://github.com/provenance-io/provenance/issues/1264).

--- a/cmd/provenanced/config/manager.go
+++ b/cmd/provenanced/config/manager.go
@@ -546,6 +546,14 @@ func addFieldMapToViper(vpr *viper.Viper, fvmap FieldValueMap) error {
 	if err != nil {
 		return err
 	}
+	// The TM BaseConfig struct has a RootDir field with the mapstruct name "home".
+	// So the fvmap created from a TM config struct will have a "home" entry with a value of "".
+	// If we were to then include that when calling MergeConfigMap, it would tell viper that the "home" value is "".
+	// This prevents the default value (defined with the --home flag) from being used.
+	// Since the "home" value defines where the config files are, it's safe to assume none of the config
+	// files will contain a "home" field that we need to pay attention to.
+	// So for this, remove the "home" field from the configMap before calling MergeConfigMap.
+	delete(configMap, flags.FlagHome)
 	return vpr.MergeConfigMap(configMap)
 }
 


### PR DESCRIPTION
## Description

In the config manager, when loading a config map into viper, do not include the "home" field.

The Tendermint BaseConfig struct has this field:
```
RootDir string `mapstructure:"home"`
```

So when we convert a `tendermint.Config` into a field value map, it will have a "home" entry. The `DefaultConfig()` has it as `""`, and it's not a field in the tendermint config file. So it will almost always be `""`. Then, when we provide the field value map to viper, viper thinks, "I have been given `""` as the `"home"` value, so I don't need to use the default (defined with the command's flags)." Later, whenever anyone asks viper to `.Get(flags.FlagHome)`, an empty string is returned. 

I verified this by:
1. Adding some `fmt.Printf("home dir: \"%v\"\n", vpr.Get(flags.FlagHome))` lines before and after tm config stuff in `loadUnpackedConfig`.
2. Deleting the `data/` dir from my local default config location (`/Users/danielwedul/Library/Application Support/Provenance`).
3. Running `provenanced start` in an environment that doesn't have a `PIO_HOME` defined.

Before the fix in this PR:
1. Those log lines showed a `""` after calling `addFieldMapToViper` with the default tendermint config struct.
2. The app panicked with `panic: mkdir data/snapshots: no such file or directory` (where `.Get(flags.FlagHome)` is called).

After the fix in this PR:
1. All those log lines show the correct home dir.
2. The app stops with a message of `open /Users/danielwedul/Library/Application Support/Provenance/data/priv_validator_state.json: no such file or directory` which is expected since I had deleted that `data` dir.
3. The app creates that `data/snapshots` directory as expected.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
