### PR TITLE
Mark v1.15.2 and v1.15.1 in the changelog. Update validate-go-version make target to only allow go version 1.20.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,34 @@ marker escrow account if it does not have deposit access.  In order for it to wo
 
 ---
 
+## [v1.15.2](https://github.com/provenance-io/provenance/releases/tag/v1.15.2) - 2023-06-08
+
+### Bug Fixes
+
+* Address the [Barberry security advisory](https://forum.cosmos.network/t/cosmos-sdk-security-advisory-barberry/10825) [PR 1576](https://github.com/provenance-io/provenance/pull/1576)
+
+### Full Commit History
+
+* https://github.com/provenance-io/provenance/compare/v1.15.1...v1.15.2
+
+---
+
+## [v1.15.1](https://github.com/provenance-io/provenance/releases/tag/v1.15.1) - 2023-06-01
+
+### Improvements
+
+* Bumped ibc-go to 6.1.1 [PR 1563](https://github.com/provenance-io/provenance/pull/1563).
+
+### Bug Fixes
+
+* Bring back some proto messages that were deleted but still needed for historical queries [#1554](https://github.com/provenance-io/provenance/issues/1554).
+
+### Full Commit History
+
+* https://github.com/provenance-io/provenance/compare/v1.15.0...v1.15.1
+
+---
+
 ## [v1.15.0](https://github.com/provenance-io/provenance/releases/tag/v1.15.0) - 2023-05-05
 
 ### Features

--- a/Makefile
+++ b/Makefile
@@ -46,11 +46,12 @@ HTTPS_GIT := https://github.com/provenance-io/provenance.git
 DOCKER := $(shell which docker)
 DOCKER_BUF := $(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace bufbuild/buf
 
+# Only support go version 1.20
 GO_MAJOR_VERSION = $(shell $(GO) version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1)
 GO_MINOR_VERSION = $(shell $(GO) version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f2)
-MINIMUM_SUPPORTED_GO_MAJOR_VERSION = 1
-MINIMUM_SUPPORTED_GO_MINOR_VERSION = 17
-GO_VERSION_VALIDATION_ERR_MSG = Golang version $(GO_MAJOR_VERSION).$(GO_MINOR_VERSION) is not supported, please update to at least $(MINIMUM_SUPPORTED_GO_MAJOR_VERSION).$(MINIMUM_SUPPORTED_GO_MINOR_VERSION)
+SUPPORTED_GO_MAJOR_VERSION = 1
+SUPPORTED_GO_MINOR_VERSION = 20
+GO_VERSION_VALIDATION_ERR_MSG = Golang version $(GO_MAJOR_VERSION).$(GO_MINOR_VERSION) is not supported, you must use $(SUPPORTED_GO_MAJOR_VERSION).$(SUPPORTED_GO_MINOR_VERSION)
 
 # The below include contains the tools target.
 include contrib/devtools/Makefile
@@ -381,13 +382,8 @@ cleveldb:
 
 
 validate-go-version: ## Validates the installed version of go against Provenance's minimum requirement.
-	@if [ $(GO_MAJOR_VERSION) -gt $(MINIMUM_SUPPORTED_GO_MAJOR_VERSION) ]; then \
-		exit 0 ;\
-	elif [ $(GO_MAJOR_VERSION) -lt $(MINIMUM_SUPPORTED_GO_MAJOR_VERSION) ]; then \
-		echo '$(GO_VERSION_VALIDATION_ERR_MSG)';\
-		exit 1; \
-	elif [ $(GO_MINOR_VERSION) -lt $(MINIMUM_SUPPORTED_GO_MINOR_VERSION) ] ; then \
-		echo '$(GO_VERSION_VALIDATION_ERR_MSG)';\
+	@if [ "$(GO_MAJOR_VERSION)" -ne $(SUPPORTED_GO_MAJOR_VERSION) ] || [ "$(GO_MINOR_VERSION)" -ne $(SUPPORTED_GO_MINOR_VERSION) ]; then \
+		echo '$(GO_VERSION_VALIDATION_ERR_MSG)'; \
 		exit 1; \
 	fi
 


### PR DESCRIPTION
## Description

This PR:
* Brings the `v1.15.2` and `v1.15.1` changelog entries into `main` from `release/v1.15.x`.
* Updates the `validate-go-version` make target to only allow version 1.20. This change was made in `release/v1.15.x` for `v1.15.2` but with go version 1.18. But since we're only going to support 1.20 for `v1.16`, it's a good change to have in `main` too. Currently, `main` just requires at least go version 1.17, which isn't correct anyway.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
