### PR TITLE
Bump wasmd to v0.30.0-pio-2 (from v0.30.0-pio-2-rc2). (#1477)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -184,7 +184,7 @@ replace github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.0
 
 // TODO: Required for v1.13.x: Remove this and update the require line above to have the new version once it's out. https://github.com/provenance-io/provenance/issues/1015
 // TODO: This is also required for https://github.com/provenance-io/provenance/issues/1414
-replace github.com/CosmWasm/wasmd => github.com/provenance-io/wasmd v0.30.0-pio-2-rc2
+replace github.com/CosmWasm/wasmd => github.com/provenance-io/wasmd v0.30.0-pio-2
 
 // TODO: Required for IBC Transfer Module. Remove this when they patch it to include our changes. https://github.com/provenance-io/provenance/issues/1100
 replace github.com/cosmos/ibc-go/v6 => github.com/provenance-io/ibc-go/v6 v6.1.0-pio-1

--- a/go.sum
+++ b/go.sum
@@ -1004,8 +1004,8 @@ github.com/provenance-io/cosmos-sdk v0.46.10-pio-3 h1:xoDLk++pxKDiPoMb6ch+qNzaID
 github.com/provenance-io/cosmos-sdk v0.46.10-pio-3/go.mod h1:bBmYwqCTndsFE+QQs2zdIoZ3f86jEi0BmDVm6unmf3k=
 github.com/provenance-io/ibc-go/v6 v6.1.0-pio-1 h1:2R9CS/FFGaOoPsdH+/8u+voFNmZqqkD6NuKsmnxMXLo=
 github.com/provenance-io/ibc-go/v6 v6.1.0-pio-1/go.mod h1:CY3zh2HLfetRiW8LY6kVHMATe90Wj/UOoY8T6cuB0is=
-github.com/provenance-io/wasmd v0.30.0-pio-2-rc2 h1:3NdOCa/bNAC+69F2N7CSCHHRi9fStBjrmWDBfdusgYo=
-github.com/provenance-io/wasmd v0.30.0-pio-2-rc2/go.mod h1:sXwFDt9N/vZ0ni3W1M3oH69DUmza4nnsZw+GeSWCuK4=
+github.com/provenance-io/wasmd v0.30.0-pio-2 h1:uhS6i/b25WpboUEP60jXf/fJTM66rDkVwAJEJ9ZGAw4=
+github.com/provenance-io/wasmd v0.30.0-pio-2/go.mod h1:sXwFDt9N/vZ0ni3W1M3oH69DUmza4nnsZw+GeSWCuK4=
 github.com/rakyll/statik v0.1.7 h1:OF3QCZUuyPxuGEP7B4ypUa7sB/iHtqOTDYZXGM8KOdQ=
 github.com/rakyll/statik v0.1.7/go.mod h1:AlZONWzMtEnMs7W4e/1LURLiI49pIMmp6V9Unghqrcc=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=


### PR DESCRIPTION
## Description

Backport of #1477 to `release/v1.15.x`.

Bump wasmd to `v0.30.0-pio-2` (from `v0.30.0-pio-2-rc2`).

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
