### PR TITLE
Backport: Ignore the home field when adding a config map to viper. (#1393)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,9 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
-* nothing
+### Bug Fixes
+
+* Fix `start` using default home directory [PR 1393](https://github.com/provenance-io/provenance/pull/1393).
 
 ---
 

--- a/cmd/provenanced/config/manager.go
+++ b/cmd/provenanced/config/manager.go
@@ -546,6 +546,14 @@ func addFieldMapToViper(vpr *viper.Viper, fvmap FieldValueMap) error {
 	if err != nil {
 		return err
 	}
+	// The TM BaseConfig struct has a RootDir field with the mapstruct name "home".
+	// So the fvmap created from a TM config struct will have a "home" entry with a value of "".
+	// If we were to then include that when calling MergeConfigMap, it would tell viper that the "home" value is "".
+	// This prevents the default value (defined with the --home flag) from being used.
+	// Since the "home" value defines where the config files are, it's safe to assume none of the config
+	// files will contain a "home" field that we need to pay attention to.
+	// So for this, remove the "home" field from the configMap before calling MergeConfigMap.
+	delete(configMap, flags.FlagHome)
 	return vpr.MergeConfigMap(configMap)
 }
 


### PR DESCRIPTION
## Description

Backport of #1393 to `release/v1.14.x`.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
