### PR TITLE
Add upgrade handlers for rust-rc1 and rust.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - errcheck
@@ -34,7 +33,6 @@ linters:
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
 
 issues:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * Add marker deposit access check for sends to marker escrow account [#1525](https://github.com/provenance-io/provenance/issues/1525).
 * Add support for `name` owner to execute `MsgModifyName` transaction [#1536](https://github.com/provenance-io/provenance/issues/1536).
 * Add usage of `AddGovPropFlagsToCmd` and `ReadGovPropFlags` cli for `GetModifyNameCmd` [#1542](https://github.com/provenance-io/provenance/issues/1542).
+* Create `rust` upgrade handlers [PR 1549](https://github.com/provenance-io/provenance/pull/1549).
 
 ### API Breaking
 

--- a/app/prefix_test/prefix_test.go
+++ b/app/prefix_test/prefix_test.go
@@ -1,10 +1,32 @@
-package app
+package prefix_test
+
+// These tests are for things in the app/prefix.go file.
+// They're in this other folder and package so that they don't interfere with
+// the other tests in the app folder, e.g. the stuff in upgrade_test.go.
+//
+// These tests alter some global variables in a way that can't easily be undone.
+// For example, the bech32 address HRP is changed from the default "cosmos" to
+// "tp" during these tests.
+//
+// When this file was in the app/ folder, any tests that created an app would
+// pass when run individually, but fail when being run with all tests.
+// What was happening is that, during app setup, a genesis file is created using
+// the default "cosmos" HRP on all the addresses. But by the time it tries to
+// read/parse that file, the tests in this file have run, changing the HRP to tp
+// and locking the config (so it can't be changed back).
+//
+// By putting these tests in their own folder, they are invoked on their own,
+// separately from any other tests, and without modifying global variables used
+// by any other tests.
 
 import (
 	"testing"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/provenance-io/provenance/app"
 )
 
 func TestFullBIP44Path(t *testing.T) {
@@ -47,17 +69,16 @@ func TestFullBIP44Path(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if len(tc.panicMessage) > 0 {
 				require.PanicsWithValue(t, tc.panicMessage, func() {
-					SetConfig(tc.isTestnet, tc.seal)
+					app.SetConfig(tc.isTestnet, tc.seal)
 				}, "SetConfig")
 			} else {
 				require.NotPanics(t, func() {
-					SetConfig(tc.isTestnet, tc.seal)
+					app.SetConfig(tc.isTestnet, tc.seal)
 				}, "SetConfig")
 				config := sdk.GetConfig()
 				fullBIP44Path := config.GetFullBIP44Path()
 				require.Equal(t, tc.expected, fullBIP44Path, "GetFullBIP44Path")
 			}
-
 		})
 	}
 }

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -1,13 +1,18 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	govtypesv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	govtypesv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	msgfeetypes "github.com/provenance-io/provenance/x/msgfees/types"
 )
 
 var (
@@ -47,8 +52,44 @@ var handlers = map[string]appUpgrade{
 			return app.mm.RunMigrations(ctx, app.configurator, versionMap)
 		},
 	},
-	"rust-rc1": {}, // upgrade for v1.16.0-rc1,
-	"rust":     {}, // upgrade for v1.16.0,
+	"rust-rc1": { // upgrade for v1.16.0-rc1,
+		Handler: func(ctx sdk.Context, app *App, plan upgradetypes.Plan) (module.VersionMap, error) {
+			versionMap, err := runModuleMigrations(ctx, app)
+			if err != nil {
+				return nil, err
+			}
+
+			// We only need to call AddGovV1SubmitFee on testnet.
+			err = AddGovV1SubmitFee(ctx, app)
+			if err != nil {
+				return nil, err
+			}
+
+			err = RemoveP8eMemorializeContractFee(ctx, app)
+			if err != nil {
+				return nil, err
+			}
+
+			return versionMap, nil
+		},
+	},
+	"rust": { // upgrade for v1.16.0,
+		Handler: func(ctx sdk.Context, app *App, plan upgradetypes.Plan) (module.VersionMap, error) {
+			versionMap, err := runModuleMigrations(ctx, app)
+			if err != nil {
+				return nil, err
+			}
+
+			// No need to call AddGovV1SubmitFee in here as mainnet already has it defined.
+
+			err = RemoveP8eMemorializeContractFee(ctx, app)
+			if err != nil {
+				return nil, err
+			}
+
+			return versionMap, nil
+		},
+	},
 	// TODO - Add new upgrade definitions here.
 }
 
@@ -129,3 +170,80 @@ func runModuleMigrations(ctx sdk.Context, app *App) (module.VersionMap, error) {
 // Create a use of runModuleMigrations so that the linter neither complains about it not being used,
 // nor complains about a nolint:unused directive that isn't needed because the function is used.
 var _ = runModuleMigrations
+
+// AddGovV1SubmitFee adds a msg-fee for the gov v1 MsgSubmitProposal if there isn't one yet.
+func AddGovV1SubmitFee(ctx sdk.Context, app *App) (err error) {
+	typeURL := sdk.MsgTypeURL(&govtypesv1.MsgSubmitProposal{})
+	defer func() {
+		if err != nil {
+			ctx.Logger().Error(fmt.Sprintf("Error encountered while setting message fee for %q", typeURL), "error", err)
+		}
+	}()
+
+	ctx.Logger().Info(fmt.Sprintf("Creating message fee for %q if it doesn't already exist.", typeURL))
+	fee, err := app.MsgFeesKeeper.GetMsgFee(ctx, typeURL)
+	if err != nil {
+		return fmt.Errorf("error getting existing v1 fee for %q: %w", typeURL, err)
+	}
+	// If there's already a fee for it, do nothing.
+	if fee != nil {
+		ctx.Logger().Info(fmt.Sprintf("Message fee for %q already exists with amount %q. Nothing more to do.", fee.MsgTypeUrl, fee.AdditionalFee.String()))
+		return nil
+	}
+
+	// Copy the fee from the beta entry if it exists, otherwise, just make it fresh.
+	betaTypeURL := sdk.MsgTypeURL(&govtypesv1beta1.MsgSubmitProposal{})
+	betaFee, err := app.MsgFeesKeeper.GetMsgFee(ctx, betaTypeURL)
+	if err != nil {
+		return fmt.Errorf("error getting existing v1beta1 message fee for %q: %w", betaTypeURL, err)
+	}
+	if betaFee != nil {
+		fee = betaFee
+		fee.MsgTypeUrl = typeURL
+		ctx.Logger().Info(fmt.Sprintf("Copying %q fee to %q.", betaTypeURL, fee.MsgTypeUrl))
+	} else {
+		fee = &msgfeetypes.MsgFee{
+			MsgTypeUrl:           typeURL,
+			AdditionalFee:        sdk.NewInt64Coin("nhash", 100_000_000_000), // 100 hash
+			Recipient:            "",
+			RecipientBasisPoints: 0,
+		}
+		ctx.Logger().Info(fmt.Sprintf("Creating %q fee.", fee.MsgTypeUrl))
+	}
+
+	err = app.MsgFeesKeeper.SetMsgFee(ctx, *fee)
+	if err != nil {
+		return fmt.Errorf("error setting message fee for %q: %w", fee.MsgTypeUrl, err)
+	}
+	ctx.Logger().Info("Successfully set fee for %q with amount %q.", fee.MsgTypeUrl, fee.AdditionalFee.String())
+
+	return nil
+}
+
+// RemoveP8eMemorializeContractFee removes the message fee for the now-non-existent MsgP8eMemorializeContractRequest.
+func RemoveP8eMemorializeContractFee(ctx sdk.Context, app *App) (err error) {
+	typeURL := "/provenance.metadata.v1.MsgP8eMemorializeContractRequest"
+	defer func() {
+		if err != nil {
+			ctx.Logger().Error(fmt.Sprintf("Error encountered while removing message fee for %q", typeURL), "error", err)
+		}
+	}()
+
+	ctx.Logger().Info(fmt.Sprintf("Removing message fee for %q if one exists.", typeURL))
+	// Get the existing fee for log output, but ignore any errors so we try to delete the entry either way.
+	fee, _ := app.MsgFeesKeeper.GetMsgFee(ctx, typeURL)
+	err = app.MsgFeesKeeper.RemoveMsgFee(ctx, typeURL)
+	switch {
+	case errors.Is(err, msgfeetypes.ErrMsgFeeDoesNotExist):
+		ctx.Logger().Info(fmt.Sprintf("Message fee for %q already does not exist. Nothing more to do.", typeURL))
+		err = nil
+	case err != nil:
+		return fmt.Errorf("error removing message fee for %q: %w", typeURL, err)
+	case fee != nil:
+		ctx.Logger().Info(fmt.Sprintf("Successfully removed message fee for %q with amount %q.", fee.MsgTypeUrl, fee.AdditionalFee.String()))
+	default:
+		ctx.Logger().Info(fmt.Sprintf("Successfully removed message fee for %q.", typeURL))
+	}
+
+	return nil
+}

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
@@ -60,15 +59,9 @@ var handlers = map[string]appUpgrade{
 			}
 
 			// We only need to call AddGovV1SubmitFee on testnet.
-			err = AddGovV1SubmitFee(ctx, app)
-			if err != nil {
-				return nil, err
-			}
+			AddGovV1SubmitFee(ctx, app)
 
-			err = RemoveP8eMemorializeContractFee(ctx, app)
-			if err != nil {
-				return nil, err
-			}
+			RemoveP8eMemorializeContractFee(ctx, app)
 
 			return versionMap, nil
 		},
@@ -82,10 +75,7 @@ var handlers = map[string]appUpgrade{
 
 			// No need to call AddGovV1SubmitFee in here as mainnet already has it defined.
 
-			err = RemoveP8eMemorializeContractFee(ctx, app)
-			if err != nil {
-				return nil, err
-			}
+			RemoveP8eMemorializeContractFee(ctx, app)
 
 			return versionMap, nil
 		},
@@ -172,31 +162,23 @@ func runModuleMigrations(ctx sdk.Context, app *App) (module.VersionMap, error) {
 var _ = runModuleMigrations
 
 // AddGovV1SubmitFee adds a msg-fee for the gov v1 MsgSubmitProposal if there isn't one yet.
-func AddGovV1SubmitFee(ctx sdk.Context, app *App) (err error) {
+func AddGovV1SubmitFee(ctx sdk.Context, app *App) {
 	typeURL := sdk.MsgTypeURL(&govtypesv1.MsgSubmitProposal{})
-	defer func() {
-		if err != nil {
-			ctx.Logger().Error(fmt.Sprintf("Error encountered while setting message fee for %q", typeURL), "error", err)
-		}
-	}()
 
 	ctx.Logger().Info(fmt.Sprintf("Creating message fee for %q if it doesn't already exist.", typeURL))
-	fee, err := app.MsgFeesKeeper.GetMsgFee(ctx, typeURL)
-	if err != nil {
-		return fmt.Errorf("error getting existing v1 fee for %q: %w", typeURL, err)
-	}
+	// At the time of writing this, the only way GetMsgFee returns an error is if it can't unmarshall state.
+	// If that's the case for the v1 entry, we want to fix it anyway, so we just ignore any error here.
+	fee, _ := app.MsgFeesKeeper.GetMsgFee(ctx, typeURL)
 	// If there's already a fee for it, do nothing.
 	if fee != nil {
-		ctx.Logger().Info(fmt.Sprintf("Message fee for %q already exists with amount %q. Nothing more to do.", fee.MsgTypeUrl, fee.AdditionalFee.String()))
-		return nil
+		ctx.Logger().Info(fmt.Sprintf("Message fee for %q already exists with amount %q. Nothing to do.", fee.MsgTypeUrl, fee.AdditionalFee.String()))
+		return
 	}
 
 	// Copy the fee from the beta entry if it exists, otherwise, just make it fresh.
 	betaTypeURL := sdk.MsgTypeURL(&govtypesv1beta1.MsgSubmitProposal{})
-	betaFee, err := app.MsgFeesKeeper.GetMsgFee(ctx, betaTypeURL)
-	if err != nil {
-		return fmt.Errorf("error getting existing v1beta1 message fee for %q: %w", betaTypeURL, err)
-	}
+	// Here too, if there's an error getting the beta fee, just ignore it.
+	betaFee, _ := app.MsgFeesKeeper.GetMsgFee(ctx, betaTypeURL)
 	if betaFee != nil {
 		fee = betaFee
 		fee.MsgTypeUrl = typeURL
@@ -211,39 +193,26 @@ func AddGovV1SubmitFee(ctx sdk.Context, app *App) (err error) {
 		ctx.Logger().Info(fmt.Sprintf("Creating %q fee.", fee.MsgTypeUrl))
 	}
 
-	err = app.MsgFeesKeeper.SetMsgFee(ctx, *fee)
-	if err != nil {
-		return fmt.Errorf("error setting message fee for %q: %w", fee.MsgTypeUrl, err)
-	}
-	ctx.Logger().Info("Successfully set fee for %q with amount %q.", fee.MsgTypeUrl, fee.AdditionalFee.String())
+	// At the time of writing this, SetMsgFee always returns nil.
+	_ = app.MsgFeesKeeper.SetMsgFee(ctx, *fee)
+	ctx.Logger().Info(fmt.Sprintf("Successfully set fee for %q with amount %q.", fee.MsgTypeUrl, fee.AdditionalFee.String()))
 
-	return nil
+	return
 }
 
 // RemoveP8eMemorializeContractFee removes the message fee for the now-non-existent MsgP8eMemorializeContractRequest.
-func RemoveP8eMemorializeContractFee(ctx sdk.Context, app *App) (err error) {
+func RemoveP8eMemorializeContractFee(ctx sdk.Context, app *App) {
 	typeURL := "/provenance.metadata.v1.MsgP8eMemorializeContractRequest"
-	defer func() {
-		if err != nil {
-			ctx.Logger().Error(fmt.Sprintf("Error encountered while removing message fee for %q", typeURL), "error", err)
-		}
-	}()
 
 	ctx.Logger().Info(fmt.Sprintf("Removing message fee for %q if one exists.", typeURL))
 	// Get the existing fee for log output, but ignore any errors so we try to delete the entry either way.
 	fee, _ := app.MsgFeesKeeper.GetMsgFee(ctx, typeURL)
-	err = app.MsgFeesKeeper.RemoveMsgFee(ctx, typeURL)
-	switch {
-	case errors.Is(err, msgfeetypes.ErrMsgFeeDoesNotExist):
-		ctx.Logger().Info(fmt.Sprintf("Message fee for %q already does not exist. Nothing more to do.", typeURL))
-		err = nil
-	case err != nil:
-		return fmt.Errorf("error removing message fee for %q: %w", typeURL, err)
-	case fee != nil:
+	// At the time of writing this, the only error that RemoveMsgFee can return is ErrMsgFeeDoesNotExist.
+	// So ignore any error here and just use fee != nil for the different log messages.
+	_ = app.MsgFeesKeeper.RemoveMsgFee(ctx, typeURL)
+	if fee == nil {
+		ctx.Logger().Info(fmt.Sprintf("Message fee for %q already does not exist. Nothing to do.", typeURL))
+	} else {
 		ctx.Logger().Info(fmt.Sprintf("Successfully removed message fee for %q with amount %q.", fee.MsgTypeUrl, fee.AdditionalFee.String()))
-	default:
-		ctx.Logger().Info(fmt.Sprintf("Successfully removed message fee for %q.", typeURL))
 	}
-
-	return nil
 }

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -196,8 +196,6 @@ func AddGovV1SubmitFee(ctx sdk.Context, app *App) {
 	// At the time of writing this, SetMsgFee always returns nil.
 	_ = app.MsgFeesKeeper.SetMsgFee(ctx, *fee)
 	ctx.Logger().Info(fmt.Sprintf("Successfully set fee for %q with amount %q.", fee.MsgTypeUrl, fee.AdditionalFee.String()))
-
-	return
 }
 
 // RemoveP8eMemorializeContractFee removes the message fee for the now-non-existent MsgP8eMemorializeContractRequest.

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -3,11 +3,13 @@ package app
 import (
 	"bytes"
 	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/rs/zerolog"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/tendermint/tendermint/libs/log"
@@ -15,27 +17,245 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/server"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
 
 	msgfeetypes "github.com/provenance-io/provenance/x/msgfees/types"
 )
 
-type IntegrationTestSuite struct {
+type UpgradeTestSuite struct {
 	suite.Suite
 
 	app *App
 	ctx sdk.Context
+
+	logBuffer bytes.Buffer
 }
 
-func TestIntegrationTestSuite(t *testing.T) {
-	suite.Run(t, new(IntegrationTestSuite))
+func TestUpgradeTestSuite(t *testing.T) {
+	suite.Run(t, new(UpgradeTestSuite))
 }
 
-func (s *IntegrationTestSuite) SetupSuite() {
+func (s *UpgradeTestSuite) SetupSuite() {
+	// Alert: This function is SetupSuite. That means all tests in here
+	// will use the same app with the same store and data.
+	bufferedLoggerMaker := func() log.Logger {
+		lw := zerolog.ConsoleWriter{
+			Out:          &s.logBuffer,
+			NoColor:      true,
+			PartsExclude: []string{"time"}, // Without this, each line starts with "<nil> "
+		}
+		// Error log lines will start with "ERR ".
+		// Info log lines will start with "INF ".
+		// Debug log lines are omitted, but would start with "DBG ".
+		logger := zerolog.New(lw).Level(zerolog.InfoLevel)
+		return server.ZeroLogWrapper{Logger: logger}
+	}
+	defer SetLoggerMaker(SetLoggerMaker(bufferedLoggerMaker))
 	s.app = Setup(s.T())
+	s.logBuffer.Reset()
 	s.ctx = s.app.BaseApp.NewContext(false, tmproto.Header{})
 }
 
-func TestAddGovV1SubmitFee(t *testing.T) {
+// AssertUpgradeHandlerLogs runs the Handler of the provided key and asserts that
+// each entry in expInLog is in the log output, and each entry in expNotInLog
+// is not in the log output.
+//
+// entries in expInLog are expected to be full lines.
+// entries in expNotInLog can be parts of lines.
+//
+// This returns the log output and whether all assertions passed (true = all passed,
+// false = one or more problems were found).
+func (s *UpgradeTestSuite) AssertUpgradeHandlerLogs(key string, expInLog, expNotInLog []string) (logOutput string, allPassed bool) {
+	s.T().Helper()
+	defer func() {
+		allPassed = !s.T().Failed()
+	}()
+
+	if !s.Assert().Contains(upgrades, key, "defined upgrades map") {
+		return // If the upgrades map doesn't have that key, there's nothing more to do in here.
+	}
+	handler := upgrades[key].Handler
+	if !s.Assert().NotNil(handler, "upgrades[%q].Handler", key) {
+		return // If the entry doesn't have a .Handler, there's nothing more to do in here.
+	}
+
+	// This app was just created brand new, so it will create all the modules with their most
+	// recent versions. As such, this GetModuleVersionMap will return all the most current
+	// module versions info. That means that none of the module migrations will be running when we
+	// call the handler, and that the log won't have any entries from any specific module migrations.
+	// If you really want to include those in this run, you can try doing stuff with SetModuleVersionMap
+	// prior to calling this AssertUpgradeHandlerLogs function. You'll probably also need to recreate
+	// any old state for that module since anything added already was done using new stuff.
+	origVersionMap := s.app.UpgradeKeeper.GetModuleVersionMap(s.ctx)
+
+	var versionMap module.VersionMap
+	var err error
+	s.logBuffer.Reset()
+	testFunc := func() {
+		versionMap, err = handler(s.ctx, s.app, origVersionMap)
+	}
+	if !s.Assert().NotPanics(testFunc, "upgrades[%q].Handler(...)", key) {
+		return // If the handler panics, there's nothing more to check in here.
+	}
+
+	// Add the handler log output to the test log for easier troubleshooting.
+	logOutput = s.logBuffer.String()
+	s.T().Logf("upgrades[%q].Handler(...) log output:\n%s", key, logOutput)
+
+	// Checking for error cases should be done in individual function unit tests.
+	// For this, always check for no error and a non-empty version map.
+	s.Assert().NoError(err, "upgrades[%q].Handler(...) error", key)
+	s.Assert().NotEmpty(versionMap, "upgrades[%q].Handler(...) version map", key)
+
+	logLines := strings.Split(logOutput, "\n")
+	for _, exp := range expInLog {
+		// I'm including the expected in the msgAndArgs here even though it's also included in the
+		// failure message because the failure message puts everything on one line. So the expected
+		// string is almost at the end of a very long line. Having it in the "message" portion of
+		// the failure makes it easier to identify the problematic entry.
+		s.Assert().Contains(logLines, exp, "upgrades[%q].Handler(...) log output.\nExpecting: %q", key, exp)
+	}
+
+	for _, unexp := range expNotInLog {
+		// Same here with the msgAndArgs thing.
+		s.Assert().NotContains(logOutput, unexp, "upgrades[%q].Handler(...) log output.\nNot Expecting: %q", key, unexp)
+	}
+
+	return
+}
+
+func (s *UpgradeTestSuite) TestKeysInHandlersMap() {
+	// handlerKeys are all the keys in the upgrades map defined in upgrades.go.
+	handlerKeys := make([]string, 0, len(upgrades))
+	// colors are the different colors used in the upgrades map.
+	colors := make([]string, 0, 2)
+	// rcs is a map of "<color>" to "rc<number>" suffixes for that color.
+	rcs := make(map[string][]string)
+
+	// addColor adds an entry to colors if it isn't already in there.
+	addColor := func(newColor string) {
+		for _, color := range colors {
+			if newColor == color {
+				return
+			}
+		}
+		colors = append(colors, newColor)
+	}
+
+	// get all the upgrade handler keys and identify the unique colors and their release candidates.
+	for key := range upgrades {
+		handlerKeys = append(handlerKeys, key)
+		parts := strings.SplitN(key, "-", 2)
+		addColor(parts[0])
+		if len(parts) > 1 && len(parts[1]) > 0 {
+			rcs[parts[0]] = append(rcs[parts[0]], parts[1])
+		}
+	}
+
+	// Sort all that stuff so it's easier to read in output and easier to test against.
+	sort.Strings(handlerKeys)
+	sort.Strings(colors)
+	for _, v := range rcs {
+		sort.Strings(v)
+	}
+
+	s.Run("upgrade key format", func() {
+		// Upgrade keys should either be "<color>" or have the format "<color>-rc<number>".
+		// Non-letters should be removed from the color to form one word, e.g. "neoncarrot"
+		// Only lowercase letters should be used.
+		rx := regexp.MustCompile(`^[a-z]+(-rc[0-9]+)?$`)
+		for _, upgradeKey := range handlerKeys {
+			s.Assert().Regexp(rx, upgradeKey)
+		}
+	})
+
+	s.Run("two or more colors exist", func() {
+		// We always need the colors currently in use on mainnet and testnet.
+		// The ones before that shouldn't be removed until we add new ones.
+		// It's okay to not clean the old ones up immediately, though.
+		// So we always want at least 2 different colors in there.
+		s.Assert().GreaterOrEqual(len(colors), 2, "number of distinct colors: %q in %q", colors, handlerKeys)
+		// If there are more than 3, we need to do some cleanup though.
+		s.Assert().LessOrEqual(len(colors), 3, "number of distinct colors: %q in %q", colors, handlerKeys)
+	})
+
+	s.Run("no two colors start with same character", func() {
+		// Little tricky here. i will go from 0 to len(colors) - 2 and the color will go from the 2nd to last.
+		// So colors[i] in here will be the entry just before color.
+		for i, color := range colors[1:] {
+			s.Assert().NotEqual(string(colors[i][0]), string(color[0]), "first letters of colors %q and %q", colors[i], color)
+		}
+	})
+
+	s.Run("rc exists for each color", func() {
+		// We shouldn't delete any entries (rc or non) until all of the entries for that color can be deleted.
+		// This helps maintain a complete picture of the upgrades involved with a version.
+		for _, color := range colors {
+			s.Assert().NotEmpty(rcs[color], "rc entries for %s in %q", color, handlerKeys)
+		}
+	})
+
+	s.Run("rcs all exist sequentially", func() {
+		// All of the rc entries should be present starting with 1 and increasing by 1 each time.
+		// I.e. we shouldn't skip a number, and old rc entries shouldn't be deleted until all
+		// entries for that color can be deleted.
+		// The rc numbers for a color won't necessarily align with the software version rc numbers.
+		// E.g. quicksilver-rc1 was for v1.15.0-rc2.
+
+		// Make a slice of strings rc1, rc2, ... rc11.
+		// If we end up with something larger than rc11, dry your eyes and bump this.
+		expRCs := make([]string, 10)
+		for i := range expRCs {
+			expRCs[i] = fmt.Sprintf("rc%d", i+1)
+		}
+		for _, color := range colors {
+			if len(rcs[color]) > 0 {
+				exp := expRCs[:len(rcs[color])]
+				s.Assert().Equal(exp, rcs[color], "rc suffixes for %s in %q", color, handlerKeys)
+			}
+		}
+	})
+
+	s.Run("non rc exists for each color", func() {
+		// If an rc entry for a color exists, the non-rc entry needs to exist too.
+		// That way, the mainnet upgrade handler isn't forgotten, and is harder to
+		// forget about as the rc entries are being written.
+		for _, color := range colors {
+			s.Assert().Contains(handlerKeys, color, "non-rc entry for %s in %q", color, handlerKeys)
+		}
+	})
+}
+
+func (s *UpgradeTestSuite) TestRustRC1() {
+	// Each part is (hopefully) tested thoroughly on its own.
+	// So for this test, just make sure there's log entries for each part being done.
+
+	expInLog := []string{
+		"INF Starting module migrations. This may take a significant amount of time to complete. Do not restart node.",
+		`INF Creating message fee for "/cosmos.gov.v1.MsgSubmitProposal" if it doesn't already exist.`,
+		`INF Removing message fee for "/provenance.metadata.v1.MsgP8eMemorializeContractRequest" if one exists.`,
+	}
+
+	s.AssertUpgradeHandlerLogs("rust-rc1", expInLog, nil)
+}
+
+func (s *UpgradeTestSuite) TestRust() {
+	// Each part is (hopefully) tested thoroughly on its own.
+	// So for this test, just make sure there's log entries for each part being done.
+	// And not a log entry for stuff done in rust-rc1 but not this one.
+
+	expInLog := []string{
+		"INF Starting module migrations. This may take a significant amount of time to complete. Do not restart node.",
+		`INF Removing message fee for "/provenance.metadata.v1.MsgP8eMemorializeContractRequest" if one exists.`,
+	}
+	expNotInLog := []string{
+		`Creating message fee for "/cosmos.gov.v1.MsgSubmitProposal" if it doesn't already exist.`,
+	}
+
+	s.AssertUpgradeHandlerLogs("rust", expInLog, expNotInLog)
+}
+
+func (s *UpgradeTestSuite) TestAddGovV1SubmitFee() {
 	v1TypeURL := "/cosmos.gov.v1.MsgSubmitProposal"
 	v1B1TypeURL := "/cosmos.gov.v1beta1.MsgSubmitProposal"
 
@@ -87,63 +307,115 @@ func TestAddGovV1SubmitFee(t *testing.T) {
 		},
 	}
 
-	// Create a loggerMaker that captures info+ log output.
-	var logBuffer bytes.Buffer
-	bufferedLoggerMaker := func() log.Logger {
-		lw := zerolog.ConsoleWriter{Out: &logBuffer}
-		logger := zerolog.New(lw).Level(zerolog.InfoLevel).With().Timestamp().Logger()
-		return server.ZeroLogWrapper{Logger: logger}
-	}
-	defer SetLoggerMaker(SetLoggerMaker(bufferedLoggerMaker))
-
-	app := Setup(t)
-	ctx := app.NewContext(false, tmproto.Header{})
-
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		s.Run(tc.name, func() {
 			// Set/unset the v1 fee.
 			if tc.v1Amt != nil {
 				fee := msgfeetypes.NewMsgFee(v1TypeURL, *tc.v1Amt, "", 0)
-				require.NoError(t, app.MsgFeesKeeper.SetMsgFee(ctx, fee), "SetMsgFee v1")
+				s.Require().NoError(s.app.MsgFeesKeeper.SetMsgFee(s.ctx, fee), "SetMsgFee v1")
 			} else {
-				err := app.MsgFeesKeeper.RemoveMsgFee(ctx, v1TypeURL)
+				err := s.app.MsgFeesKeeper.RemoveMsgFee(s.ctx, v1TypeURL)
 				if err != nil && !errors.Is(err, msgfeetypes.ErrMsgFeeDoesNotExist) {
-					require.NoError(t, err, "RemoveMsgFee v1")
+					s.Require().NoError(err, "RemoveMsgFee v1")
 				}
 			}
 
 			// Set/unset the v1beta1 fee.
 			if tc.v1B1Amt != nil {
 				fee := msgfeetypes.NewMsgFee(v1B1TypeURL, *tc.v1B1Amt, "", 0)
-				require.NoError(t, app.MsgFeesKeeper.SetMsgFee(ctx, fee), "SetMsgFee v1beta1")
+				s.Require().NoError(s.app.MsgFeesKeeper.SetMsgFee(s.ctx, fee), "SetMsgFee v1beta1")
 			} else {
-				err := app.MsgFeesKeeper.RemoveMsgFee(ctx, v1B1TypeURL)
+				err := s.app.MsgFeesKeeper.RemoveMsgFee(s.ctx, v1B1TypeURL)
 				if err != nil && !errors.Is(err, msgfeetypes.ErrMsgFeeDoesNotExist) {
-					require.NoError(t, err, "RemoveMsgFee v1")
+					s.Require().NoError(err, "RemoveMsgFee v1")
 				}
 			}
 
 			// Reset the log buffer to clear out unrelated entries.
-			logBuffer.Reset()
-			// Call AddGovV1SubmitFee and relog its output (to help if things fail).
+			s.logBuffer.Reset()
+			// Call addGovV1SubmitFee and relog its output (to help if things fail).
 			testFunc := func() {
-				AddGovV1SubmitFee(ctx, app)
+				addGovV1SubmitFee(s.ctx, s.app)
 			}
-			require.NotPanics(t, testFunc, "AddGovV1SubmitFee")
-			logOutput := logBuffer.String()
-			t.Logf("AddGovV1SubmitFee log output:\n%s", logOutput)
+			s.Require().NotPanics(testFunc, "addGovV1SubmitFee")
+			logOutput := s.logBuffer.String()
+			s.T().Logf("addGovV1SubmitFee log output:\n%s", logOutput)
 
 			// Make sure the log has the expected lines.
 			for _, exp := range tc.expInLog {
-				assert.Contains(t, logOutput, exp, "AddGovV1SubmitFee log output")
+				s.Assert().Contains(logOutput, exp, "addGovV1SubmitFee log output")
 			}
 
 			// Get the fee and make sure it's now as expected.
-			fee, err := app.MsgFeesKeeper.GetMsgFee(ctx, v1TypeURL)
-			require.NoError(t, err, "GetMsgFee(%q) error", v1TypeURL)
-			require.NotNil(t, fee, "GetMsgFee(%q) value", v1TypeURL)
+			fee, err := s.app.MsgFeesKeeper.GetMsgFee(s.ctx, v1TypeURL)
+			s.Require().NoError(err, "GetMsgFee(%q) error", v1TypeURL)
+			s.Require().NotNil(fee, "GetMsgFee(%q) value", v1TypeURL)
 			actFeeAmt := fee.AdditionalFee
-			assert.Equal(t, tc.expAmt.String(), actFeeAmt.String(), "final %s fee amount", v1TypeURL)
+			s.Assert().Equal(tc.expAmt.String(), actFeeAmt.String(), "final %s fee amount", v1TypeURL)
+		})
+	}
+}
+
+func (s *UpgradeTestSuite) TestRemoveP8eMemorializeContractFee() {
+	typeURL := "/provenance.metadata.v1.MsgP8eMemorializeContractRequest"
+	startingMsg := `Removing message fee for "` + typeURL + `" if one exists.`
+
+	coin := func(denom string, amt int64) *sdk.Coin {
+		rv := sdk.NewInt64Coin(denom, amt)
+		return &rv
+	}
+
+	tests := []struct {
+		name     string
+		amt      *sdk.Coin
+		expInLog []string
+	}{
+		{
+			name: "does not exist",
+			expInLog: []string{
+				startingMsg,
+				`Message fee for "` + typeURL + `" already does not exist. Nothing to do.`,
+			},
+		},
+		{
+			name: "exists",
+			amt:  coin("p8ecoin", 808),
+			expInLog: []string{
+				startingMsg,
+				`Successfully removed message fee for "` + typeURL + `" with amount "808p8ecoin".`,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			// set/unset the fee
+			if tc.amt != nil {
+				fee := msgfeetypes.NewMsgFee(typeURL, *tc.amt, "", 0)
+				s.Require().NoError(s.app.MsgFeesKeeper.SetMsgFee(s.ctx, fee), "Setup: SetMsgFee(%q)", typeURL)
+			} else {
+				err := s.app.MsgFeesKeeper.RemoveMsgFee(s.ctx, typeURL)
+				if err != nil && !errors.Is(err, msgfeetypes.ErrMsgFeeDoesNotExist) {
+					s.Require().NoError(err, "Setup: RemoveMsgFee(%q)", typeURL)
+				}
+			}
+
+			s.logBuffer.Reset()
+			testFunc := func() {
+				removeP8eMemorializeContractFee(s.ctx, s.app)
+			}
+			s.Require().NotPanics(testFunc, "removeP8eMemorializeContractFee")
+			logOutput := s.logBuffer.String()
+			s.T().Logf("removeP8eMemorializeContractFee log output:\n%s", logOutput)
+
+			for _, exp := range tc.expInLog {
+				s.Assert().Contains(logOutput, exp, "removeP8eMemorializeContractFee log output")
+			}
+
+			// Make sure there isn't a fee anymore.
+			fee, err := s.app.MsgFeesKeeper.GetMsgFee(s.ctx, typeURL)
+			s.Require().NoError(err, "GetMsgFee(%q) error", typeURL)
+			s.Require().Nil(fee, "GetMsgFee(%q) value", typeURL)
 		})
 	}
 }

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -218,7 +218,7 @@ func (s *UpgradeTestSuite) TestKeysInHandlersMap() {
 
 	s.Run("non rc exists for each color", func() {
 		// If an rc entry for a color exists, the non-rc entry needs to exist too.
-		// That way, the mainnet upgrade handler isn't forgotten, and is harder to
+		// That way, the mainnet upgrade handler is harder to
 		// forget about as the rc entries are being written.
 		for _, color := range colors {
 			s.Assert().Contains(handlerKeys, color, "non-rc entry for %s in %q", color, handlerKeys)

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -1,13 +1,22 @@
 package app
 
 import (
+	"bytes"
+	"errors"
 	"testing"
 
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/tendermint/tendermint/libs/log"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+
+	"github.com/cosmos/cosmos-sdk/server"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	msgfeetypes "github.com/provenance-io/provenance/x/msgfees/types"
 )
 
 type IntegrationTestSuite struct {
@@ -24,4 +33,117 @@ func TestIntegrationTestSuite(t *testing.T) {
 func (s *IntegrationTestSuite) SetupSuite() {
 	s.app = Setup(s.T())
 	s.ctx = s.app.BaseApp.NewContext(false, tmproto.Header{})
+}
+
+func TestAddGovV1SubmitFee(t *testing.T) {
+	v1TypeURL := "/cosmos.gov.v1.MsgSubmitProposal"
+	v1B1TypeURL := "/cosmos.gov.v1beta1.MsgSubmitProposal"
+
+	startingMsg := `Creating message fee for "` + v1TypeURL + `" if it doesn't already exist.`
+	successMsg := func(amt string) string {
+		return `Successfully set fee for "` + v1TypeURL + `" with amount "` + amt + `".`
+	}
+
+	coin := func(denom string, amt int64) *sdk.Coin {
+		rv := sdk.NewInt64Coin(denom, amt)
+		return &rv
+	}
+
+	tests := []struct {
+		name     string
+		v1Amt    *sdk.Coin
+		v1B1Amt  *sdk.Coin
+		expInLog []string
+		expAmt   sdk.Coin
+	}{
+		{
+			name:    "v1 fee already exists",
+			v1Amt:   coin("foocoin", 88),
+			v1B1Amt: coin("betacoin", 99),
+			expInLog: []string{
+				startingMsg,
+				`Message fee for "` + v1TypeURL + `" already exists with amount "88foocoin". Nothing to do.`,
+			},
+			expAmt: *coin("foocoin", 88),
+		},
+		{
+			name:    "v1beta1 exists",
+			v1B1Amt: coin("betacoin", 99),
+			expInLog: []string{
+				startingMsg,
+				`Copying "` + v1B1TypeURL + `" fee to "` + v1TypeURL + `".`,
+				successMsg("99betacoin"),
+			},
+			expAmt: *coin("betacoin", 99),
+		},
+		{
+			name: "brand new",
+			expInLog: []string{
+				startingMsg,
+				`Creating "` + v1TypeURL + `" fee.`,
+				successMsg("100000000000nhash"),
+			},
+			expAmt: *coin("nhash", 100_000_000_000),
+		},
+	}
+
+	// Create a loggerMaker that captures info+ log output.
+	var logBuffer bytes.Buffer
+	bufferedLoggerMaker := func() log.Logger {
+		lw := zerolog.ConsoleWriter{Out: &logBuffer}
+		logger := zerolog.New(lw).Level(zerolog.InfoLevel).With().Timestamp().Logger()
+		return server.ZeroLogWrapper{Logger: logger}
+	}
+	defer SetLoggerMaker(SetLoggerMaker(bufferedLoggerMaker))
+
+	app := Setup(t)
+	ctx := app.NewContext(false, tmproto.Header{})
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Set/unset the v1 fee.
+			if tc.v1Amt != nil {
+				fee := msgfeetypes.NewMsgFee(v1TypeURL, *tc.v1Amt, "", 0)
+				require.NoError(t, app.MsgFeesKeeper.SetMsgFee(ctx, fee), "SetMsgFee v1")
+			} else {
+				err := app.MsgFeesKeeper.RemoveMsgFee(ctx, v1TypeURL)
+				if err != nil && !errors.Is(err, msgfeetypes.ErrMsgFeeDoesNotExist) {
+					require.NoError(t, err, "RemoveMsgFee v1")
+				}
+			}
+
+			// Set/unset the v1beta1 fee.
+			if tc.v1B1Amt != nil {
+				fee := msgfeetypes.NewMsgFee(v1B1TypeURL, *tc.v1B1Amt, "", 0)
+				require.NoError(t, app.MsgFeesKeeper.SetMsgFee(ctx, fee), "SetMsgFee v1beta1")
+			} else {
+				err := app.MsgFeesKeeper.RemoveMsgFee(ctx, v1B1TypeURL)
+				if err != nil && !errors.Is(err, msgfeetypes.ErrMsgFeeDoesNotExist) {
+					require.NoError(t, err, "RemoveMsgFee v1")
+				}
+			}
+
+			// Reset the log buffer to clear out unrelated entries.
+			logBuffer.Reset()
+			// Call AddGovV1SubmitFee and relog its output (to help if things fail).
+			testFunc := func() {
+				AddGovV1SubmitFee(ctx, app)
+			}
+			require.NotPanics(t, testFunc, "AddGovV1SubmitFee")
+			logOutput := logBuffer.String()
+			t.Logf("AddGovV1SubmitFee log output:\n%s", logOutput)
+
+			// Make sure the log has the expected lines.
+			for _, exp := range tc.expInLog {
+				assert.Contains(t, logOutput, exp, "AddGovV1SubmitFee log output")
+			}
+
+			// Get the fee and make sure it's now as expected.
+			fee, err := app.MsgFeesKeeper.GetMsgFee(ctx, v1TypeURL)
+			require.NoError(t, err, "GetMsgFee(%q) error", v1TypeURL)
+			require.NotNil(t, fee, "GetMsgFee(%q) value", v1TypeURL)
+			actFeeAmt := fee.AdditionalFee
+			assert.Equal(t, tc.expAmt.String(), actFeeAmt.String(), "final %s fee amount", v1TypeURL)
+		})
+	}
 }


### PR DESCRIPTION
## Description

Remove the `paua` and `paua-rc2` upgrades and stuff specific to those upgrades.

Add upgrade handlers for `rust-rc1` and `rust`. The `rust-rc1` upgrade will create a gov v1 `MsgSubmitProposal` message fee (if it doesn't already exist). Both upgrades will delete the `MsgP8eMemorializeContractRequest` message fee since that message no longer exists.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
