### PR TITLE
Fix make proto-gen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ blockade.yaml
 keyring-*
 vendor/
 *.account
+.go.mod.bak
 
 # VS Code
 .history/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * Fix third party Protobuf workflow checks on Provenance release steps [#1339](https://github.com/provenance-io/provenance/issues/1339)
 * Fix committer email format in third party Protobuf workflow (for [#1339](https://github.com/provenance-io/provenance/issues/1339)) [PR 1385](https://github.com/provenance-io/provenance/pull/1385)
 * Fix `start` using default home directory [PR 1393](https://github.com/provenance-io/provenance/pull/1393).
+* Fix `make proto-gen` [PR 1404](https://github.com/provenance-io/provenance/pull/1404).
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -570,12 +570,14 @@ containerProtoFmt=prov-proto-fmt-$(containerProtoVer)
 
 proto-gen:
 	@echo "Generating Protobuf files"
+	cp go.mod .go.mod.bak
 	if docker ps -a --format '{{.Names}}' | grep -Eq "^${containerProtoGen}$$"; then \
 		docker start -a $(containerProtoGen); \
 	else \
 		docker run --name $(containerProtoGen) -v $(CURDIR):/workspace --workdir /workspace $(containerProtoImage) \
 			sh ./scripts/protocgen.sh; \
 	fi
+	mv .go.mod.bak go.mod
 	go mod tidy
 
 # This generates the SDK's custom wrapper for google.protobuf.Any. It should only be run manually when needed


### PR DESCRIPTION
## Description

Fixes the `make proto-gen` error:
```
$ make proto-gen
<snip>
go mod tidy
go: finding module for package github.com/btcsuite/btcd/btcec
github.com/provenance-io/provenance/x/metadata/types imports
	github.com/btcsuite/btcd/btcec: module github.com/btcsuite/btcd@latest found (v0.23.4), but does not contain package github.com/btcsuite/btcd/btcec
make: *** [proto-gen] Error 1
```

The `go.mod` file is being updated by the docker container that does the work. This PR updates the make target to back up `go.mod` first, then gen, then restore it before doing `go mod tidy`.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
