### PR TITLE
Require smart contract signers to either be a party or be authorized by other signers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * Expand the `additional_bindings` gRPC tag to use object form to allow for Typescript transpiling [#1405](https://github.com/provenance-io/provenance/issues/1405).
 * Add attribute cli command to query account addresses by attribute name [#1451](https://github.com/provenance-io/provenance/issues/1451).
 * Add removal of attributes from accounts on name deletion [#1410](https://github.com/provenance-io/provenance/issues/1410).
+* Enhance ability of smart contracts to use the metadata module [#1280](https://github.com/provenance-io/provenance/issues/1280).
 
 ### Deprecated
 

--- a/x/metadata/client/cli/cli_test.go
+++ b/x/metadata/client/cli/cli_test.go
@@ -163,8 +163,8 @@ func (s *IntegrationCLITestSuite) SetupSuite() {
 	var authData authtypes.GenesisState
 	authData.Params = authtypes.DefaultParams()
 	genAccounts = append(genAccounts, authtypes.NewBaseAccount(s.accountAddr, nil, 3, 0))
-	genAccounts = append(genAccounts, authtypes.NewBaseAccount(s.user1Addr, nil, 4, 0))
-	genAccounts = append(genAccounts, authtypes.NewBaseAccount(s.user2Addr, nil, 5, 0))
+	genAccounts = append(genAccounts, authtypes.NewBaseAccount(s.user1Addr, nil, 4, 1))
+	genAccounts = append(genAccounts, authtypes.NewBaseAccount(s.user2Addr, nil, 5, 1))
 	genAccounts = append(genAccounts, authtypes.NewBaseAccount(s.user3Addr, nil, 6, 0))
 	accounts, err := authtypes.PackAccounts(genAccounts)
 	s.Require().NoError(err)

--- a/x/metadata/keeper/export_test.go
+++ b/x/metadata/keeper/export_test.go
@@ -166,6 +166,16 @@ func (k Keeper) IsWasmAccount(ctx sdk.Context, addr sdk.AccAddress) bool {
 	return k.isWasmAccount(ctx, addr)
 }
 
+// ValidateAllRequiredSigned is a TEST ONLY exposure of validateAllRequiredSigned.
+func (k Keeper) ValidateAllRequiredSigned(ctx sdk.Context, required []string, msg types.MetadataMsg) ([]*PartyDetails, error) {
+	return k.validateAllRequiredSigned(ctx, required, msg)
+}
+
+// ValidateSmartContractSigners is a TEST ONLY exposure of validateSmartContractSigners.
+func (k Keeper) ValidateSmartContractSigners(ctx sdk.Context, usedSigners map[string]bool, msg types.MetadataMsg) error {
+	return k.validateSmartContractSigners(ctx, usedSigners, msg)
+}
+
 var (
 	// ValidateRolesPresent is a TEST ONLY exposure of validateRolesPresent.
 	ValidateRolesPresent = validateRolesPresent

--- a/x/metadata/keeper/export_test.go
+++ b/x/metadata/keeper/export_test.go
@@ -161,6 +161,11 @@ func (k Keeper) ValidateProvenanceRole(ctx sdk.Context, parties []*PartyDetails)
 	return k.validateProvenanceRole(ctx, parties)
 }
 
+// IsWasmAccount is a TEST ONLY exposure of isWasmAccount.
+func (k Keeper) IsWasmAccount(ctx sdk.Context, addr sdk.AccAddress) bool {
+	return k.isWasmAccount(ctx, addr)
+}
+
 var (
 	// ValidateRolesPresent is a TEST ONLY exposure of validateRolesPresent.
 	ValidateRolesPresent = validateRolesPresent

--- a/x/metadata/keeper/export_test.go
+++ b/x/metadata/keeper/export_test.go
@@ -111,6 +111,16 @@ func (c *AuthzCache) AcceptableMap() map[string]authz.Authorization {
 	return c.acceptable
 }
 
+// ValidateAllRequiredPartiesSigned is a TEST ONLY exposure of validateAllRequiredPartiesSigned.
+func (k Keeper) ValidateAllRequiredPartiesSigned(
+	ctx sdk.Context,
+	reqParties, availableParties []types.Party,
+	reqRoles []types.PartyType,
+	msg types.MetadataMsg,
+) ([]*PartyDetails, error) {
+	return k.validateAllRequiredPartiesSigned(ctx, reqParties, availableParties, reqRoles, msg)
+}
+
 var (
 	// AssociateSigners is a TEST ONLY exposure of associateSigners.
 	AssociateSigners = associateSigners

--- a/x/metadata/keeper/keeper.go
+++ b/x/metadata/keeper/keeper.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 
 	"github.com/provenance-io/provenance/x/metadata/types"
@@ -145,11 +144,6 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 }
 
 var _ MetadataKeeperI = &Keeper{}
-
-// GetAccount looks up an account by address
-func (k Keeper) GetAccount(ctx sdk.Context, addr sdk.AccAddress) authtypes.AccountI {
-	return k.authKeeper.GetAccount(ctx, addr)
-}
 
 // VerifyCorrectOwner to determines whether the signer resolves to the owner of the OSLocator record.
 func (k Keeper) VerifyCorrectOwner(ctx sdk.Context, ownerAddr sdk.AccAddress) bool {

--- a/x/metadata/keeper/msg_server.go
+++ b/x/metadata/keeper/msg_server.go
@@ -273,7 +273,7 @@ func (k msgServer) WriteScopeSpecification(
 	var existing *types.ScopeSpecification
 	if e, found := k.GetScopeSpecification(ctx, msg.Specification.SpecificationId); found {
 		existing = &e
-		if _, err := k.ValidateSignersWithoutParties(ctx, existing.OwnerAddresses, msg); err != nil {
+		if err := k.ValidateSignersWithoutParties(ctx, existing.OwnerAddresses, msg); err != nil {
 			return nil, err
 		}
 	}
@@ -298,7 +298,7 @@ func (k msgServer) DeleteScopeSpecification(
 	if !found {
 		return nil, fmt.Errorf("scope specification not found with id %s", msg.SpecificationId)
 	}
-	if _, err := k.ValidateSignersWithoutParties(ctx, existing.OwnerAddresses, msg); err != nil {
+	if err := k.ValidateSignersWithoutParties(ctx, existing.OwnerAddresses, msg); err != nil {
 		return nil, err
 	}
 
@@ -323,7 +323,7 @@ func (k msgServer) WriteContractSpecification(
 	var existing *types.ContractSpecification
 	if e, found := k.GetContractSpecification(ctx, msg.Specification.SpecificationId); found {
 		existing = &e
-		if _, err := k.ValidateSignersWithoutParties(ctx, existing.OwnerAddresses, msg); err != nil {
+		if err := k.ValidateSignersWithoutParties(ctx, existing.OwnerAddresses, msg); err != nil {
 			return nil, err
 		}
 	}
@@ -348,7 +348,7 @@ func (k msgServer) DeleteContractSpecification(
 	if !found {
 		return nil, fmt.Errorf("contract specification not found with id %s", msg.SpecificationId)
 	}
-	if _, err := k.ValidateSignersWithoutParties(ctx, existing.OwnerAddresses, msg); err != nil {
+	if err := k.ValidateSignersWithoutParties(ctx, existing.OwnerAddresses, msg); err != nil {
 		return nil, err
 	}
 
@@ -400,7 +400,7 @@ func (k msgServer) AddContractSpecToScopeSpec(
 	if !found {
 		return nil, fmt.Errorf("scope specification not found with id %s", msg.ScopeSpecificationId)
 	}
-	if _, err := k.ValidateSignersWithoutParties(ctx, scopeSpec.OwnerAddresses, msg); err != nil {
+	if err := k.ValidateSignersWithoutParties(ctx, scopeSpec.OwnerAddresses, msg); err != nil {
 		return nil, err
 	}
 
@@ -427,7 +427,7 @@ func (k msgServer) DeleteContractSpecFromScopeSpec(
 	if !found {
 		return nil, fmt.Errorf("scope specification not found with id %s", msg.ScopeSpecificationId)
 	}
-	if _, err := k.ValidateSignersWithoutParties(ctx, scopeSpec.OwnerAddresses, msg); err != nil {
+	if err := k.ValidateSignersWithoutParties(ctx, scopeSpec.OwnerAddresses, msg); err != nil {
 		return nil, err
 	}
 
@@ -472,7 +472,7 @@ func (k msgServer) WriteRecordSpecification(
 		return nil, fmt.Errorf("contract specification not found with id %s (uuid %s) required for adding or updating record specification with id %s",
 			contractSpecID, contractSpecUUID, msg.Specification.SpecificationId)
 	}
-	if _, err = k.ValidateSignersWithoutParties(ctx, contractSpec.OwnerAddresses, msg); err != nil {
+	if err = k.ValidateSignersWithoutParties(ctx, contractSpec.OwnerAddresses, msg); err != nil {
 		return nil, err
 	}
 
@@ -510,7 +510,7 @@ func (k msgServer) DeleteRecordSpecification(
 		return nil, fmt.Errorf("contract specification not found with id %s required for deleting record specification with id %s",
 			contractSpecID, msg.SpecificationId)
 	}
-	if _, err := k.ValidateSignersWithoutParties(ctx, contractSpec.OwnerAddresses, msg); err != nil {
+	if err := k.ValidateSignersWithoutParties(ctx, contractSpec.OwnerAddresses, msg); err != nil {
 		return nil, err
 	}
 

--- a/x/metadata/keeper/record.go
+++ b/x/metadata/keeper/record.go
@@ -206,7 +206,7 @@ func (k Keeper) ValidateWriteRecord(
 		if oldSession != nil {
 			reqParties = append(reqParties, oldSession.Parties...)
 		}
-		if _, err = k.ValidateSignersWithParties(ctx, reqParties, session.Parties, recSpec.ResponsibleParties, msg); err != nil {
+		if err = k.ValidateSignersWithParties(ctx, reqParties, session.Parties, recSpec.ResponsibleParties, msg); err != nil {
 			return err
 		}
 	}
@@ -343,7 +343,7 @@ func (k Keeper) ValidateDeleteRecord(ctx sdk.Context, proposedID types.MetadataA
 				return err
 			}
 		} else {
-			if _, err := k.ValidateSignersWithParties(ctx, scope.Owners, scope.Owners, reqSpec.ResponsibleParties, msg); err != nil {
+			if err := k.ValidateSignersWithParties(ctx, scope.Owners, scope.Owners, reqSpec.ResponsibleParties, msg); err != nil {
 				return err
 			}
 		}

--- a/x/metadata/keeper/record.go
+++ b/x/metadata/keeper/record.go
@@ -192,7 +192,7 @@ func (k Keeper) ValidateWriteRecord(
 		if oldSession != nil {
 			reqSigs = append(reqSigs, oldSession.GetAllPartyAddresses()...)
 		}
-		if _, err = k.ValidateSignersWithoutParties(ctx, reqSigs, msg); err != nil {
+		if err = k.ValidateSignersWithoutParties(ctx, reqSigs, msg); err != nil {
 			return err
 		}
 	} else {
@@ -329,7 +329,7 @@ func (k Keeper) ValidateDeleteRecord(ctx sdk.Context, proposedID types.MetadataA
 	case !scope.RequirePartyRollup:
 		// Old:
 		//   - All scope owners must sign.
-		if _, err := k.ValidateSignersWithoutParties(ctx, scope.GetAllOwnerAddresses(), msg); err != nil {
+		if err := k.ValidateSignersWithoutParties(ctx, scope.GetAllOwnerAddresses(), msg); err != nil {
 			return err
 		}
 	default:
@@ -339,7 +339,7 @@ func (k Keeper) ValidateDeleteRecord(ctx sdk.Context, proposedID types.MetadataA
 		reqSpec, found := k.GetRecordSpecification(ctx, record.SpecificationId)
 		if !found {
 			// If the record spec doesn't exist, only check for optional=false signers.
-			if _, err := k.ValidateSignersWithoutParties(ctx, types.GetRequiredPartyAddresses(scope.Owners), msg); err != nil {
+			if err := k.ValidateSignersWithoutParties(ctx, types.GetRequiredPartyAddresses(scope.Owners), msg); err != nil {
 				return err
 			}
 		} else {

--- a/x/metadata/keeper/scope.go
+++ b/x/metadata/keeper/scope.go
@@ -323,7 +323,7 @@ func (k Keeper) ValidateWriteScope(
 			}
 			// Note: This means that a scope can be initially written without consideration for signers and roles.
 			if existing != nil {
-				if validatedParties, err = k.ValidateSignersWithParties(ctx, existing.Owners, existing.Owners, scopeSpec.PartiesInvolved, msg); err != nil {
+				if validatedParties, err = k.validateAllRequiredPartiesSigned(ctx, existing.Owners, existing.Owners, scopeSpec.PartiesInvolved, msg); err != nil {
 					return err
 				}
 			} else {
@@ -381,7 +381,7 @@ func (k Keeper) ValidateDeleteScope(ctx sdk.Context, msg *types.MsgDeleteScopeRe
 				return err
 			}
 		} else {
-			if validatedParties, err = k.ValidateSignersWithParties(ctx, scope.Owners, scope.Owners, scopeSpec.PartiesInvolved, msg); err != nil {
+			if validatedParties, err = k.validateAllRequiredPartiesSigned(ctx, scope.Owners, scope.Owners, scopeSpec.PartiesInvolved, msg); err != nil {
 				return err
 			}
 		}
@@ -445,7 +445,7 @@ func (k Keeper) ValidateAddScopeDataAccess(
 		if !found {
 			return fmt.Errorf("scope specification %s not found", existing.SpecificationId)
 		}
-		if _, err := k.ValidateSignersWithParties(ctx, existing.Owners, existing.Owners, scopeSpec.PartiesInvolved, msg); err != nil {
+		if err := k.ValidateSignersWithParties(ctx, existing.Owners, existing.Owners, scopeSpec.PartiesInvolved, msg); err != nil {
 			return err
 		}
 	}
@@ -497,7 +497,7 @@ dataAccessLoop:
 		if !found {
 			return fmt.Errorf("scope specification %s not found", existing.SpecificationId)
 		}
-		if _, err := k.ValidateSignersWithParties(ctx, existing.Owners, existing.Owners, scopeSpec.PartiesInvolved, msg); err != nil {
+		if err := k.ValidateSignersWithParties(ctx, existing.Owners, existing.Owners, scopeSpec.PartiesInvolved, msg); err != nil {
 			return err
 		}
 	}
@@ -545,7 +545,7 @@ func (k Keeper) ValidateUpdateScopeOwners(
 		if err := validateRolesPresent(proposed.Owners, scopeSpec.PartiesInvolved); err != nil {
 			return err
 		}
-		if _, err := k.ValidateSignersWithParties(ctx, existing.Owners, existing.Owners, scopeSpec.PartiesInvolved, msg); err != nil {
+		if err := k.ValidateSignersWithParties(ctx, existing.Owners, existing.Owners, scopeSpec.PartiesInvolved, msg); err != nil {
 			return err
 		}
 	}

--- a/x/metadata/keeper/scope.go
+++ b/x/metadata/keeper/scope.go
@@ -294,6 +294,13 @@ func (k Keeper) ValidateWriteScope(
 	var validatedParties []*PartyDetails
 	checkSigners := true
 
+	if err = validateRolesPresent(proposed.Owners, scopeSpec.PartiesInvolved); err != nil {
+		return err
+	}
+	if err = k.validateProvenanceRole(ctx, BuildPartyDetails(nil, proposed.Owners)); err != nil {
+		return err
+	}
+
 	if !onlyChangeIsValueOwner {
 		// Make sure everyone has signed.
 		if (existing != nil && !existing.RequirePartyRollup) || (existing == nil && !proposed.RequirePartyRollup) {
@@ -301,12 +308,6 @@ func (k Keeper) ValidateWriteScope(
 			//   - All roles required by the scope spec must have a party in the owners.
 			//   - If not new, all existing owners must sign.
 			//   - Value owner signer restrictions are applied.
-			if err = validateRolesPresent(proposed.Owners, scopeSpec.PartiesInvolved); err != nil {
-				return err
-			}
-			if err = k.validateProvenanceRole(ctx, BuildPartyDetails(nil, proposed.Owners)); err != nil {
-				return err
-			}
 			if existing != nil && !existing.Equals(proposed) {
 				if validatedParties, err = k.validateAllRequiredSigned(ctx, existing.GetAllOwnerAddresses(), msg); err != nil {
 					return err
@@ -321,12 +322,6 @@ func (k Keeper) ValidateWriteScope(
 			//   - If not new, all roles required by the scope spec must have a signer and
 			//     associated party from the existing scope.
 			//   - Value owner signer restrictions are applied.
-			if err = validateRolesPresent(proposed.Owners, scopeSpec.PartiesInvolved); err != nil {
-				return err
-			}
-			if err = k.validateProvenanceRole(ctx, BuildPartyDetails(nil, proposed.Owners)); err != nil {
-				return err
-			}
 			// Note: This means that a scope can be initially written without consideration for signers and roles.
 			if existing != nil {
 				if validatedParties, err = k.validateAllRequiredPartiesSigned(ctx, existing.Owners, existing.Owners, scopeSpec.PartiesInvolved, msg); err != nil {
@@ -527,6 +522,13 @@ func (k Keeper) ValidateUpdateScopeOwners(
 		return fmt.Errorf("scope specification %s not found", proposed.SpecificationId)
 	}
 
+	if err := validateRolesPresent(proposed.Owners, scopeSpec.PartiesInvolved); err != nil {
+		return err
+	}
+	if err := k.validateProvenanceRole(ctx, BuildPartyDetails(nil, proposed.Owners)); err != nil {
+		return err
+	}
+
 	// Make sure everyone has signed.
 	if !existing.RequirePartyRollup {
 		// Old:
@@ -534,12 +536,6 @@ func (k Keeper) ValidateUpdateScopeOwners(
 		//   - If not new, all existing owners must sign.
 		//   - Value owner signer restrictions are applied.
 		// The value owner isn't changing so we don't care about that one.
-		if err := validateRolesPresent(proposed.Owners, scopeSpec.PartiesInvolved); err != nil {
-			return err
-		}
-		if err := k.validateProvenanceRole(ctx, BuildPartyDetails(nil, proposed.Owners)); err != nil {
-			return err
-		}
 		if err := k.ValidateSignersWithoutParties(ctx, existing.GetAllOwnerAddresses(), msg); err != nil {
 			return err
 		}
@@ -551,12 +547,6 @@ func (k Keeper) ValidateUpdateScopeOwners(
 		//     associated party from the existing scope.
 		//   - Value owner signer restrictions are applied.
 		// The value owner isn't changing so we don't care about that one.
-		if err := validateRolesPresent(proposed.Owners, scopeSpec.PartiesInvolved); err != nil {
-			return err
-		}
-		if err := k.validateProvenanceRole(ctx, BuildPartyDetails(nil, proposed.Owners)); err != nil {
-			return err
-		}
 		validatedParties, err := k.validateAllRequiredPartiesSigned(ctx, existing.Owners, existing.Owners, scopeSpec.PartiesInvolved, msg)
 		if err != nil {
 			return err

--- a/x/metadata/keeper/scope.go
+++ b/x/metadata/keeper/scope.go
@@ -304,6 +304,9 @@ func (k Keeper) ValidateWriteScope(
 			if err = validateRolesPresent(proposed.Owners, scopeSpec.PartiesInvolved); err != nil {
 				return err
 			}
+			if err = k.validateProvenanceRole(ctx, BuildPartyDetails(nil, proposed.Owners)); err != nil {
+				return err
+			}
 			if existing != nil && !existing.Equals(proposed) {
 				if validatedParties, err = k.validateAllRequiredSigned(ctx, existing.GetAllOwnerAddresses(), msg); err != nil {
 					return err
@@ -319,6 +322,9 @@ func (k Keeper) ValidateWriteScope(
 			//     associated party from the existing scope.
 			//   - Value owner signer restrictions are applied.
 			if err = validateRolesPresent(proposed.Owners, scopeSpec.PartiesInvolved); err != nil {
+				return err
+			}
+			if err = k.validateProvenanceRole(ctx, BuildPartyDetails(nil, proposed.Owners)); err != nil {
 				return err
 			}
 			// Note: This means that a scope can be initially written without consideration for signers and roles.
@@ -531,6 +537,9 @@ func (k Keeper) ValidateUpdateScopeOwners(
 		if err := validateRolesPresent(proposed.Owners, scopeSpec.PartiesInvolved); err != nil {
 			return err
 		}
+		if err := k.validateProvenanceRole(ctx, BuildPartyDetails(nil, proposed.Owners)); err != nil {
+			return err
+		}
 		if err := k.ValidateSignersWithoutParties(ctx, existing.GetAllOwnerAddresses(), msg); err != nil {
 			return err
 		}
@@ -545,7 +554,14 @@ func (k Keeper) ValidateUpdateScopeOwners(
 		if err := validateRolesPresent(proposed.Owners, scopeSpec.PartiesInvolved); err != nil {
 			return err
 		}
-		if err := k.ValidateSignersWithParties(ctx, existing.Owners, existing.Owners, scopeSpec.PartiesInvolved, msg); err != nil {
+		if err := k.validateProvenanceRole(ctx, BuildPartyDetails(nil, proposed.Owners)); err != nil {
+			return err
+		}
+		validatedParties, err := k.validateAllRequiredPartiesSigned(ctx, existing.Owners, existing.Owners, scopeSpec.PartiesInvolved, msg)
+		if err != nil {
+			return err
+		}
+		if err = k.validateSmartContractSigners(ctx, GetAllSigners(validatedParties), msg); err != nil {
 			return err
 		}
 	}

--- a/x/metadata/keeper/scope.go
+++ b/x/metadata/keeper/scope.go
@@ -292,7 +292,6 @@ func (k Keeper) ValidateWriteScope(
 
 	var err error
 	var validatedParties []*PartyDetails
-	checkSigners := true
 
 	if err = validateRolesPresent(proposed.Owners, scopeSpec.PartiesInvolved); err != nil {
 		return err
@@ -312,8 +311,6 @@ func (k Keeper) ValidateWriteScope(
 				if validatedParties, err = k.validateAllRequiredSigned(ctx, existing.GetAllOwnerAddresses(), msg); err != nil {
 					return err
 				}
-			} else {
-				checkSigners = false
 			}
 		} else {
 			// New:
@@ -327,8 +324,6 @@ func (k Keeper) ValidateWriteScope(
 				if validatedParties, err = k.validateAllRequiredPartiesSigned(ctx, existing.Owners, existing.Owners, scopeSpec.PartiesInvolved, msg); err != nil {
 					return err
 				}
-			} else {
-				checkSigners = false
 			}
 		}
 	}
@@ -338,10 +333,8 @@ func (k Keeper) ValidateWriteScope(
 		return err
 	}
 
-	if checkSigners {
-		if err = k.validateSmartContractSigners(ctx, usedSigners, msg); err != nil {
-			return err
-		}
+	if err = k.validateSmartContractSigners(ctx, usedSigners, msg); err != nil {
+		return err
 	}
 
 	return nil

--- a/x/metadata/keeper/scope_test.go
+++ b/x/metadata/keeper/scope_test.go
@@ -1412,8 +1412,15 @@ func (s *ScopeKeeperTestSuite) TestValidateScopeUpdateOwners() {
 			name:     "smart contract without provenance role removed",
 			existing: scopeWithOwners(ownerPartyList(s.user1, s.scUser)),
 			proposed: scopeWithOwners(ownerPartyList(s.user1)),
-			signers:  []string{s.user1, s.scUser},
+			signers:  []string{s.scUser, s.user1},
 			errorMsg: "",
+		},
+		{
+			name:     "smart contract without provenance role removed but wrong signer order",
+			existing: scopeWithOwners(ownerPartyList(s.user1, s.scUser)),
+			proposed: scopeWithOwners(ownerPartyList(s.user1)),
+			signers:  []string{s.user1, s.scUser},
+			errorMsg: "smart contract signer " + s.scUser + " cannot follow non-smart-contract signer",
 		},
 		{
 			name:     "with rollup smart contract without provenance role added",

--- a/x/metadata/keeper/session.go
+++ b/x/metadata/keeper/session.go
@@ -166,6 +166,9 @@ func (k Keeper) ValidateWriteSession(ctx sdk.Context, existing *types.Session, m
 		if err = validateRolesPresent(proposed.Parties, contractSpec.PartiesInvolved); err != nil {
 			return err
 		}
+		if err = k.validateProvenanceRole(ctx, BuildPartyDetails(nil, proposed.Parties)); err != nil {
+			return err
+		}
 		if err = k.ValidateSignersWithoutParties(ctx, scope.GetAllOwnerAddresses(), msg); err != nil {
 			return err
 		}
@@ -184,14 +187,19 @@ func (k Keeper) ValidateWriteSession(ctx sdk.Context, existing *types.Session, m
 		var availableParties []types.Party
 		var reqParties []types.Party
 		if existing != nil {
+			availableParties = existing.Parties
+			// Providing the existing parties to ValidateSignersWithParties, so we need to check some stuff on proposed.
 			if err = validateRolesPresent(proposed.Parties, contractSpec.PartiesInvolved); err != nil {
 				return err
 			}
-			availableParties = existing.Parties
+			if err = k.validateProvenanceRole(ctx, BuildPartyDetails(nil, proposed.Parties)); err != nil {
+				return err
+			}
 			reqParties = append(reqParties, existing.Parties...)
 		} else {
-			// We don't call validateRolesPresent here because proposed.Parties is being provided to ValidateSignersWithParties.
 			availableParties = proposed.Parties
+			// We don't call validateRolesPresent or validateProvenanceRole here because proposed.Parties is being
+			// provided to ValidateSignersWithParties, which does those.
 		}
 		reqParties = append(reqParties, scope.Owners...)
 		if err = k.ValidateSignersWithParties(ctx, reqParties, availableParties, contractSpec.PartiesInvolved, msg); err != nil {

--- a/x/metadata/keeper/session.go
+++ b/x/metadata/keeper/session.go
@@ -194,7 +194,7 @@ func (k Keeper) ValidateWriteSession(ctx sdk.Context, existing *types.Session, m
 			availableParties = proposed.Parties
 		}
 		reqParties = append(reqParties, scope.Owners...)
-		if _, err = k.ValidateSignersWithParties(ctx, reqParties, availableParties, contractSpec.PartiesInvolved, msg); err != nil {
+		if err = k.ValidateSignersWithParties(ctx, reqParties, availableParties, contractSpec.PartiesInvolved, msg); err != nil {
 			return err
 		}
 	}

--- a/x/metadata/keeper/session.go
+++ b/x/metadata/keeper/session.go
@@ -166,7 +166,7 @@ func (k Keeper) ValidateWriteSession(ctx sdk.Context, existing *types.Session, m
 		if err = validateRolesPresent(proposed.Parties, contractSpec.PartiesInvolved); err != nil {
 			return err
 		}
-		if _, err = k.ValidateSignersWithoutParties(ctx, scope.GetAllOwnerAddresses(), msg); err != nil {
+		if err = k.ValidateSignersWithoutParties(ctx, scope.GetAllOwnerAddresses(), msg); err != nil {
 			return err
 		}
 	} else {

--- a/x/metadata/keeper/signers.go
+++ b/x/metadata/keeper/signers.go
@@ -323,8 +323,7 @@ func (k Keeper) validateProvenanceRole(ctx sdk.Context, parties []*PartyDetails)
 			// that address that needs to be the smart contract.
 			addr := party.GetAcc()
 			if len(addr) > 0 {
-				account, isBaseAccount := k.GetAccount(ctx, party.GetAcc()).(*authtypes.BaseAccount)
-				isWasmAcct := account != nil && isBaseAccount && account.GetSequence() == uint64(0) && account.GetPubKey() == nil
+				isWasmAcct := k.isWasmAccount(ctx, party.GetAcc())
 				isProvRole := party.GetRole() == types.PartyType_PARTY_TYPE_PROVENANCE
 				if isWasmAcct && !isProvRole {
 					return fmt.Errorf("account %q is a smart contract but does not have the PROVENANCE role", party.GetAddress())
@@ -336,6 +335,16 @@ func (k Keeper) validateProvenanceRole(ctx sdk.Context, parties []*PartyDetails)
 		}
 	}
 	return nil
+}
+
+// isWasmAccount returns true if the provided addr is the address of a smart contract account.
+// A smart contract account is a BaseAccount that exists, has a sequence of 0 and does not have a public key.
+func (k Keeper) isWasmAccount(ctx sdk.Context, addr sdk.AccAddress) bool {
+	if len(addr) == 0 {
+		return false
+	}
+	account, isBaseAccount := k.authKeeper.GetAccount(ctx, addr).(*authtypes.BaseAccount)
+	return account != nil && isBaseAccount && account.GetSequence() == uint64(0) && account.GetPubKey() == nil
 }
 
 // ValidateScopeValueOwnerUpdate verifies that it's okay for the msg signers to

--- a/x/metadata/keeper/signers.go
+++ b/x/metadata/keeper/signers.go
@@ -47,6 +47,9 @@ func (k Keeper) ValidateSignersWithParties(
 	if err != nil {
 		return err
 	}
+	if err = k.validateProvenanceRole(ctx, parties); err != nil {
+		return err
+	}
 	return k.validateSmartContractSigners(ctx, GetAllSigners(parties), msg)
 }
 
@@ -87,12 +90,6 @@ func (k Keeper) validateAllRequiredPartiesSigned(
 	}
 	if rolesAreMissing {
 		return nil, fmt.Errorf("missing signers for roles required by spec: %s", missingRolesString(parties, reqRoles))
-	}
-
-	// Make sure all smart contract accounts have the PROVENANCE role,
-	// and all parties with the PROVENANCE role have smart contract accounts.
-	if err = k.validateProvenanceRole(ctx, parties); err != nil {
-		return nil, err
 	}
 
 	return parties, nil

--- a/x/metadata/keeper/signers.go
+++ b/x/metadata/keeper/signers.go
@@ -347,29 +347,71 @@ func (k Keeper) isWasmAccount(ctx sdk.Context, addr sdk.AccAddress) bool {
 	return account != nil && isBaseAccount && account.GetSequence() == uint64(0) && account.GetPubKey() == nil
 }
 
+// validateSmartContractSigners makes sure that any msg signers that are smart contracts
+// are in the usedSigners map or are authorized by all signers after them.
+// The usedSigners map has bech32 keys and value indicating whether that address was
+// used as a signer in some capacity (e.g. they're a party).
+func (k Keeper) validateSmartContractSigners(ctx sdk.Context, usedSigners map[string]bool, msg types.MetadataMsg) error {
+	// When a smart contract is a signer, they must either be used as a signer
+	// already, or must be authorized by all signers after it.
+	// The wasm encoders (hopefully) put the smart contract as the first signer
+	// followed by other signers. That's why we only check the signers after it.
+	signerAccs := msg.GetSigners()
+	for i, signer := range signerAccs {
+		signerStr := signer.String()
+		if usedSigners[signerStr] || !k.isWasmAccount(ctx, signer) {
+			continue
+		}
+		// it's a wasm account, and it wasn't used yet.
+		if i+1 >= len(signerAccs) {
+			// Not fully accurate error message here, but close enough. And we'll probably never see it anyway.
+			// A smart contract would be allowed to be the last signer if used, e.g. in a Party. We don't need
+			// to tell people that though. But we need this in case, somehow, a smart contract is doing things
+			// without any other signers, but it isn't supposed to be involved in what's going on.
+			return fmt.Errorf("smart contract signer %s cannot be the last signer", signerStr)
+		}
+		// Make sure each of the remaining addresses have granted authorization to this smart contract.
+		for _, granter := range signerAccs[i+1:] {
+			grantee, err := k.findAuthzGrantee(ctx, granter, []sdk.AccAddress{signer}, msg)
+			if err != nil {
+				return err
+			}
+			if !signer.Equals(grantee) {
+				return fmt.Errorf("smart contract signer %s is not authorized", signer)
+			}
+		}
+	}
+	return nil
+}
+
 // ValidateScopeValueOwnerUpdate verifies that it's okay for the msg signers to
 // change a scope's value owner from existing to proposed.
 // If some parties have already been validated (possibly utilizing authz), they
 // can be provided in order to prevent an authorization from being used twice during
 // a single Tx.
+//
+// If no error is returned, a map of bech32 strings to true is returned where each key
+// is a signer that either has a signer in validatedParties, or is used directly in here.
 func (k Keeper) ValidateScopeValueOwnerUpdate(
 	ctx sdk.Context,
 	existing,
 	proposed string,
 	validatedParties []*PartyDetails,
 	msg types.MetadataMsg,
-) error {
+) (map[string]bool, error) {
+	usedSigners := GetAllSigners(validatedParties)
 	if existing == proposed {
-		return nil
+		return usedSigners, nil
 	}
 	signers := msg.GetSignerStrs()
 	if len(existing) > 0 {
-		marker, hasAuth := k.GetMarkerAndCheckAuthority(ctx, existing, signers, markertypes.Access_Withdraw)
+		marker, hasAuth, accWithAccess := k.GetMarkerAndCheckAuthority(ctx, existing, signers, markertypes.Access_Withdraw)
 		if marker != nil {
 			// If the existing is a marker, make sure a signer has withdraw authority on it.
 			if !hasAuth {
-				return fmt.Errorf("missing signature for %s (%s) with authority to withdraw/remove it as scope value owner", existing, marker.GetDenom())
+				return nil, fmt.Errorf("missing signature for %s (%s) with authority to withdraw/remove it as scope value owner", existing, marker.GetDenom())
 			}
+			usedSigners[accWithAccess] = true
 		} else {
 			// If the existing isn't a marker, make sure they're one of the signers or
 			// have an authorization grant for one of the signers.
@@ -378,6 +420,7 @@ func (k Keeper) ValidateScopeValueOwnerUpdate(
 			// First just check the list of signers.
 			for _, signer := range signers {
 				if existing == signer {
+					usedSigners[signer] = true
 					found = true
 					break
 				}
@@ -389,6 +432,7 @@ func (k Keeper) ValidateScopeValueOwnerUpdate(
 			if !found {
 				for _, party := range validatedParties {
 					if party.GetAddress() == existing && party.HasSigner() {
+						usedSigners[party.GetSigner()] = true
 						found = true
 						break
 					}
@@ -403,44 +447,56 @@ func (k Keeper) ValidateScopeValueOwnerUpdate(
 					grantees := safeBech32ToAccAddresses(signers)
 					grantee, err := k.findAuthzGrantee(ctx, granter, grantees, msg)
 					if err != nil {
-						return fmt.Errorf("authz error with existing value owner %q: %w", existing, err)
+						return nil, fmt.Errorf("authz error with existing value owner %q: %w", existing, err)
 					}
 					if len(grantee) > 0 {
+						usedSigners[grantee.String()] = true
 						found = true
 					}
 				}
 			}
 
 			if !found {
-				return fmt.Errorf("missing signature from existing value owner %s", existing)
+				return nil, fmt.Errorf("missing signature from existing value owner %s", existing)
 			}
 		}
 	}
 
 	if len(proposed) > 0 {
 		// If the proposed is a marker, make sure a signer has deposit authority on it.
-		marker, hasAuth := k.GetMarkerAndCheckAuthority(ctx, proposed, signers, markertypes.Access_Deposit)
+		marker, hasAuth, signer := k.GetMarkerAndCheckAuthority(ctx, proposed, signers, markertypes.Access_Deposit)
 		if marker != nil && !hasAuth {
-			return fmt.Errorf("missing signature for %s (%s) with authority to deposit/add it as scope value owner", proposed, marker.GetDenom())
+			return nil, fmt.Errorf("missing signature for %s (%s) with authority to deposit/add it as scope value owner", proposed, marker.GetDenom())
+		}
+		if len(signer) > 0 {
+			usedSigners[signer] = true
 		}
 		// If it's not a marker, we don't really care what it's being set to.
 	}
 
-	return nil
+	return usedSigners, nil
 }
 
 // ValidateSignersWithoutParties makes sure that each entry in the required list are either signers of the msg,
 // or have granted an authz authorization to one of the signers.
-//
-// Party details are returned containing information on which addresses had signers.
-// All roles in these details are UNSPECIFIED.
+// It then makes sure that any signers that are smart contracts are allowed to sign.
 //
 // When parties (and/or roles) are involved, use ValidateSignersWithParties.
 func (k Keeper) ValidateSignersWithoutParties(
 	ctx sdk.Context,
 	required []string,
 	msg types.MetadataMsg,
-) ([]*PartyDetails, error) {
+) error {
+	parties, err := k.validateAllRequiredSigned(ctx, required, msg)
+	if err != nil {
+		return err
+	}
+	return k.validateSmartContractSigners(ctx, GetAllSigners(parties), msg)
+}
+
+// validateAllRequiredSigned ensures that all required addresses are either in the msg signers,
+// or have granted an authorization to someone in the signers.
+func (k Keeper) validateAllRequiredSigned(ctx sdk.Context, required []string, msg types.MetadataMsg) ([]*PartyDetails, error) {
 	details := make([]*PartyDetails, len(required))
 	for i, addr := range required {
 		details[i] = &PartyDetails{
@@ -516,35 +572,36 @@ func validatePartiesArePresent(required, available []types.Party) error {
 
 // GetMarkerAndCheckAuthority gets a marker by address and checks if one of the signers has the provided role.
 // If the address isn't a marker, nil, false is returned.
+// The signer that has the requested permission is also returned.
 func (k Keeper) GetMarkerAndCheckAuthority(
 	ctx sdk.Context,
 	address string,
 	signers []string,
 	role markertypes.Access,
-) (markertypes.MarkerAccountI, bool) {
+) (markertypes.MarkerAccountI, bool, string) {
 	addr, err := sdk.AccAddressFromBech32(address)
 	// if the address is invalid then it is not possible for it to be a marker.
 	if err != nil {
-		return nil, false
+		return nil, false, ""
 	}
 
 	acc := k.authKeeper.GetAccount(ctx, addr)
 	if acc == nil {
-		return nil, false
+		return nil, false, ""
 	}
 
 	// Convert over to the actual underlying marker type, or not.
 	marker, isMarker := acc.(*markertypes.MarkerAccount)
 	if !isMarker {
-		return nil, false
+		return nil, false, ""
 	}
 
 	// Check if any of the signers have the desired role.
 	for _, signer := range signers {
 		if marker.HasAccess(signer, role) {
-			return marker, true
+			return marker, true, signer
 		}
 	}
 
-	return marker, false
+	return marker, false, ""
 }

--- a/x/metadata/keeper/signers_test.go
+++ b/x/metadata/keeper/signers_test.go
@@ -514,17 +514,6 @@ func (s *AuthzTestSuite) TestValidateAllRequiredPartiesSigned() {
 			expErr: "",
 		},
 		{
-			name:             "provenance party not smart contract",
-			reqParties:       nil,
-			availableParties: ptz(pt("party1", provenance, false)),
-			reqRoles:         rz(provenance),
-			msg:              newMsg("party1"),
-			authKeeper:       NewMockAuthKeeper(), // will return nil by default, so no need to mock it specifically.
-			authzKeeper:      NewMockAuthzKeeper(),
-			expParties:       nil,
-			expErr:           fmt.Sprintf("account %q has role PROVENANCE but is not a smart contract", accStr("party1")),
-		},
-		{
 			name:             "non-provenance smart contract account in reqParties ignored",
 			reqParties:       ptz(pt("party1", owner, false)),
 			availableParties: nil,
@@ -547,19 +536,6 @@ func (s *AuthzTestSuite) TestValidateAllRequiredPartiesSigned() {
 				}.Real(),
 			},
 			expErr: "",
-		},
-		{
-			name:             "smart contract not provenance party",
-			reqParties:       nil,
-			availableParties: ptz(pt("party1", owner, false)),
-			reqRoles:         rz(owner),
-			msg:              newMsg("party1"),
-			authKeeper: NewMockAuthKeeper().WithGetAccountResults(
-				NewGetAccountCall(acc("party1"), scAcct("party1")),
-			),
-			authzKeeper: NewMockAuthzKeeper(),
-			expParties:  nil,
-			expErr:      fmt.Sprintf("account %q is a smart contract but does not have the PROVENANCE role", accStr("party1")),
 		},
 	}
 

--- a/x/metadata/keeper/signers_utils.go
+++ b/x/metadata/keeper/signers_utils.go
@@ -187,6 +187,17 @@ func (p *PartyDetails) IsSameAs(p2 types.Partier) bool {
 	return types.SamePartiers(p, p2)
 }
 
+// GetAllSigners gets a map of bech32 strings to true with a key for each used signer.
+func GetAllSigners(parties []*PartyDetails) map[string]bool {
+	rv := make(map[string]bool)
+	for _, party := range parties {
+		if party.HasSigner() {
+			rv[party.GetSigner()] = true
+		}
+	}
+	return rv
+}
+
 // SignersWrapper stores the signers as strings and acc addresses.
 // One is created by providing the strings. They are then converted to acc addresses
 // if they're needed that way.

--- a/x/metadata/spec/01_concepts.md
+++ b/x/metadata/spec/01_concepts.md
@@ -95,6 +95,16 @@ If the value owner address is changing as well as one or more other fields, thes
 * When a value owner address is a non-marker address, and is being changed, that existing address must be one of the signers.
 * When a value owner address is empty, and is being changed, standard scope signer requirements are also applied even if that's the only change to the scope.
 
+### Smart Contract Requirements
+
+The following are requirements related to smart contract usage of the `x/metadata` module:
+
+* A party with a smart contract address MUST have the `PROVENANCE` role.
+* A party with the `PROVENANCE` role MUST have the address of a smart contract.
+* When a smart contract signs a message, it MUST not have any non-smart-contract signers before it and SHOULD include the invoker address(es) after.
+* When a smart contract is a signer, it must either be a party/owner, or have authorizations (via `x/authz`) from all signers after it.
+* If a smart contract is a signer, but not a party, it cannot be the only signer, and cannot be the last signer.
+
 ### With Party Rollup Required
 
 When a scope has `require_party_rollup = true`, all session parties must also be listed in the scope owners.

--- a/x/metadata/spec/01_concepts.md
+++ b/x/metadata/spec/01_concepts.md
@@ -101,7 +101,7 @@ The following are requirements related to smart contract usage of the `x/metadat
 
 * A party with a smart contract address MUST have the `PROVENANCE` role.
 * A party with the `PROVENANCE` role MUST have the address of a smart contract.
-* When a smart contract signs a message, it MUST not have any non-smart-contract signers before it and SHOULD include the invoker address(es) after.
+* When a smart contract signs a message, it MUST be first or have only smart-contract signers before it, and SHOULD include the invoker address(es) after.
 * When a smart contract is a signer, it must either be a party/owner, or have authorizations (via `x/authz`) from all signers after it.
 * If a smart contract is a signer, but not a party, it cannot be the only signer, and cannot be the last signer.
 


### PR DESCRIPTION
## Description

closes: #1280

This makes it so that, for metadata messages, if a smart contract is a signer, one of the following must be satisfied:
* They are a party/owner of the thing being written.
* All signers after it have granted authorizations (via authz) to it for the message type. The last signer cannot be a smart contract address unless they are a party/owner.

This also:
* Updates the non-rollup validation to enforce the provenance/smart-contract role.
* Fixes rollup provenance/smart-contract role validation to correctly look at the proposed parties.


---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
