### PR TITLE
Disallow some messages and mark v1.15.2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,18 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ---
 
+## [v1.15.2](https://github.com/provenance-io/provenance/releases/tag/v1.15.2) - 2023-06-08
+
+### Bug Fixes
+
+* Address the [Barberry security advisory](https://forum.cosmos.network/t/cosmos-sdk-security-advisory-barberry/10825) [PR 1576](https://github.com/provenance-io/provenance/pull/1576)
+
+### Full Commit History
+
+* https://github.com/provenance-io/provenance/compare/v1.15.1...v1.15.2
+
+---
+
 ## [v1.15.1](https://github.com/provenance-io/provenance/releases/tag/v1.15.1) - 2023-06-01
 
 ### Improvements

--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,9 @@ DOCKER_BUF := $(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace bu
 
 GO_MAJOR_VERSION = $(shell $(GO) version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1)
 GO_MINOR_VERSION = $(shell $(GO) version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f2)
-MINIMUM_SUPPORTED_GO_MAJOR_VERSION = 1
-MINIMUM_SUPPORTED_GO_MINOR_VERSION = 17
-GO_VERSION_VALIDATION_ERR_MSG = Golang version $(GO_MAJOR_VERSION).$(GO_MINOR_VERSION) is not supported, please update to at least $(MINIMUM_SUPPORTED_GO_MAJOR_VERSION).$(MINIMUM_SUPPORTED_GO_MINOR_VERSION)
+SUPPORTED_GO_MAJOR_VERSION = 1
+SUPPORTED_GO_MINOR_VERSION = 18
+GO_VERSION_VALIDATION_ERR_MSG = Golang version $(GO_MAJOR_VERSION).$(GO_MINOR_VERSION) is not supported, you must use $(SUPPORTED_GO_MAJOR_VERSION).$(SUPPORTED_GO_MINOR_VERSION)
 
 # The below include contains the tools target.
 include contrib/devtools/Makefile
@@ -381,13 +381,8 @@ cleveldb:
 
 
 validate-go-version: ## Validates the installed version of go against Provenance's minimum requirement.
-	@if [ $(GO_MAJOR_VERSION) -gt $(MINIMUM_SUPPORTED_GO_MAJOR_VERSION) ]; then \
-		exit 0 ;\
-	elif [ $(GO_MAJOR_VERSION) -lt $(MINIMUM_SUPPORTED_GO_MAJOR_VERSION) ]; then \
-		echo '$(GO_VERSION_VALIDATION_ERR_MSG)';\
-		exit 1; \
-	elif [ $(GO_MINOR_VERSION) -lt $(MINIMUM_SUPPORTED_GO_MINOR_VERSION) ] ; then \
-		echo '$(GO_VERSION_VALIDATION_ERR_MSG)';\
+	@if [ "$(GO_MAJOR_VERSION)" -ne $(SUPPORTED_GO_MAJOR_VERSION) ] || [ "$(GO_MINOR_VERSION)" -ne $(SUPPORTED_GO_MINOR_VERSION) ]; then \
+		echo '$(GO_VERSION_VALIDATION_ERR_MSG)'; \
 		exit 1; \
 	fi
 

--- a/RELEASE_CHANGELOG.md
+++ b/RELEASE_CHANGELOG.md
@@ -1,3 +1,17 @@
+## [v1.15.2](https://github.com/provenance-io/provenance/releases/tag/v1.15.2) - 2023-06-08
+
+Provenance blockchain version `v1.15.2` addresses the [Barberry security advisory](https://forum.cosmos.network/t/cosmos-sdk-security-advisory-barberry/10825). Users **must** manually upgrade to `v1.15.2` as soon as possible.
+
+### Bug Fixes
+
+* Address the [Barberry security advisory](https://forum.cosmos.network/t/cosmos-sdk-security-advisory-barberry/10825) [PR 1576](https://github.com/provenance-io/provenance/pull/1576)
+
+### Full Commit History
+
+* https://github.com/provenance-io/provenance/compare/v1.15.1...v1.15.2
+
+---
+
 ## [v1.15.1](https://github.com/provenance-io/provenance/releases/tag/v1.15.1) - 2023-06-01
 
 Provenance blockchain version `v1.15.1` is a state-compatible upgrade to `v1.15.0`. Users are encouraged to upgrade to `v1.15.1` at their earliest convenience.

--- a/internal/antewrapper/handler.go
+++ b/internal/antewrapper/handler.go
@@ -43,7 +43,8 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 
 	decorators := []sdk.AnteDecorator{
 		cosmosante.NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
-		NewFeeMeterContextDecorator(),         // NOTE : fee gas meter also has the functionality of GasTracerContextDecorator in previous versions
+		NewMsgTypeBlacklistContextDecorator(),
+		NewFeeMeterContextDecorator(), // NOTE : fee gas meter also has the functionality of GasTracerContextDecorator in previous versions
 		NewTxGasLimitDecorator(),
 		NewMinGasPricesDecorator(),
 		NewMsgFeesDecorator(options.MsgFeesKeeper),

--- a/internal/antewrapper/msg_blacklist.go
+++ b/internal/antewrapper/msg_blacklist.go
@@ -1,0 +1,40 @@
+package antewrapper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+)
+
+// MsgTypeBlacklistContextDecorator is (hopefully) a temporary hard-coded antehandler that disallows certain messages.
+// Once the circuit breaker module is added to provenance, this should be removed.
+type MsgTypeBlacklistContextDecorator struct {
+	Blacklist []string
+}
+
+func NewMsgTypeBlacklistContextDecorator() MsgTypeBlacklistContextDecorator {
+	return MsgTypeBlacklistContextDecorator{
+		Blacklist: []string{
+			// Disallow vesting account creation due to barberry: https://forum.cosmos.network/t/cosmos-sdk-security-advisory-barberry/10825
+			// Once that fix is in the SDK that we pull in, these can be removed.
+			// MsgCreatePeriodicVestingAccount is specific to barberry, the other two are due to extra caution.
+			sdk.MsgTypeURL(&vestingtypes.MsgCreatePeriodicVestingAccount{}),
+			sdk.MsgTypeURL(&vestingtypes.MsgCreateVestingAccount{}),
+			sdk.MsgTypeURL(&vestingtypes.MsgCreatePermanentLockedAccount{}),
+		},
+	}
+}
+
+var _ sdk.AnteDecorator = MsgTypeBlacklistContextDecorator{}
+
+func (b MsgTypeBlacklistContextDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	for _, msg := range tx.GetMsgs() {
+		msgT := sdk.MsgTypeURL(msg)
+		for _, nope := range b.Blacklist {
+			if msgT == nope {
+				return ctx, sdkerrors.ErrInvalidRequest.Wrapf("%s messages are not allowed", msgT)
+			}
+		}
+	}
+	return next(ctx, tx, simulate)
+}

--- a/internal/antewrapper/msg_blacklist_test.go
+++ b/internal/antewrapper/msg_blacklist_test.go
@@ -1,0 +1,136 @@
+package antewrapper_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/ante"
+	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/provenance-io/provenance/internal/antewrapper"
+)
+
+type TestTx struct {
+	Msgs []sdk.Msg
+}
+
+func NewTestTx(msgs ...sdk.Msg) TestTx {
+	return TestTx{Msgs: msgs}
+}
+
+var (
+	_ sdk.Tx     = (*TestTx)(nil)
+	_ ante.GasTx = (*TestTx)(nil)
+)
+
+// GetMsgs satisfies sdk.Tx interface.
+func (t TestTx) GetMsgs() []sdk.Msg {
+	return t.Msgs
+}
+
+// ValidateBasic satisfies sdk.Tx interface.
+func (t TestTx) ValidateBasic() error {
+	return nil
+}
+
+// GetGas satisfies ante.GasTx interface.
+func (t TestTx) GetGas() uint64 {
+	return 1_000_000_000
+}
+
+const AllGood = "terminator called"
+
+func terminator(ctx sdk.Context, _ sdk.Tx, _ bool) (newCtx sdk.Context, err error) {
+	return ctx, errors.New(AllGood)
+}
+
+func badMsgErr(msg sdk.Msg) string {
+	return sdk.MsgTypeURL(msg) + " messages are not allowed: invalid request"
+}
+
+func TestMsgTypeBlacklistContextDecorator_AnteHandle(t *testing.T) {
+	goodMsg := &banktypes.MsgSend{}
+
+	perVMsg := &vestingtypes.MsgCreatePeriodicVestingAccount{}
+	perVMsgErr := badMsgErr(perVMsg)
+	vMsg := &vestingtypes.MsgCreateVestingAccount{}
+	vMsgErr := badMsgErr(vMsg)
+	permLVMsg := &vestingtypes.MsgCreatePermanentLockedAccount{}
+	permLVMsgErr := badMsgErr(permLVMsg)
+
+	tests := []struct {
+		name string
+		tx   sdk.Tx
+		exp  string
+	}{
+		{
+			name: "good",
+			tx:   NewTestTx(goodMsg),
+			exp:  AllGood,
+		},
+		{
+			name: "periodic vesting",
+			tx:   NewTestTx(perVMsg),
+			exp:  perVMsgErr,
+		},
+		{
+			name: "standard vesting",
+			tx:   NewTestTx(vMsg),
+			exp:  vMsgErr,
+		},
+		{
+			name: "permanent locked",
+			tx:   NewTestTx(permLVMsg),
+			exp:  permLVMsgErr,
+		},
+		{
+			name: "good good",
+			tx:   NewTestTx(goodMsg, goodMsg),
+			exp:  AllGood,
+		},
+		{
+			name: "bad good",
+			tx:   NewTestTx(perVMsg, goodMsg),
+			exp:  perVMsgErr,
+		},
+		{
+			name: "good bad",
+			tx:   NewTestTx(goodMsg, perVMsg),
+			exp:  perVMsgErr,
+		},
+		{
+			name: "bad bad",
+			tx:   NewTestTx(permLVMsg, vMsg),
+			exp:  permLVMsgErr,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bl := antewrapper.NewMsgTypeBlacklistContextDecorator()
+			_, err := bl.AnteHandle(sdk.Context{}, tc.tx, false, terminator)
+			assert.EqualError(t, err, tc.exp, "MsgTypeBlacklistContextDecorator.AnteHandle")
+		})
+	}
+}
+
+func (s *AnteTestSuite) TestBlacklistedMsgs() {
+	s.SetupTest(true)
+	badMsgs := []sdk.Msg{
+		&vestingtypes.MsgCreatePeriodicVestingAccount{},
+		&vestingtypes.MsgCreateVestingAccount{},
+		&vestingtypes.MsgCreatePeriodicVestingAccount{},
+	}
+
+	for _, msg := range badMsgs {
+		name := sdk.MsgTypeURL(msg)
+		exp := badMsgErr(msg)
+		s.Run(name, func() {
+			_, err := s.anteHandler(s.ctx, NewTestTx(msg), true)
+			s.Assert().EqualError(err, exp, "anteHandler")
+		})
+	}
+}


### PR DESCRIPTION
## Description

Disallow some messages due to barberry.
Mark `v1.15.2` in the changelog.

This PR is only applied to `release/v1.15.x` as it won't be needed in `main`. `main` will get an updated SDK version with a better fix.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
