### PR TITLE
Create pre-upgrade command. Fix minimum-gas-prices repacking unset.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+TODO[1594]: Move these to correct sections once v1.16.0-rc1 is marked.
+* Add pre-upgrade command that updates config files to newest format and sets `consensus.timeout_commit` to `5s` [PR 1594](https://github.com/provenance-io/provenance/pull/1594)
+* Fix `minimum-gas-prices` from sometimes getting unset in the configs [PR 1594](https://github.com/provenance-io/provenance/pull/1594)
+
 ### Features
 
 * Add support to add/remove required attributes for a restricted marker. [#1512](https://github.com/provenance-io/provenance/issues/1512)

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -76,8 +76,7 @@ func (s *UpgradeTestSuite) GetLogOutput(msg string, args ...interface{}) string 
 // Use this if there's a possible error that we probably don't care about (but might).
 func (s *UpgradeTestSuite) LogIfError(err error, format string, args ...interface{}) {
 	if err != nil {
-		args = append(args, err)
-		s.T().Logf(format+": %v", args)
+		s.T().Logf(format+" error: %v", append(args, err)...)
 	}
 }
 

--- a/cmd/provenanced/cmd/cmd_test.go
+++ b/cmd/provenanced/cmd/cmd_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestInitCmd(t *testing.T) {
-	rootCmd, _ := cmd.NewRootCmd()
+	rootCmd, _ := cmd.NewRootCmd(true)
 	rootCmd.SetArgs([]string{
 		"init",        // Test the init cmd
 		"simapp-test", // Moniker

--- a/cmd/provenanced/cmd/cmd_test.go
+++ b/cmd/provenanced/cmd/cmd_test.go
@@ -12,8 +12,10 @@ import (
 )
 
 func TestInitCmd(t *testing.T) {
-	rootCmd, _ := cmd.NewRootCmd(true)
+	home := t.TempDir()
+	rootCmd, _ := cmd.NewRootCmd(false)
 	rootCmd.SetArgs([]string{
+		"--home", home,
 		"init",        // Test the init cmd
 		"simapp-test", // Moniker
 		fmt.Sprintf("--%s=%s", cli.FlagOverwrite, "true"), // Overwrite genesis.json, in case it already exists

--- a/cmd/provenanced/cmd/config_test.go
+++ b/cmd/provenanced/cmd/config_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/tendermint/tendermint/libs/log"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/server"
 	sdksim "github.com/cosmos/cosmos-sdk/simapp"
@@ -24,9 +26,6 @@ import (
 	"github.com/provenance-io/provenance/cmd/provenanced/cmd"
 	provconfig "github.com/provenance-io/provenance/cmd/provenanced/config"
 	"github.com/provenance-io/provenance/internal/pioconfig"
-
-	tmconfig "github.com/tendermint/tendermint/config"
-	"github.com/tendermint/tendermint/libs/log"
 )
 
 type ConfigTestSuite struct {
@@ -57,7 +56,7 @@ func (s *ConfigTestSuite) SetupTest() {
 		WithCodec(encodingConfig.Codec).
 		WithHomeDir(s.Home)
 	clientCtx.Viper = viper.New()
-	serverCtx := server.NewContext(clientCtx.Viper, tmconfig.DefaultConfig(), log.NewNopLogger())
+	serverCtx := server.NewContext(clientCtx.Viper, provconfig.DefaultTmConfig(), log.NewNopLogger())
 
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, client.ClientContextKey, &clientCtx)

--- a/cmd/provenanced/cmd/config_test.go
+++ b/cmd/provenanced/cmd/config_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"regexp"
 	"strings"
@@ -85,7 +85,7 @@ func TestConfigTestSuite(t *testing.T) {
 // Test setup above. Test helpers below.
 //
 
-func (s ConfigTestSuite) getConfigCmd() *cobra.Command {
+func (s *ConfigTestSuite) getConfigCmd() *cobra.Command {
 	// What I really need here is a cobra.Command
 	// that already has a context.
 	// So I'm going to call --help on the config command
@@ -103,7 +103,7 @@ func (s ConfigTestSuite) getConfigCmd() *cobra.Command {
 	return configCmd
 }
 
-func (s ConfigTestSuite) ensureConfigFiles() {
+func (s *ConfigTestSuite) ensureConfigFiles() {
 	configCmd := s.getConfigCmd()
 	// Extract the individual config objects.
 	appConfig, aerr := provconfig.ExtractAppConfig(configCmd)
@@ -117,66 +117,66 @@ func (s ConfigTestSuite) ensureConfigFiles() {
 	provconfig.SaveConfigs(configCmd, appConfig, tmConfig, clientConfig, false)
 }
 
-func (s ConfigTestSuite) makeConfigHeaderLine(t, fn string) string {
+func (s *ConfigTestSuite) makeConfigHeaderLine(t, fn string) string {
 	return fmt.Sprintf("%s Config: %s/config/%s (or env)", t, s.Home, fn)
 }
 
-func (s ConfigTestSuite) makeAppConfigHeaderLines() string {
+func (s *ConfigTestSuite) makeAppConfigHeaderLines() string {
 	return s.makeConfigHeaderLine(s.HeaderStrApp, s.BaseFNApp) + "\n----------------"
 }
 
-func (s ConfigTestSuite) makeTMConfigHeaderLines() string {
+func (s *ConfigTestSuite) makeTMConfigHeaderLines() string {
 	return s.makeConfigHeaderLine(s.HeaderStrTM, s.BaseFNTM) + "\n-----------------------"
 }
 
-func (s ConfigTestSuite) makeClientConfigHeaderLines() string {
+func (s *ConfigTestSuite) makeClientConfigHeaderLines() string {
 	return s.makeConfigHeaderLine(s.HeaderStrClient, s.baseFNClient) + "\n-------------------"
 }
 
-func (s ConfigTestSuite) makeConfigUpdatedLine(t, fn string) string {
+func (s *ConfigTestSuite) makeConfigUpdatedLine(t, fn string) string {
 	return fmt.Sprintf("%s Config Updated: %s/config/%s", t, s.Home, fn)
 }
 
-func (s ConfigTestSuite) makeAppConfigUpdateLines() string {
+func (s *ConfigTestSuite) makeAppConfigUpdateLines() string {
 	return s.makeConfigUpdatedLine(s.HeaderStrApp, s.BaseFNApp) + "\n------------------------"
 }
 
-func (s ConfigTestSuite) makeTMConfigUpdateLines() string {
+func (s *ConfigTestSuite) makeTMConfigUpdateLines() string {
 	return s.makeConfigUpdatedLine(s.HeaderStrTM, s.BaseFNTM) + "\n-------------------------------"
 }
 
-func (s ConfigTestSuite) makeClientConfigUpdateLines() string {
+func (s *ConfigTestSuite) makeClientConfigUpdateLines() string {
 	return s.makeConfigUpdatedLine(s.HeaderStrClient, s.baseFNClient) + "\n---------------------------"
 }
 
-func (s ConfigTestSuite) makeConfigDiffHeaderLine(t, fn string) string {
+func (s *ConfigTestSuite) makeConfigDiffHeaderLine(t, fn string) string {
 	return fmt.Sprintf("%s Config Differences from Defaults: %s/config/%s (or env)", t, s.Home, fn)
 }
 
-func (s ConfigTestSuite) makeAppDiffHeaderLines() string {
+func (s *ConfigTestSuite) makeAppDiffHeaderLines() string {
 	return s.makeConfigDiffHeaderLine(s.HeaderStrApp, s.BaseFNApp) + "\n------------------------------------------"
 }
 
-func (s ConfigTestSuite) makeTMDiffHeaderLines() string {
+func (s *ConfigTestSuite) makeTMDiffHeaderLines() string {
 	return s.makeConfigDiffHeaderLine(s.HeaderStrTM, s.BaseFNTM) + "\n-------------------------------------------------"
 }
 
-func (s ConfigTestSuite) makeClientDiffHeaderLines() string {
+func (s *ConfigTestSuite) makeClientDiffHeaderLines() string {
 	return s.makeConfigDiffHeaderLine(s.HeaderStrClient, s.baseFNClient) + "\n---------------------------------------------"
 }
 
-func (s ConfigTestSuite) makeMultiLine(lines ...string) string {
+func (s *ConfigTestSuite) makeMultiLine(lines ...string) string {
 	return strings.Join(lines, "\n") + "\n"
 }
 
-func (s ConfigTestSuite) makeKeyUpdatedLine(key, oldVal, newVal string) string {
+func (s *ConfigTestSuite) makeKeyUpdatedLine(key, oldVal, newVal string) string {
 	return fmt.Sprintf("%s Was: %s, Is Now: %s", key, oldVal, newVal)
 }
 
 func applyMockIODiscardOutErr(c *cobra.Command) *bytes.Buffer {
 	b := bytes.NewBufferString("")
-	c.SetOut(ioutil.Discard)
-	c.SetErr(ioutil.Discard)
+	c.SetOut(io.Discard)
+	c.SetErr(io.Discard)
 	return b
 }
 
@@ -226,7 +226,7 @@ func (s *ConfigTestSuite) TestConfigCmdGet() {
 	b := applyMockIOOutErr(configCmd)
 	err := configCmd.Execute()
 	s.Require().NoError(err, "%s - unexpected error executing configCmd", configCmd.Name())
-	out, err := ioutil.ReadAll(b)
+	out, err := io.ReadAll(b)
 	s.Require().NoError(err, "%s - unexpected error reading configCmd output", configCmd.Name())
 	outStr := string(out)
 
@@ -275,7 +275,7 @@ func (s *ConfigTestSuite) TestConfigCmdGet() {
 		b2 := applyMockIOOutErr(configCmd2)
 		err2 := configCmd2.Execute()
 		require.NoError(t, err2, "%s - unexpected error executing configCmd", configCmd2.Name())
-		out2, err2 := ioutil.ReadAll(b2)
+		out2, err2 := io.ReadAll(b2)
 		require.NoError(t, err2, "%s - unexpected error reading configCmd output", configCmd2.Name())
 		out2Str := string(out2)
 		require.Equal(t, outStr, out2Str, "output of no-args vs output of %s", args)
@@ -318,7 +318,7 @@ func (s *ConfigTestSuite) TestConfigCmdGet() {
 			b3 := applyMockIOOutErr(configCmd3)
 			err3 := configCmd3.Execute()
 			require.NoError(t, err3, "%s - unexpected error executing configCmd", configCmd3.Name())
-			out3, rerr3 := ioutil.ReadAll(b3)
+			out3, rerr3 := io.ReadAll(b3)
 			require.NoError(t, rerr3, "%s - unexpected error reading configCmd output", configCmd3.Name())
 			out3Str := string(out3)
 			require.Contains(t, outStr, out3Str, "output of no-args vs output of %s", tc.args)
@@ -391,7 +391,7 @@ func (s *ConfigTestSuite) TestConfigGetMulti() {
 			b := applyMockIOOutErr(configCmd)
 			err := configCmd.Execute()
 			require.NoError(t, err, "%s %s - unexpected error executing configCmd", configCmd.Name(), args)
-			out, err := ioutil.ReadAll(b)
+			out, err := io.ReadAll(b)
 			require.NoError(t, err, "%s %s - unexpected error reading configCmd output", configCmd.Name(), args)
 			outStr := string(out)
 			assert.Equal(t, tc.expected, outStr, "%s %s - output", configCmd.Name(), args)
@@ -416,7 +416,7 @@ func (s *ConfigTestSuite) TestConfigGetMulti() {
 		b := applyMockIOOutErr(configCmd)
 		err := configCmd.Execute()
 		require.NoError(t, err, "%s %s - expected error executing configCmd", configCmd.Name(), args)
-		out, err := ioutil.ReadAll(b)
+		out, err := io.ReadAll(b)
 		require.NoError(t, err, "%s %s - unexpected error reading configCmd output", configCmd.Name(), args)
 		outStr := string(out)
 		assert.Equal(t, expected, outStr, "%s %s - output", configCmd.Name(), args)
@@ -439,7 +439,7 @@ func (s *ConfigTestSuite) TestConfigGetMulti() {
 		b := applyMockIOOutErr(configCmd)
 		err := configCmd.Execute()
 		require.NoError(t, err, "%s %s - expected error executing configCmd", configCmd.Name(), args)
-		out, err := ioutil.ReadAll(b)
+		out, err := io.ReadAll(b)
 		require.NoError(t, err, "%s %s - unexpected error reading configCmd output", configCmd.Name(), args)
 		outStr := string(out)
 		assert.Equal(t, expected, outStr, "%s %s - output", configCmd.Name(), args)
@@ -465,7 +465,7 @@ func (s *ConfigTestSuite) TestConfigChanged() {
 		allEqual("client"),
 		"",
 	}
-	expectedAllOutLines := []string{}
+	var expectedAllOutLines []string
 	expectedAllOutLines = append(expectedAllOutLines, expectedAppOutLines...)
 	expectedAllOutLines = append(expectedAllOutLines, expectedTMOutLines...)
 	expectedAllOutLines = append(expectedAllOutLines, expectedClientOutLines...)
@@ -504,7 +504,7 @@ func (s *ConfigTestSuite) TestConfigChanged() {
 			b := applyMockIOOutErr(configCmd)
 			err := configCmd.Execute()
 			require.NoError(t, err, "%s %s - unexpected error executing configCmd", configCmd.Name(), tc.args)
-			out, err := ioutil.ReadAll(b)
+			out, err := io.ReadAll(b)
 			require.NoError(t, err, "%s %s - unexpected error reading configCmd output", configCmd.Name(), tc.args)
 			outStr := string(out)
 			assert.Equal(t, tc.out, outStr, "%s %s - output", configCmd.Name(), tc.args)
@@ -543,7 +543,7 @@ func (s *ConfigTestSuite) TestConfigSetValidation() {
 			b := applyMockIOOutErr(configCmd)
 			err := configCmd.Execute()
 			require.NoError(t, err, "%s %s unexpected error executing configCmd", configCmd.Name(), tc.args)
-			out, rerr := ioutil.ReadAll(b)
+			out, rerr := io.ReadAll(b)
 			require.NoError(t, rerr, "%s %s unexpected error reading output", configCmd.Name(), tc.args)
 			outStr := string(out)
 			assert.True(t, strings.Contains(outStr, expected), "%s %s output", configCmd.Name(), tc.args)
@@ -668,7 +668,7 @@ func (s *ConfigTestSuite) TestConfigCmdSet() {
 			b := applyMockIOOutErr(configCmd)
 			err := configCmd.Execute()
 			require.NoError(t, err, "%s %s - unexpected error in execution", configCmd.Name(), args)
-			out, rerr := ioutil.ReadAll(b)
+			out, rerr := io.ReadAll(b)
 			require.NoError(t, rerr, "%s %s - unexpected error in reading", configCmd.Name(), args)
 			outStr := string(out)
 			for _, re := range tc.toMatch {
@@ -745,7 +745,7 @@ func (s *ConfigTestSuite) TestConfigSetMulti() {
 			b := applyMockIOOutErr(configCmd)
 			err := configCmd.Execute()
 			require.NoError(t, err, "%s %s - unexpected error in execution", configCmd.Name(), tc.args)
-			out, rerr := ioutil.ReadAll(b)
+			out, rerr := io.ReadAll(b)
 			require.NoError(t, rerr, "%s %s - unexpected error in reading", configCmd.Name(), tc.args)
 			outStr := string(out)
 			assert.Equal(t, tc.out, outStr, "%s %s output", configCmd.Name(), tc.args)
@@ -765,7 +765,7 @@ func (s *ConfigTestSuite) TestPackUnpack() {
 		b := applyMockIOOutErr(configCmd)
 		err := configCmd.Execute()
 		require.NoError(t, err, "%s %s - unexpected error in execution", configCmd.Name(), args)
-		out, rerr := ioutil.ReadAll(b)
+		out, rerr := io.ReadAll(b)
 		require.NoError(t, rerr, "%s %s - unexpected error in reading", configCmd.Name(), args)
 		outStr := string(out)
 
@@ -779,7 +779,7 @@ func (s *ConfigTestSuite) TestPackUnpack() {
 		assert.False(t, provconfig.FileExists(appFile), "file exists: app")
 		tmFile := provconfig.GetFullPathToAppConf(configCmd)
 		assert.Contains(t, outStr, tmFile, "tendermint filename")
-		assert.False(t, provconfig.FileExists(tmFile), "file exists: tenderming")
+		assert.False(t, provconfig.FileExists(tmFile), "file exists: tendermint")
 		clientFile := provconfig.GetFullPathToAppConf(configCmd)
 		assert.Contains(t, outStr, clientFile, "client filename")
 		assert.False(t, provconfig.FileExists(clientFile), "file exists: client")
@@ -792,7 +792,7 @@ func (s *ConfigTestSuite) TestPackUnpack() {
 		b := applyMockIOOutErr(configCmd)
 		err := configCmd.Execute()
 		require.NoError(t, err, "%s %s - unexpected error in execution", configCmd.Name(), args)
-		out, rerr := ioutil.ReadAll(b)
+		out, rerr := io.ReadAll(b)
 		require.NoError(t, rerr, "%s %s - unexpected error in reading", configCmd.Name(), args)
 		outStr := string(out)
 
@@ -804,7 +804,7 @@ func (s *ConfigTestSuite) TestPackUnpack() {
 		assert.True(t, provconfig.FileExists(appFile), "file exists: app")
 		tmFile := provconfig.GetFullPathToAppConf(configCmd)
 		assert.Contains(t, outStr, tmFile, "tendermint filename")
-		assert.True(t, provconfig.FileExists(tmFile), "file exists: tenderming")
+		assert.True(t, provconfig.FileExists(tmFile), "file exists: tendermint")
 		clientFile := provconfig.GetFullPathToAppConf(configCmd)
 		assert.Contains(t, outStr, clientFile, "client filename")
 		assert.True(t, provconfig.FileExists(clientFile), "file exists: client")

--- a/cmd/provenanced/cmd/config_test.go
+++ b/cmd/provenanced/cmd/config_test.go
@@ -247,7 +247,7 @@ func (s *ConfigTestSuite) TestConfigCmdGet() {
 		// Tendermint header and a few entries.
 		{"tendermint header", regexp.MustCompile(`(?m)^Tendermint Config: .*/config/` + s.BaseFNTM + ` \(or env\)$`)},
 		{"tendermint fast_sync", regexp.MustCompile(`(?m)^fast_sync=true$`)},
-		{"tendermint consensus.timeout_commit", regexp.MustCompile(`(?m)^consensus.timeout_commit="1s"$`)},
+		{"tendermint consensus.timeout_commit", regexp.MustCompile(`(?m)^consensus.timeout_commit="5s"$`)},
 		{"tendermint mempool.size", regexp.MustCompile(`(?m)^mempool.size=5000$`)},
 		{"tendermint statesync.trust_period", regexp.MustCompile(`(?m)^statesync.trust_period="168h0m0s"$`)},
 		{"tendermint p2p.recv_rate", regexp.MustCompile(`(?m)^p2p.recv_rate=5120000$`)},
@@ -609,7 +609,7 @@ func (s *ConfigTestSuite) TestConfigCmdSet() {
 		},
 		{
 			name:    "consensus.timeout_commit",
-			oldVal:  `"1s"`,
+			oldVal:  `"5s"`,
 			newVal:  `"2s"`,
 			toMatch: []*regexp.Regexp{reTMConfigUpdated},
 		},
@@ -701,7 +701,7 @@ func (s *ConfigTestSuite) TestConfigSetMulti() {
 			out: s.makeMultiLine(
 				s.makeTMConfigUpdateLines(),
 				s.makeKeyUpdatedLine("log_format", `"plain"`, `"json"`),
-				s.makeKeyUpdatedLine("consensus.timeout_commit", `"1s"`, `"950ms"`),
+				s.makeKeyUpdatedLine("consensus.timeout_commit", `"5s"`, `"950ms"`),
 				""),
 		},
 		{

--- a/cmd/provenanced/cmd/init.go
+++ b/cmd/provenanced/cmd/init.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -38,9 +39,10 @@ import (
 const (
 	// FlagOverwrite defines a flag to overwrite an existing genesis JSON file.
 	FlagOverwrite = "overwrite"
-
 	// FlagRecover defines a flag to initialize the private validator key from a specific seed.
 	FlagRecover = "recover"
+	// FlagTimeoutCommit is the flag string for providing a consensus.timeout_commit setting.
+	FlagTimeoutCommit = "timeout-commit"
 )
 
 // InitCmd Creates a command for generating genesis and config files.
@@ -57,11 +59,12 @@ func InitCmd(mbm module.BasicManager) *cobra.Command {
 			return Init(cmd, mbm, args[0])
 		},
 	}
-	cmd.Flags().String(flags.FlagChainID, "", "genesis file chain-id, if left blank will be randomly created")
-	cmd.Flags().BoolP(FlagRecover, "r", false, "interactive key recovery from mnemonic")
-	cmd.Flags().BoolP(FlagOverwrite, "o", false, "overwrite the genesis.json file")
-	cmd.Flags().String(provconfig.CustomDenomFlag, "", "custom denom, optional")
-	cmd.Flags().Int64(provconfig.CustomMsgFeeFloorPriceFlag, 0, "custom msg fee floor price, optional")
+	cmd.Flags().String(flags.FlagChainID, "", "Genesis file chain-id, if left blank will be randomly created")
+	cmd.Flags().BoolP(FlagRecover, "r", false, "Interactive key recovery from mnemonic")
+	cmd.Flags().BoolP(FlagOverwrite, "o", false, "Overwrite the genesis.json file")
+	cmd.Flags().String(provconfig.CustomDenomFlag, "", "Custom denom, optional")
+	cmd.Flags().Int64(provconfig.CustomMsgFeeFloorPriceFlag, 0, "Custom msg fee floor price, optional")
+	cmd.Flags().Duration(FlagTimeoutCommit, 0, "The consensus.timeout_commit value to start with (default is 5s for mainnet or testnet, 1s otherwise)")
 	return cmd
 }
 
@@ -75,8 +78,12 @@ func Init(
 	isTestnet, _ := cmd.Flags().GetBool(EnvTypeFlag)
 	doRecover, _ := cmd.Flags().GetBool(FlagRecover)
 	doOverwrite, _ := cmd.Flags().GetBool(FlagOverwrite)
+	timeoutCommit, err := cmd.Flags().GetDuration(FlagTimeoutCommit)
+	if err != nil {
+		return fmt.Errorf("invalid --%s: %w", FlagTimeoutCommit, err)
+	}
 
-	if err := provconfig.EnsureConfigDir(cmd); err != nil {
+	if err = provconfig.EnsureConfigDir(cmd); err != nil {
 		return err
 	}
 
@@ -109,6 +116,14 @@ func Init(
 		cmd.Printf("chain id: %s\n", chainID)
 	}
 	clientConfig.ChainID = chainID
+
+	// If a timeout commit wasn't provided and not on a mainnet or testnet, set the timeout commit to 1s.
+	if timeoutCommit == 0 && !strings.Contains(chainID, "mainnet") && !strings.Contains(chainID, "testnet") {
+		timeoutCommit = 1 * time.Second
+	}
+	if timeoutCommit > 0 {
+		tmConfig.Consensus.TimeoutCommit = timeoutCommit
+	}
 
 	// Gather the bip39 mnemonic if a recover was requested.
 	var mnemonic string

--- a/cmd/provenanced/cmd/init.go
+++ b/cmd/provenanced/cmd/init.go
@@ -60,8 +60,8 @@ func InitCmd(mbm module.BasicManager) *cobra.Command {
 	cmd.Flags().String(flags.FlagChainID, "", "genesis file chain-id, if left blank will be randomly created")
 	cmd.Flags().BoolP(FlagRecover, "r", false, "interactive key recovery from mnemonic")
 	cmd.Flags().BoolP(FlagOverwrite, "o", false, "overwrite the genesis.json file")
-	cmd.Flags().String(CustomDenomFlag, "", "custom denom, optional")
-	cmd.Flags().Int64(CustomMsgFeeFloorPriceFlag, 0, "custom msg fee floor price, optional")
+	cmd.Flags().String(provconfig.CustomDenomFlag, "", "custom denom, optional")
+	cmd.Flags().Int64(provconfig.CustomMsgFeeFloorPriceFlag, 0, "custom msg fee floor price, optional")
 	return cmd
 }
 
@@ -76,10 +76,6 @@ func Init(
 	doRecover, _ := cmd.Flags().GetBool(FlagRecover)
 	doOverwrite, _ := cmd.Flags().GetBool(FlagOverwrite)
 
-	customDenom, _ := cmd.Flags().GetString(CustomDenomFlag)
-	customMsgFeeFloorPrice, _ := cmd.Flags().GetInt64(CustomMsgFeeFloorPriceFlag)
-
-	pioconfig.SetProvenanceConfig(customDenom, customMsgFeeFloorPrice)
 	if err := provconfig.EnsureConfigDir(cmd); err != nil {
 		return err
 	}

--- a/cmd/provenanced/cmd/pre_upgrade.go
+++ b/cmd/provenanced/cmd/pre_upgrade.go
@@ -81,12 +81,14 @@ func UpdateConfig(cmd *cobra.Command) error {
 		return err
 	}
 
-	// Update the timeout commit if it's too low.
-	timeoutCommit := config.DefaultConsensusTimeoutCommit
-	if tmCfg.Consensus.TimeoutCommit < timeoutCommit/2 {
-		cmd.Printf("Updating consensus.timeout_commit config value to %q (from %q)\n",
-			timeoutCommit, tmCfg.Consensus.TimeoutCommit)
-		tmCfg.Consensus.TimeoutCommit = timeoutCommit
+	if clientCfg.ChainID == "pio-mainnet-1" {
+		// Update the timeout commit if it's too low.
+		timeoutCommit := config.DefaultConsensusTimeoutCommit
+		if tmCfg.Consensus.TimeoutCommit < timeoutCommit/2 {
+			cmd.Printf("Updating consensus.timeout_commit config value to %q (from %q)\n",
+				timeoutCommit, tmCfg.Consensus.TimeoutCommit)
+			tmCfg.Consensus.TimeoutCommit = timeoutCommit
+		}
 	}
 
 	return SafeSaveConfigs(cmd, appCfg, tmCfg, clientCfg, true)

--- a/cmd/provenanced/cmd/pre_upgrade.go
+++ b/cmd/provenanced/cmd/pre_upgrade.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	tmconfig "github.com/tendermint/tendermint/config"
+
+	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
+
+	"github.com/provenance-io/provenance/cmd/provenanced/config"
+)
+
+func GetPreUpgradeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "pre-upgrade",
+		Short:        "Pre-Upgrade command",
+		Long:         "Pre-upgrade command to implement custom pre-upgrade handling",
+		Args:         cobra.NoArgs,
+		Hidden:       true,
+		SilenceUsage: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			err := UpdateConfig(cmd)
+			if err != nil {
+				cmd.PrintErrf("could not update config file(s): %v\n", err)
+				os.Exit(30)
+			}
+		},
+	}
+
+	return cmd
+}
+
+// UpdateConfig writes the current config to files.
+func UpdateConfig(cmd *cobra.Command) error {
+	// This depends on the configs already being loaded.
+	// Usually this is done with the root command's PersistentPreRunE.
+	// If the config(s) change too much though, you might need to read/load
+	// them using something else that correctly reads in the previous version.
+
+	appCfg, err := config.ExtractAppConfig(cmd)
+	if err != nil {
+		return err
+	}
+
+	tmCfg, err := config.ExtractTmConfig(cmd)
+	if err != nil {
+		return err
+	}
+
+	clientCfg, err := config.ExtractClientConfig(cmd)
+	if err != nil {
+		return err
+	}
+
+	if tmCfg.Consensus.TimeoutCommit <= 4*time.Second {
+		tmCfg.Consensus.TimeoutCommit = 5 * time.Second
+	}
+
+	return SafeSaveConfigs(cmd, appCfg, tmCfg, clientCfg, true)
+}
+
+func SafeSaveConfigs(cmd *cobra.Command,
+	appConfig *serverconfig.Config,
+	tmConfig *tmconfig.Config,
+	clientConfig *config.ClientConfig,
+	verbose bool,
+) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if e, isErr := r.(error); isErr {
+				err = fmt.Errorf("error saving config file(s): %w", e)
+			} else {
+				err = fmt.Errorf("error saving config file(s): %v", r)
+			}
+		}
+	}()
+	config.SaveConfigs(cmd, appConfig, tmConfig, clientConfig, verbose)
+	return nil
+}

--- a/cmd/provenanced/cmd/pre_upgrade.go
+++ b/cmd/provenanced/cmd/pre_upgrade.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -82,12 +81,11 @@ func UpdateConfig(cmd *cobra.Command) error {
 		return err
 	}
 
-	// Set any config values that we want to forcefully update.
-
-	timeoutCommit := 5 * time.Second
-	if tmCfg.Consensus.TimeoutCommit != timeoutCommit {
+	// Update the timeout commit if it's too low.
+	timeoutCommit := config.DefaultConsensusTimeoutCommit
+	if tmCfg.Consensus.TimeoutCommit < timeoutCommit/2 {
 		cmd.Printf("Updating consensus.timeout_commit config value to %q (from %q)\n",
-			timeoutCommit.String(), tmCfg.Consensus.TimeoutCommit.String())
+			timeoutCommit, tmCfg.Consensus.TimeoutCommit)
 		tmCfg.Consensus.TimeoutCommit = timeoutCommit
 	}
 

--- a/cmd/provenanced/cmd/pre_upgrade.go
+++ b/cmd/provenanced/cmd/pre_upgrade.go
@@ -52,7 +52,7 @@ Exit code meanings:
 			if err != nil {
 				return errors.Join(fmt.Errorf("could not update config file(s): %w", err), ErrFail)
 			}
-			cmd.Printf("pre-upgrade successful")
+			cmd.Printf("pre-upgrade successful\n")
 			return nil
 		},
 	}

--- a/cmd/provenanced/cmd/pre_upgrade_test.go
+++ b/cmd/provenanced/cmd/pre_upgrade_test.go
@@ -1,0 +1,408 @@
+package cmd_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/server"
+	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
+	sdksim "github.com/cosmos/cosmos-sdk/simapp"
+	"github.com/provenance-io/provenance/app"
+	"github.com/provenance-io/provenance/cmd/provenanced/cmd"
+	"github.com/provenance-io/provenance/cmd/provenanced/config"
+	"github.com/provenance-io/provenance/internal/pioconfig"
+	tmconfig "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/libs/log"
+)
+
+// logIfError logs an error if it's not nil.
+// The error is automatically added to the format and args.
+// Use this if there's a possible error that we probably don't care about (but might).
+func logIfError(t *testing.T, err error, format string, args ...interface{}) {
+	if err != nil {
+		t.Logf(format+" error: %v", append(args, err)...)
+	}
+}
+
+func logDir(t *testing.T, path string) {
+	contents, err := os.ReadDir(path)
+	if os.IsNotExist(err) {
+		t.Logf("Directory does not exist: %s", path)
+		return
+	}
+	if err != nil {
+		t.Logf("Error reading directory: %v", err)
+		return
+	}
+
+	var files []string
+	var dirs []string
+	for _, entry := range contents {
+		if entry.IsDir() {
+			dirs = append(dirs, entry.Name())
+		} else {
+			files = append(files, entry.Name())
+		}
+	}
+
+	if len(dirs) == 0 {
+		t.Logf("No subdirectories: %s", path)
+	} else {
+		t.Logf("Subdirectories: %s\n  %s", path, strings.Join(dirs, "  \n"))
+	}
+	if len(files) == 0 {
+		t.Logf("No files: %s", path)
+	} else {
+		t.Logf("Directory files: %s\n  %s", path, strings.Join(files, "  \n"))
+	}
+
+	for _, file := range files {
+		fullPath := filepath.Join(path, file)
+		fileContents, err := os.ReadFile(fullPath)
+		if err != nil {
+			t.Logf("Error reading file: %v", err)
+		}
+		t.Logf("File Contents: %s\n%s", fullPath, fileContents)
+	}
+
+	for _, dir := range dirs {
+		logDir(t, filepath.Join(path, dir))
+	}
+}
+
+// CmdResult contains the info, results, and output of the an executed command.
+type CmdResult struct {
+	Cmd      *cobra.Command
+	Home     string
+	Stdout   string
+	Stderr   string
+	Result   error
+	ExitCode int
+}
+
+func executeRootCmd(t *testing.T, home string, cmdArgs ...string) *CmdResult {
+	rv := &CmdResult{Home: home}
+
+	origHome := app.DefaultNodeHome
+	defer func() {
+		app.DefaultNodeHome = origHome
+	}()
+	t.Logf("Setting DefaultNodeHome = %q", home)
+	app.DefaultNodeHome = home
+
+	// Use our own buffers for the output so we can capture it.
+	var outBuf, errBuf bytes.Buffer
+	rv.Cmd, _ = cmd.NewRootCmd(false)
+	rv.Cmd.SetOut(&outBuf)
+	rv.Cmd.SetErr(&errBuf)
+	rv.Cmd.SetArgs(cmdArgs)
+
+	t.Logf("Executing: %s", strings.Join(append([]string{rv.Cmd.Name()}, cmdArgs...), " "))
+	// This is similar logic to main.go, but just capturing the exit code instead of calling os.Exit.
+	if rv.Result = cmd.Execute(rv.Cmd); rv.Result != nil {
+		var srvErrP *server.ErrorCode
+		var srvErr server.ErrorCode
+		switch {
+		case errors.As(rv.Result, &srvErrP):
+			rv.ExitCode = srvErrP.Code
+		case errors.As(rv.Result, &srvErr):
+			rv.ExitCode = srvErr.Code
+		default:
+			os.Exit(1)
+		}
+	}
+	t.Logf("exit code: %d", rv.ExitCode)
+
+	rv.Stdout = outBuf.String()
+	if len(rv.Stdout) == 0 {
+		t.Logf("Nothing printed to stdout.")
+	} else {
+		t.Logf("stdout:\n%s", rv.Stdout)
+	}
+
+	rv.Stderr = errBuf.String()
+	if len(rv.Stderr) == 0 {
+		t.Logf("Nothing printed to stderr.")
+	} else {
+		t.Logf("stderr:\n%s", rv.Stderr)
+	}
+
+	return rv
+}
+
+func executePreUpgradeCmd(t *testing.T, home string, cmdArgs ...string) *CmdResult {
+	return executeRootCmd(t, home, append([]string{"pre-upgrade"}, cmdArgs...)...)
+}
+
+// assertContainsAll asserts that all of the expected entries are substrings of the actual.
+// Returns true if that is the case, false = failure.
+func assertContainsAll(t *testing.T, actual string, expected []string, msgAndArgs ...interface{}) bool {
+	t.Helper()
+	missing := make(map[int]bool)
+	for i, exp := range expected {
+		if !strings.Contains(actual, exp) {
+			missing[i] = true
+		}
+	}
+
+	if len(missing) == 0 {
+		return true
+	}
+
+	lines := []string{
+		fmt.Sprintf("Missing %d expected substring(s).", len(missing)),
+		fmt.Sprintf("Actual:\n%s", actual),
+		"Expected:",
+	}
+	for i, exp := range expected {
+		result := "( found )"
+		if missing[i] {
+			result = "(missing)"
+		}
+		lines = append(lines, fmt.Sprintf("[%d] %s: %q", i, result, exp))
+	}
+
+	return assert.Fail(t, strings.Join(lines, "\n"), msgAndArgs...)
+}
+
+// makeDummyCmd creates a dummy command with a context in it that can be used to test all the config stuff.
+func makeDummyCmd(t *testing.T, home string) *cobra.Command {
+	encodingConfig := sdksim.MakeTestEncodingConfig()
+	clientCtx := client.Context{}.
+		WithCodec(encodingConfig.Codec).
+		WithHomeDir(home)
+	clientCtx.Viper = viper.New()
+	serverCtx := server.NewContext(clientCtx.Viper, config.DefaultTmConfig(), log.NewNopLogger())
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, client.ClientContextKey, &clientCtx)
+	ctx = context.WithValue(ctx, server.ServerContextKey, serverCtx)
+
+	dummyCmd := &cobra.Command{
+		Use:   "dummy",
+		Short: "Just used for testing. Doesn't do anything.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	dummyCmd.SetOut(io.Discard)
+	dummyCmd.SetErr(io.Discard)
+	dummyCmd.SetArgs([]string{})
+	var err error
+	dummyCmd, err = dummyCmd.ExecuteContextC(ctx)
+	require.NoError(t, err, "dummy command execution")
+	require.NoError(t, config.LoadConfigFromFiles(dummyCmd), "LoadConfigFromFiles")
+	return dummyCmd
+}
+
+func TestPreUpgradeCmd(t *testing.T) {
+	app.SetConfig(true, true)
+	pioconfig.SetProvenanceConfig("", 0)
+
+	appCfgD := config.DefaultAppConfig()
+	tmCfgD := config.DefaultTmConfig()
+	clientCfgD := config.DefaultClientConfig()
+
+	appCfgC := config.DefaultAppConfig()
+	appCfgC.API.Enable = true
+	appCfgC.API.Swagger = true
+	tmCfgC := config.DefaultTmConfig()
+	tmCfgC.Consensus.TimeoutCommit = 1 * time.Second
+	tmCfgC.LogLevel = "debug"
+	clientCfgC := config.DefaultClientConfig()
+	clientCfgC.Output = "json"
+
+	tmCfgFixed := config.DefaultTmConfig()
+	tmCfgFixed.LogLevel = "debug"
+
+	var homeDefaultsUnpacked, homeDefaultsPacked string
+	var homeChangedUnpacked, homeChangedPacked string
+	var homeDNE string
+
+	tmpDir := t.TempDir()
+
+	t.Run("setup: defaults unpacked", func(t *testing.T) {
+		home := filepath.Join(tmpDir, "defaults_unpacked")
+		homeDefaultsUnpacked = home
+		t.Logf("Creating: %s", home)
+		require.NoError(t, os.MkdirAll(home, 0o755), "MkdirAll")
+
+		t.Logf("Saving configs")
+		dummyCmd := makeDummyCmd(t, home)
+		require.NotPanics(t, func() { config.SaveConfigs(dummyCmd, appCfgD, tmCfgD, clientCfgD, false) }, "SaveConfigs")
+		logDir(t, home)
+	})
+
+	t.Run("setup: defaults packed", func(t *testing.T) {
+		home := filepath.Join(tmpDir, "defaults_packed")
+		homeDefaultsPacked = home
+		t.Logf("Creating: %s", home)
+		require.NoError(t, os.MkdirAll(home, 0o755), "MkdirAll")
+
+		t.Logf("Saving configs")
+		dummyCmd := makeDummyCmd(t, home)
+		require.NotPanics(t, func() { config.SaveConfigs(dummyCmd, appCfgD, tmCfgD, clientCfgD, false) }, "SaveConfigs")
+		logDir(t, home)
+
+		t.Logf("Packing configs")
+		dummyCmd = makeDummyCmd(t, home)
+		require.NoError(t, config.PackConfig(dummyCmd), "PackConfig")
+		logDir(t, home)
+	})
+
+	t.Run("setup: changed unpacked", func(t *testing.T) {
+		home := filepath.Join(tmpDir, "changed_unpacked")
+		homeChangedUnpacked = home
+		t.Logf("Creating: %s", home)
+		require.NoError(t, os.MkdirAll(home, 0o755), "MkdirAll")
+
+		t.Logf("Saving configs")
+		dummyCmd := makeDummyCmd(t, home)
+		require.NotPanics(t, func() { config.SaveConfigs(dummyCmd, appCfgC, tmCfgC, clientCfgC, false) }, "SaveConfigs")
+		logDir(t, home)
+	})
+
+	t.Run("setup: changed packed", func(t *testing.T) {
+		home := filepath.Join(tmpDir, "changed_packed")
+		homeChangedPacked = home
+		t.Logf("Creating: %s", home)
+		require.NoError(t, os.MkdirAll(home, 0o755), "MkdirAll")
+
+		t.Logf("Saving configs")
+		dummyCmd := makeDummyCmd(t, home)
+		require.NotPanics(t, func() { config.SaveConfigs(dummyCmd, appCfgC, tmCfgC, clientCfgC, false) }, "SaveConfigs")
+		logDir(t, home)
+
+		t.Logf("Packing configs")
+		dummyCmd = makeDummyCmd(t, home)
+		require.NoError(t, config.PackConfig(dummyCmd), "PackConfig")
+		logDir(t, home)
+	})
+
+	t.Run("setup: home does not exist", func(t *testing.T) {
+		homeDNE = filepath.Join(tmpDir, "dne")
+		t.Logf("Not creating: %s", homeDNE)
+
+		logDir(t, homeDNE)
+	})
+
+	success := "pre-upgrade successful"
+
+	tests := []struct {
+		name         string
+		home         string
+		args         []string
+		expExitCode  int
+		expInStdout  []string
+		expInStderr  []string
+		expAppCfg    *serverconfig.Config
+		expTmCfg     *tmconfig.Config
+		expClientCfg *config.ClientConfig
+	}{
+		{
+			name:         "home dir does not exist yet",
+			home:         homeDNE,
+			expExitCode:  0,
+			expInStdout:  []string{success},
+			expAppCfg:    appCfgD,
+			expTmCfg:     tmCfgD,
+			expClientCfg: clientCfgD,
+		},
+		{
+			name:         "unpacked config with defaults",
+			home:         homeDefaultsUnpacked,
+			expExitCode:  0,
+			expInStdout:  []string{success},
+			expAppCfg:    appCfgD,
+			expTmCfg:     tmCfgD,
+			expClientCfg: clientCfgD,
+		},
+		{
+			name:         "packed config with defaults",
+			home:         homeDefaultsPacked,
+			expExitCode:  0,
+			expInStdout:  []string{success},
+			expAppCfg:    appCfgD,
+			expTmCfg:     tmCfgD,
+			expClientCfg: clientCfgD,
+		},
+		{
+			name:        "unpacked config with changes",
+			home:        homeChangedUnpacked,
+			expExitCode: 0,
+			expInStdout: []string{
+				`Updating consensus.timeout_commit config value to "5s" (from "1s")`,
+				success,
+			},
+			expAppCfg:    appCfgC,
+			expTmCfg:     tmCfgFixed,
+			expClientCfg: clientCfgC,
+		},
+		{
+			name:        "packed config with changes",
+			home:        homeChangedPacked,
+			expExitCode: 0,
+			expInStdout: []string{
+				`Updating consensus.timeout_commit config value to "5s" (from "1s")`,
+				success,
+			},
+			expAppCfg:    appCfgC,
+			expTmCfg:     tmCfgFixed,
+			expClientCfg: clientCfgC,
+		},
+		{
+			name:        "arg provided",
+			home:        homeDNE,
+			args:        []string{"arg1"},
+			expExitCode: 30,
+			expInStderr: []string{"expected 0 args, received 1"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			res := executePreUpgradeCmd(t, tc.home, tc.args...)
+			assert.Equal(t, tc.expExitCode, res.ExitCode, "exit code")
+
+			assertContainsAll(t, res.Stdout, tc.expInStdout, "stdout")
+			if len(tc.expInStderr) == 0 {
+				assert.Empty(t, tc.expInStderr, "stderr")
+			} else {
+				assertContainsAll(t, res.Stderr, tc.expInStderr, "stderr")
+			}
+
+			if res.ExitCode != 0 {
+				return
+			}
+
+			dummyCmd := makeDummyCmd(t, tc.home)
+			appCfg, err := config.ExtractAppConfig(dummyCmd)
+			if assert.NoError(t, err, "ExtractAppConfig") {
+				assert.Equal(t, tc.expAppCfg, appCfg, "app config")
+			}
+			tmCfg, err := config.ExtractTmConfig(dummyCmd)
+			tmCfg.SetRoot("")
+			if assert.NoError(t, err, "ExtractTmConfig") {
+				assert.Equal(t, tc.expTmCfg, tmCfg, "tm config")
+			}
+			clientCfg, err := config.ExtractClientConfig(dummyCmd)
+			if assert.NoError(t, err, "ExtractClientConfig") {
+				assert.Equal(t, tc.expClientCfg, clientCfg)
+			}
+		})
+	}
+}

--- a/cmd/provenanced/cmd/pre_upgrade_test.go
+++ b/cmd/provenanced/cmd/pre_upgrade_test.go
@@ -17,16 +17,18 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	tmconfig "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/libs/log"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/server"
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
 	sdksim "github.com/cosmos/cosmos-sdk/simapp"
+
 	"github.com/provenance-io/provenance/app"
 	"github.com/provenance-io/provenance/cmd/provenanced/cmd"
 	"github.com/provenance-io/provenance/cmd/provenanced/config"
 	"github.com/provenance-io/provenance/internal/pioconfig"
-	tmconfig "github.com/tendermint/tendermint/config"
-	"github.com/tendermint/tendermint/libs/log"
 )
 
 // logIfError logs an error if it's not nil.
@@ -97,12 +99,7 @@ type CmdResult struct {
 func executeRootCmd(t *testing.T, home string, cmdArgs ...string) *CmdResult {
 	rv := &CmdResult{Home: home}
 
-	origHome := app.DefaultNodeHome
-	defer func() {
-		app.DefaultNodeHome = origHome
-	}()
-	t.Logf("Setting DefaultNodeHome = %q", home)
-	app.DefaultNodeHome = home
+	cmdArgs = append([]string{"--home", home}, cmdArgs...)
 
 	// Use our own buffers for the output so we can capture it.
 	var outBuf, errBuf bytes.Buffer
@@ -214,7 +211,7 @@ func makeDummyCmd(t *testing.T, home string) *cobra.Command {
 }
 
 func TestPreUpgradeCmd(t *testing.T) {
-	app.SetConfig(true, true)
+	app.SetConfig(true, false)
 	pioconfig.SetProvenanceConfig("", 0)
 
 	appCfgD := config.DefaultAppConfig()

--- a/cmd/provenanced/cmd/root.go
+++ b/cmd/provenanced/cmd/root.go
@@ -78,8 +78,6 @@ func NewRootCmd(sealConfig bool) (*cobra.Command, params.EncodingConfig) {
 			cmd.SetOut(cmd.OutOrStdout())
 			cmd.SetErr(cmd.ErrOrStderr())
 
-			home, _ := cmd.Flags().GetString(flags.FlagHome)
-			_ = home
 			if cmd.Flags().Changed(flags.FlagHome) {
 				rootDir, _ := cmd.Flags().GetString(flags.FlagHome)
 				initClientCtx = initClientCtx.WithHomeDir(rootDir)

--- a/cmd/provenanced/cmd/root.go
+++ b/cmd/provenanced/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/rs/zerolog"
 	"github.com/spf13/cast"
@@ -236,6 +237,11 @@ func txCommand() *cobra.Command {
 
 func newApp(logger log.Logger, db dbm.DB, traceStore io.Writer, appOpts servertypes.AppOptions) servertypes.Application {
 	var cache sdk.MultiStorePersistentCache
+
+	timeoutCommit := cast.ToDuration(appOpts.Get("consensus.timeout_commit"))
+	if timeoutCommit < 4*time.Second {
+		logger.Error(fmt.Sprintf("Your consensus.timeout_commit config value should be set to \"5s\" (it is currently %q).", timeoutCommit.String()))
+	}
 
 	if cast.ToBool(appOpts.Get(server.FlagInterBlockCache)) {
 		cache = store.NewCommitKVStoreCacheManager()

--- a/cmd/provenanced/cmd/root.go
+++ b/cmd/provenanced/cmd/root.go
@@ -139,6 +139,11 @@ func Execute(rootCmd *cobra.Command) error {
 	rootCmd.PersistentFlags().Int64(config.CustomMsgFeeFloorPriceFlag, 0, "Custom msgfee floor price, optional (default 1905)")
 
 	executor := tmcli.PrepareBaseCmd(rootCmd, "", app.DefaultNodeHome)
+	// Add the --help flag now so that its usage can be capitalized.
+	// Otherwise, it gets added by cobra at the last second.
+	// And for some reason, running the root_test in an IDE doesn't see it, but
+	// running with make test causes a failure.
+	rootCmd.InitDefaultHelpFlag()
 	capitalizeUses(rootCmd)
 
 	return executor.ExecuteContext(ctx)

--- a/cmd/provenanced/cmd/root.go
+++ b/cmd/provenanced/cmd/root.go
@@ -92,10 +92,9 @@ func NewRootCmd(sealConfig bool) (*cobra.Command, params.EncodingConfig) {
 			}
 
 			// set app context based on initialized EnvTypeFlag
-			if sealConfig {
-				testnet := server.GetServerContextFromCmd(cmd).Viper.GetBool(EnvTypeFlag)
-				app.SetConfig(testnet, true)
-			}
+			testnet := server.GetServerContextFromCmd(cmd).Viper.GetBool(EnvTypeFlag)
+			app.SetConfig(testnet, sealConfig)
+
 			overwriteFlagDefaults(cmd, map[string]string{
 				// Override default value for coin-type to match our mainnet or testnet value.
 				CoinTypeFlag: fmt.Sprint(app.CoinType),

--- a/cmd/provenanced/cmd/root.go
+++ b/cmd/provenanced/cmd/root.go
@@ -238,9 +238,12 @@ func txCommand() *cobra.Command {
 func newApp(logger log.Logger, db dbm.DB, traceStore io.Writer, appOpts servertypes.AppOptions) servertypes.Application {
 	var cache sdk.MultiStorePersistentCache
 
-	timeoutCommit := cast.ToDuration(appOpts.Get("consensus.timeout_commit"))
-	if timeoutCommit < 4*time.Second {
-		logger.Error(fmt.Sprintf("Your consensus.timeout_commit config value should be set to \"5s\" (it is currently %q).", timeoutCommit.String()))
+	ChainID = cast.ToString(appOpts.Get("chain-id"))
+	if ChainID == "pio-mainnet-1" {
+		timeoutCommit := cast.ToDuration(appOpts.Get("consensus.timeout_commit"))
+		if timeoutCommit < 4*time.Second {
+			logger.Error(fmt.Sprintf("Your consensus.timeout_commit config value is too low and should be increased to \"5s\" (it is currently %q).", timeoutCommit))
+		}
 	}
 
 	if cast.ToBool(appOpts.Get(server.FlagInterBlockCache)) {

--- a/cmd/provenanced/cmd/root.go
+++ b/cmd/provenanced/cmd/root.go
@@ -51,10 +51,6 @@ const (
 	EnvTypeFlag = "testnet"
 	// Flag used to indicate coin type.
 	CoinTypeFlag = "coin-type"
-	// CustomDenomFlag flag to take in custom denom, defaults to nhash if not passed in.
-	CustomDenomFlag = "custom-denom"
-	// CustomMsgFeeFloorPriceFlag flag to take in custom msg floor fees, defaults to 1905nhash if not passed in.
-	CustomMsgFeeFloorPriceFlag = "msgfee-floor-price"
 )
 
 // ChainID is the id of the running chain
@@ -96,13 +92,10 @@ func NewRootCmd(sealConfig bool) (*cobra.Command, params.EncodingConfig) {
 			}
 
 			// set app context based on initialized EnvTypeFlag
-			testnet := server.GetServerContextFromCmd(cmd).Viper.GetBool(EnvTypeFlag)
-			customDenom := server.GetServerContextFromCmd(cmd).Viper.GetString(CustomDenomFlag)
-			customMsgFeeFloor := server.GetServerContextFromCmd(cmd).Viper.GetInt64(CustomMsgFeeFloorPriceFlag)
 			if sealConfig {
+				testnet := server.GetServerContextFromCmd(cmd).Viper.GetBool(EnvTypeFlag)
 				app.SetConfig(testnet, true)
 			}
-			pioconfig.SetProvenanceConfig(customDenom, customMsgFeeFloor)
 			overwriteFlagDefaults(cmd, map[string]string{
 				// Override default value for coin-type to match our mainnet or testnet value.
 				CoinTypeFlag: fmt.Sprint(app.CoinType),
@@ -139,9 +132,9 @@ func Execute(rootCmd *cobra.Command) error {
 	rootCmd.PersistentFlags().String(flags.FlagLogFormat, tmcfg.LogFormatPlain, "The logging format (json|plain)")
 
 	// Custom denom flag added to root command
-	rootCmd.PersistentFlags().String(CustomDenomFlag, "", "Indicates if a custom denom is to be used, and the name of it (default nhash)")
+	rootCmd.PersistentFlags().String(config.CustomDenomFlag, "", "Indicates if a custom denom is to be used, and the name of it (default nhash)")
 	// Custom msgFee floor price flag added to root command
-	rootCmd.PersistentFlags().Int64(CustomMsgFeeFloorPriceFlag, 0, "Custom msgfee floor price, optional (default 1905)")
+	rootCmd.PersistentFlags().Int64(config.CustomMsgFeeFloorPriceFlag, 0, "Custom msgfee floor price, optional (default 1905)")
 
 	executor := tmcli.PrepareBaseCmd(rootCmd, "", app.DefaultNodeHome)
 	return executor.ExecuteContext(ctx)

--- a/cmd/provenanced/cmd/root.go
+++ b/cmd/provenanced/cmd/root.go
@@ -76,37 +76,9 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 		WithViper("PIO")
 	sdk.SetCoinDenomRegex(app.SdkCoinDenomRegex)
 	rootCmd := &cobra.Command{
-		Use:   "provenanced",
-		Short: "Provenance Blockchain App",
-		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-			cmd.SetOut(cmd.OutOrStdout())
-			cmd.SetErr(cmd.ErrOrStderr())
-
-			if cmd.Flags().Changed(flags.FlagHome) {
-				rootDir, _ := cmd.Flags().GetString(flags.FlagHome)
-				initClientCtx = initClientCtx.WithHomeDir(rootDir)
-			}
-			if err := client.SetCmdClientContext(cmd, initClientCtx); err != nil {
-				return err
-			}
-			if err := config.InterceptConfigsPreRunHandler(cmd); err != nil {
-				return err
-			}
-
-			// set app context based on initialized EnvTypeFlag
-			testnet := server.GetServerContextFromCmd(cmd).Viper.GetBool(EnvTypeFlag)
-			customDenom := server.GetServerContextFromCmd(cmd).Viper.GetString(CustomDenomFlag)
-			customMsgFeeFloor := server.GetServerContextFromCmd(cmd).Viper.GetInt64(CustomMsgFeeFloorPriceFlag)
-			app.SetConfig(testnet, true)
-			pioconfig.SetProvenanceConfig(customDenom, customMsgFeeFloor)
-			overwriteFlagDefaults(cmd, map[string]string{
-				// Override default value for coin-type to match our mainnet or testnet value.
-				CoinTypeFlag: fmt.Sprint(app.CoinType),
-				// Override min gas price(server level config) here since the provenance config would have been set based on flags.
-				server.FlagMinGasPrices: pioconfig.GetProvenanceConfig().ProvenanceMinGasPrices,
-			})
-			return nil
-		},
+		Use:               "provenanced",
+		Short:             "Provenance Blockchain App",
+		PersistentPreRunE: RootPersistentPreRunE(initClientCtx),
 	}
 	initRootCmd(rootCmd, encodingConfig)
 	overwriteFlagDefaults(rootCmd, map[string]string{
@@ -116,6 +88,39 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 	})
 
 	return rootCmd, encodingConfig
+}
+
+// RootPersistentPreRunE is the root command's PersistentPreRunE for the given initial client context.
+func RootPersistentPreRunE(initClientCtx client.Context) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, _ []string) error {
+		cmd.SetOut(cmd.OutOrStdout())
+		cmd.SetErr(cmd.ErrOrStderr())
+
+		if cmd.Flags().Changed(flags.FlagHome) {
+			rootDir, _ := cmd.Flags().GetString(flags.FlagHome)
+			initClientCtx = initClientCtx.WithHomeDir(rootDir)
+		}
+		if err := client.SetCmdClientContext(cmd, initClientCtx); err != nil {
+			return err
+		}
+		if err := config.InterceptConfigsPreRunHandler(cmd); err != nil {
+			return err
+		}
+
+		// set app context based on initialized EnvTypeFlag
+		testnet := server.GetServerContextFromCmd(cmd).Viper.GetBool(EnvTypeFlag)
+		customDenom := server.GetServerContextFromCmd(cmd).Viper.GetString(CustomDenomFlag)
+		customMsgFeeFloor := server.GetServerContextFromCmd(cmd).Viper.GetInt64(CustomMsgFeeFloorPriceFlag)
+		app.SetConfig(testnet, true)
+		pioconfig.SetProvenanceConfig(customDenom, customMsgFeeFloor)
+		overwriteFlagDefaults(cmd, map[string]string{
+			// Override default value for coin-type to match our mainnet or testnet value.
+			CoinTypeFlag: fmt.Sprint(app.CoinType),
+			// Override min gas price(server level config) here since the provenance config would have been set based on flags.
+			server.FlagMinGasPrices: pioconfig.GetProvenanceConfig().ProvenanceMinGasPrices,
+		})
+		return nil
+	}
 }
 
 // Execute executes the root command.
@@ -160,6 +165,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 		ConfigCmd(),
 		AddMetaAddressCmd(),
 		snapshot.Cmd(newApp),
+		GetPreUpgradeCmd(),
 	)
 
 	server.AddCommands(rootCmd, app.DefaultNodeHome, newApp, createAppAndExport, addModuleInitFlags)

--- a/cmd/provenanced/cmd/root.go
+++ b/cmd/provenanced/cmd/root.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"unicode"
 
 	"github.com/rs/zerolog"
 	"github.com/spf13/cast"
@@ -139,13 +138,6 @@ func Execute(rootCmd *cobra.Command) error {
 	rootCmd.PersistentFlags().Int64(config.CustomMsgFeeFloorPriceFlag, 0, "Custom msgfee floor price, optional (default 1905)")
 
 	executor := tmcli.PrepareBaseCmd(rootCmd, "", app.DefaultNodeHome)
-	// Add the --help flag now so that its usage can be capitalized.
-	// Otherwise, it gets added by cobra at the last second.
-	// And for some reason, running the root_test in an IDE doesn't see it, but
-	// running with make test causes a failure.
-	rootCmd.InitDefaultHelpFlag()
-	capitalizeUses(rootCmd)
-
 	return executor.ExecuteContext(ctx)
 }
 
@@ -184,36 +176,12 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 	// Add Rosetta command
 	rootCmd.AddCommand(server.RosettaCommand(encodingConfig.InterfaceRegistry, encodingConfig.Marshaler))
 	rootCmd.AddCommand(pruning.PruningCmd(newApp))
-
 	// Disable usage when the start command returns an error.
 	startCmd, _, err := rootCmd.Find([]string{"start"})
 	if err != nil {
 		panic(fmt.Errorf("start command not found: %w", err))
 	}
 	startCmd.SilenceUsage = true
-}
-
-// fixDebugPubkeyRawTypeFlag removes the -t shorthand option of the --type flag from the debug pubkey-raw command.
-// It clashes with our persistent --testnet/-t flag added to the root command.
-func fixDebugPubkeyRawTypeFlag(rootCmd *cobra.Command) {
-	debugCmd, _, err := rootCmd.Find([]string{"debug", "pubkey-raw"})
-	if err != nil || debugCmd == nil {
-		// If the command doesn't exist, there's nothing to do.
-		return
-	}
-
-	// We can't just debugCmd.Flags().Lookup("type").Shorthand = "" here because
-	// there's some internal flagset stuff that needs clearing too, that we can't
-	// do from here. So we do this the hard way. We clear out the command's flags
-	// and re-add them all, but get rid of the shorthand on the type flag first.
-	debugFlags := debugCmd.Flags()
-	debugCmd.ResetFlags()
-	debugFlags.VisitAll(func(f *pflag.Flag) {
-		if f.Name == "type" {
-			f.Shorthand = ""
-		}
-		debugCmd.Flags().AddFlag(f)
-	})
 }
 
 func addModuleInitFlags(startCmd *cobra.Command) {
@@ -371,72 +339,47 @@ func createAppAndExport(
 	return a.ExportAppStateAndValidators(forZeroHeight, jailAllowedAddrs)
 }
 
-// setFlagDefault sets the default value of a flag if it hasn't been changed.
-func setFlagDefault(s *pflag.FlagSet, key, val string) {
-	if f := s.Lookup(key); f != nil {
-		if f.Changed {
-			return
-		}
-		f.DefValue = val
-		if err := f.Value.Set(val); err != nil {
-			panic(err)
-		}
+// fixDebugPubkeyRawTypeFlag removes the -t shorthand option of the --type flag from the debug pubkey-raw command.
+// It clashes with our persistent --testnet/-t flag added to the root command.
+func fixDebugPubkeyRawTypeFlag(rootCmd *cobra.Command) {
+	debugCmd, _, err := rootCmd.Find([]string{"debug", "pubkey-raw"})
+	if err != nil || debugCmd == nil {
+		// If the command doesn't exist, there's nothing to do.
+		return
 	}
+
+	// We can't just debugCmd.Flags().Lookup("type").Shorthand = "" here because
+	// there's some internal flagset stuff that needs clearing too, that we can't
+	// do from here. So we do this the hard way. We clear out the command's flags
+	// and re-add them all, but get rid of the shorthand on the type flag first.
+	debugFlags := debugCmd.Flags()
+	debugCmd.ResetFlags()
+	debugFlags.VisitAll(func(f *pflag.Flag) {
+		if f.Name == "type" {
+			f.Shorthand = ""
+		}
+		debugCmd.Flags().AddFlag(f)
+	})
 }
 
-// overwriteFlagDefaults recursively overwrites the default values of flags
-// with the provided defaults for this command and all sub-commands.
 func overwriteFlagDefaults(c *cobra.Command, defaults map[string]string) {
+	set := func(s *pflag.FlagSet, key, val string) {
+		if f := s.Lookup(key); f != nil {
+			if f.Changed {
+				return
+			}
+			f.DefValue = val
+			if err := f.Value.Set(val); err != nil {
+				panic(err)
+			}
+		}
+	}
 	for key, val := range defaults {
-		setFlagDefault(c.Flags(), key, val)
-		setFlagDefault(c.PersistentFlags(), key, val)
+		set(c.Flags(), key, val)
+		set(c.PersistentFlags(), key, val)
 	}
-
-	for _, sc := range c.Commands() {
-		overwriteFlagDefaults(sc, defaults)
-	}
-}
-
-// capitalizeFirst returns the provided string with the first letter capitalized.
-func capitalizeFirst(str string) string {
-	if len(str) == 0 {
-		return str
-	}
-	// str[0] only gets the first byte, but we want the first rune (might be
-	// multiple bytes, we don't know). So we use the hack where range on a
-	// string loops over runes (not bytes), and break after getting the first.
-	// Just getting the first, for now, since we commonly won't need the rest.
-	var first rune
-	for _, r := range str {
-		first = r
-		break
-	}
-	if !unicode.IsLower(first) {
-		return str
-	}
-	// Alright. We need to upper-case the first one. We'll need all the runes so we can put it back together correctly.
-	runes := make([]rune, 0, len(str))
-	for _, r := range str {
-		runes = append(runes, r)
-	}
-	runes[0] = unicode.ToUpper(runes[0])
-	return string(runes)
-}
-
-// capitalizeFlagUsage capitalizes the first letter of the flag's usage string.
-func capitalizeFlagUsage(f *pflag.Flag) {
-	f.Usage = capitalizeFirst(f.Usage)
-}
-
-// capitalizeUses recursively capitalizes the first letter of command short
-// usage and all flag usages for this command and all sub-commands.
-func capitalizeUses(c *cobra.Command) {
-	c.Short = capitalizeFirst(c.Short)
-	c.Flags().VisitAll(capitalizeFlagUsage)
-	c.PersistentFlags().VisitAll(capitalizeFlagUsage)
-
-	for _, sc := range c.Commands() {
-		capitalizeUses(sc)
+	for _, c := range c.Commands() {
+		overwriteFlagDefaults(c, defaults)
 	}
 }
 

--- a/cmd/provenanced/cmd/root.go
+++ b/cmd/provenanced/cmd/root.go
@@ -60,9 +60,9 @@ const (
 // ChainID is the id of the running chain
 var ChainID string
 
-// NewRootCmd creates a new root command for simd. It is called once in the
-// main function.
-func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
+// NewRootCmd creates a new root command for provenanced. It is called once in the main function.
+// Providing sealConfig = false is only for unit tests that want to run multiple commands.
+func NewRootCmd(sealConfig bool) (*cobra.Command, params.EncodingConfig) {
 	encodingConfig := app.MakeEncodingConfig()
 	initClientCtx := client.Context{}.
 		WithCodec(encodingConfig.Marshaler).
@@ -82,6 +82,8 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 			cmd.SetOut(cmd.OutOrStdout())
 			cmd.SetErr(cmd.ErrOrStderr())
 
+			home, _ := cmd.Flags().GetString(flags.FlagHome)
+			_ = home
 			if cmd.Flags().Changed(flags.FlagHome) {
 				rootDir, _ := cmd.Flags().GetString(flags.FlagHome)
 				initClientCtx = initClientCtx.WithHomeDir(rootDir)
@@ -97,7 +99,9 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 			testnet := server.GetServerContextFromCmd(cmd).Viper.GetBool(EnvTypeFlag)
 			customDenom := server.GetServerContextFromCmd(cmd).Viper.GetString(CustomDenomFlag)
 			customMsgFeeFloor := server.GetServerContextFromCmd(cmd).Viper.GetInt64(CustomMsgFeeFloorPriceFlag)
-			app.SetConfig(testnet, true)
+			if sealConfig {
+				app.SetConfig(testnet, true)
+			}
 			pioconfig.SetProvenanceConfig(customDenom, customMsgFeeFloor)
 			overwriteFlagDefaults(cmd, map[string]string{
 				// Override default value for coin-type to match our mainnet or testnet value.

--- a/cmd/provenanced/cmd/root_test.go
+++ b/cmd/provenanced/cmd/root_test.go
@@ -66,12 +66,12 @@ func TestAllUsesStartUpperCased(t *testing.T) {
 			break
 		}
 		isUpper := unicode.IsLower(first)
-		return assert.Falsef(t, isUpper, "unicode.IsLower(%+q) on first letter of "+msg+": %+q",
+		return assert.Falsef(t, isUpper, "unicode.IsLower(%+q), the first letter of "+msg+": %+q",
 			append([]interface{}{first}, append(args, str)...)...)
 	}
 
 	// Set this to true to have the test log out ALL the flags and usages.
-	verbose := true
+	verbose := false
 
 	assertFlagUsageFirstIsLower := func(t *testing.T, getter func() *pflag.FlagSet, name string) {
 		if verbose {
@@ -88,7 +88,7 @@ func TestAllUsesStartUpperCased(t *testing.T) {
 			if verbose {
 				t.Logf("  --%s\t%s", f.Name, f.Usage)
 			}
-			assertFirstIsNotLower(t, f.Usage, "--%s flag", f.Name)
+			assertFirstIsNotLower(t, f.Usage, "--%s flag usage", f.Name)
 		})
 	}
 
@@ -96,6 +96,9 @@ func TestAllUsesStartUpperCased(t *testing.T) {
 	checkCmd = func(t *testing.T, parents []string, cmd *cobra.Command) {
 		parents = append(parents, cmd.Name())
 		t.Run(strings.Join(parents, " "), func(t *testing.T) {
+			if verbose {
+				t.Logf("%s short usage: %q", cmd.Name(), cmd.Short)
+			}
 			assertFirstIsNotLower(t, cmd.Short, "cmd.Short")
 
 			assertFlagUsageFirstIsLower(t, cmd.NonInheritedFlags, "NonInheritedFlags")

--- a/cmd/provenanced/cmd/root_test.go
+++ b/cmd/provenanced/cmd/root_test.go
@@ -1,15 +1,9 @@
 package cmd
 
 import (
-	"io"
-	"strings"
 	"testing"
-	"unicode"
 
 	"github.com/spf13/cast"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
@@ -18,96 +12,4 @@ import (
 
 func TestIAVLConfig(t *testing.T) {
 	require.Equal(t, getIAVLCacheSize(sdksim.EmptyAppOptions{}), cast.ToInt(serverconfig.DefaultConfig().IAVLCacheSize))
-}
-
-func TestCapitalizeFirst(t *testing.T) {
-	tests := []struct {
-		str string
-		exp string
-	}{
-		{str: "", exp: ""},
-		{str: "camelCase", exp: "CamelCase"},
-		{str: "PascalCase", exp: "PascalCase"},
-		{str: "Three WoRds Nochange", exp: "Three WoRds Nochange"},
-		{str: "three WorDs CHAngeD", exp: "Three WorDs CHAngeD"},
-		{str: "œnon-ascii š", exp: "Œnon-ascii š"},
-		{str: "<something else>", exp: "<something else>"},
-	}
-
-	for _, tc := range tests {
-		name := tc.str
-		if name == "" {
-			name = "empty"
-		}
-		t.Run(name, func(t *testing.T) {
-			act := capitalizeFirst(tc.str)
-			assert.Equal(t, tc.exp, act)
-		})
-	}
-}
-
-func TestAllUsesStartUpperCased(t *testing.T) {
-	rootCmd, _ := NewRootCmd(false)
-	rootCmd.SetOut(io.Discard)
-	rootCmd.SetErr(io.Discard)
-	// We don't care about the error here.
-	// This /should/ just output provenanced help.
-	// But we need to call it so that a) all flags have been added,
-	// and b) the capitilzation has occurred.
-	_ = Execute(rootCmd)
-
-	assertFirstIsNotLower := func(t *testing.T, str, msg string, args ...interface{}) bool {
-		if len(str) == 0 {
-			return true
-		}
-		var first rune
-		for _, r := range str {
-			first = r
-			break
-		}
-		isUpper := unicode.IsLower(first)
-		return assert.Falsef(t, isUpper, "unicode.IsLower(%+q), the first letter of "+msg+": %+q",
-			append([]interface{}{first}, append(args, str)...)...)
-	}
-
-	// Set this to true to have the test log out ALL the flags and usages.
-	verbose := false
-
-	assertFlagUsageFirstIsLower := func(t *testing.T, getter func() *pflag.FlagSet, name string) {
-		if verbose {
-			t.Logf("%s()", name)
-		}
-		var s *pflag.FlagSet
-		// A panic can occur here when a command has a flag with a shorthand
-		// that conflicts with a persistent flag of an ancestor.
-		ok := assert.NotPanics(t, func() { s = getter() }, "%s()", name)
-		if !ok {
-			return
-		}
-		s.VisitAll(func(f *pflag.Flag) {
-			if verbose {
-				t.Logf("  --%s\t%s", f.Name, f.Usage)
-			}
-			assertFirstIsNotLower(t, f.Usage, "--%s flag usage", f.Name)
-		})
-	}
-
-	var checkCmd func(t *testing.T, parents []string, cmd *cobra.Command)
-	checkCmd = func(t *testing.T, parents []string, cmd *cobra.Command) {
-		parents = append(parents, cmd.Name())
-		t.Run(strings.Join(parents, " "), func(t *testing.T) {
-			if verbose {
-				t.Logf("%s short usage: %q", cmd.Name(), cmd.Short)
-			}
-			assertFirstIsNotLower(t, cmd.Short, "cmd.Short")
-
-			assertFlagUsageFirstIsLower(t, cmd.NonInheritedFlags, "NonInheritedFlags")
-			assertFlagUsageFirstIsLower(t, cmd.InheritedFlags, "InheritedFlags")
-		})
-		for _, sc := range cmd.Commands() {
-			checkCmd(t, parents, sc)
-		}
-	}
-
-	checkCmd(t, nil, rootCmd)
 }

--- a/cmd/provenanced/cmd/root_test.go
+++ b/cmd/provenanced/cmd/root_test.go
@@ -1,9 +1,15 @@
 package cmd
 
 import (
+	"io"
+	"strings"
 	"testing"
+	"unicode"
 
 	"github.com/spf13/cast"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
@@ -12,4 +18,93 @@ import (
 
 func TestIAVLConfig(t *testing.T) {
 	require.Equal(t, getIAVLCacheSize(sdksim.EmptyAppOptions{}), cast.ToInt(serverconfig.DefaultConfig().IAVLCacheSize))
+}
+
+func TestCapitalizeFirst(t *testing.T) {
+	tests := []struct {
+		str string
+		exp string
+	}{
+		{str: "", exp: ""},
+		{str: "camelCase", exp: "CamelCase"},
+		{str: "PascalCase", exp: "PascalCase"},
+		{str: "Three WoRds Nochange", exp: "Three WoRds Nochange"},
+		{str: "three WorDs CHAngeD", exp: "Three WorDs CHAngeD"},
+		{str: "œnon-ascii š", exp: "Œnon-ascii š"},
+		{str: "<something else>", exp: "<something else>"},
+	}
+
+	for _, tc := range tests {
+		name := tc.str
+		if name == "" {
+			name = "empty"
+		}
+		t.Run(name, func(t *testing.T) {
+			act := capitalizeFirst(tc.str)
+			assert.Equal(t, tc.exp, act)
+		})
+	}
+}
+
+func TestAllUsesStartUpperCased(t *testing.T) {
+	rootCmd, _ := NewRootCmd(false)
+	rootCmd.SetOut(io.Discard)
+	rootCmd.SetErr(io.Discard)
+	// We don't care about the error here.
+	// This /should/ just output provenanced help.
+	// But we need to call it so that a) all flags have been added,
+	// and b) the capitilzation has occurred.
+	_ = Execute(rootCmd)
+
+	assertFirstIsNotLower := func(t *testing.T, str, msg string, args ...interface{}) bool {
+		if len(str) == 0 {
+			return true
+		}
+		var first rune
+		for _, r := range str {
+			first = r
+			break
+		}
+		isUpper := unicode.IsLower(first)
+		return assert.Falsef(t, isUpper, "unicode.IsLower(%+q) on first letter of "+msg+": %+q",
+			append([]interface{}{first}, append(args, str)...)...)
+	}
+
+	// Set this to true to have the test log out ALL the flags and usages.
+	verbose := true
+
+	assertFlagUsageFirstIsLower := func(t *testing.T, getter func() *pflag.FlagSet, name string) {
+		if verbose {
+			t.Logf("%s()", name)
+		}
+		var s *pflag.FlagSet
+		// A panic can occur here when a command has a flag with a shorthand
+		// that conflicts with a persistent flag of an ancestor.
+		ok := assert.NotPanics(t, func() { s = getter() }, "%s()", name)
+		if !ok {
+			return
+		}
+		s.VisitAll(func(f *pflag.Flag) {
+			if verbose {
+				t.Logf("  --%s\t%s", f.Name, f.Usage)
+			}
+			assertFirstIsNotLower(t, f.Usage, "--%s flag", f.Name)
+		})
+	}
+
+	var checkCmd func(t *testing.T, parents []string, cmd *cobra.Command)
+	checkCmd = func(t *testing.T, parents []string, cmd *cobra.Command) {
+		parents = append(parents, cmd.Name())
+		t.Run(strings.Join(parents, " "), func(t *testing.T) {
+			assertFirstIsNotLower(t, cmd.Short, "cmd.Short")
+
+			assertFlagUsageFirstIsLower(t, cmd.NonInheritedFlags, "NonInheritedFlags")
+			assertFlagUsageFirstIsLower(t, cmd.InheritedFlags, "InheritedFlags")
+		})
+		for _, sc := range cmd.Commands() {
+			checkCmd(t, parents, sc)
+		}
+	}
+
+	checkCmd(t, nil, rootCmd)
 }

--- a/cmd/provenanced/config/interceptor.go
+++ b/cmd/provenanced/config/interceptor.go
@@ -8,8 +8,6 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
-	tmconfig "github.com/tendermint/tendermint/config"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/server"
 )
@@ -33,7 +31,7 @@ func InterceptConfigsPreRunHandler(cmd *cobra.Command) error {
 	}
 
 	// Create a new Server context with the same viper as the client context, a default config, and no logger.
-	serverCtx := server.NewContext(vpr, tmconfig.DefaultConfig(), nil)
+	serverCtx := server.NewContext(vpr, DefaultTmConfig(), nil)
 	if err := server.SetCmdServerContext(cmd, serverCtx); err != nil {
 		return err
 	}

--- a/cmd/provenanced/config/interceptor.go
+++ b/cmd/provenanced/config/interceptor.go
@@ -10,6 +10,15 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/server"
+
+	"github.com/provenance-io/provenance/internal/pioconfig"
+)
+
+const (
+	// CustomDenomFlag flag to take in custom denom, defaults to nhash if not passed in.
+	CustomDenomFlag = "custom-denom"
+	// CustomMsgFeeFloorPriceFlag flag to take in custom msg floor fees, defaults to 1905nhash if not passed in.
+	CustomMsgFeeFloorPriceFlag = "msgfee-floor-price"
 )
 
 // InterceptConfigsPreRunHandler performs a pre-run function for all commands.
@@ -30,6 +39,9 @@ func InterceptConfigsPreRunHandler(cmd *cobra.Command) error {
 		return err
 	}
 
+	// Set the pio config now so that the proper default is set for the rest of the stuff.
+	SetPioConfigFromFlags(cmd.Flags())
+
 	// Create a new Server context with the same viper as the client context, a default config, and no logger.
 	serverCtx := server.NewContext(vpr, DefaultTmConfig(), nil)
 	if err := server.SetCmdServerContext(cmd, serverCtx); err != nil {
@@ -38,6 +50,13 @@ func InterceptConfigsPreRunHandler(cmd *cobra.Command) error {
 
 	// Read the configs into viper and the contexts.
 	return LoadConfigFromFiles(cmd)
+}
+
+func SetPioConfigFromFlags(flagSet *pflag.FlagSet) {
+	// Ignoring errors here in the off chance that the flags weren't defined originally.
+	customDenom, _ := flagSet.GetString(CustomDenomFlag)
+	customMsgFeeFloor, _ := flagSet.GetInt64(CustomMsgFeeFloorPriceFlag)
+	pioconfig.SetProvenanceConfig(customDenom, customMsgFeeFloor)
 }
 
 // Binds viper flags using the PIO ENV prefix.

--- a/cmd/provenanced/config/manager.go
+++ b/cmd/provenanced/config/manager.go
@@ -22,6 +22,9 @@ import (
 	"github.com/provenance-io/provenance/internal/pioconfig"
 )
 
+// DefaultConsensusTimeoutCommit is the default value used for the consensus.timeout_commit config value.
+var DefaultConsensusTimeoutCommit = 5 * time.Second
+
 // PackConfig generates and saves the packed config file then removes the individual config files.
 func PackConfig(cmd *cobra.Command) error {
 	generateAndWritePackedConfig(cmd, nil, nil, nil, true)
@@ -121,7 +124,7 @@ func ExtractTmConfigAndMap(cmd *cobra.Command) (*tmconfig.Config, FieldValueMap,
 
 func DefaultTmConfig() *tmconfig.Config {
 	rv := tmconfig.DefaultConfig()
-	rv.Consensus.TimeoutCommit = 5 * time.Second
+	rv.Consensus.TimeoutCommit = DefaultConsensusTimeoutCommit
 	return rv
 }
 

--- a/cmd/provenanced/config/manager.go
+++ b/cmd/provenanced/config/manager.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
@@ -82,10 +83,17 @@ func ExtractAppConfigAndMap(cmd *cobra.Command) (*serverconfig.Config, FieldValu
 	return conf, fields, nil
 }
 
+// DefaultAppConfig gets our default app config.
+func DefaultAppConfig() *serverconfig.Config {
+	rv := serverconfig.DefaultConfig()
+	rv.MinGasPrices = pioconfig.GetProvenanceConfig().ProvenanceMinGasPrices
+	return rv
+}
+
 // ExtractTmConfig creates a tendermint config from the command context.
 func ExtractTmConfig(cmd *cobra.Command) (*tmconfig.Config, error) {
 	v := server.GetServerContextFromCmd(cmd).Viper
-	conf := tmconfig.DefaultConfig()
+	conf := DefaultTmConfig()
 	if err := v.Unmarshal(conf); err != nil {
 		return nil, fmt.Errorf("error extracting tendermint config: %w", err)
 	}
@@ -102,6 +110,12 @@ func ExtractTmConfigAndMap(cmd *cobra.Command) (*tmconfig.Config, FieldValueMap,
 	fields := MakeFieldValueMap(conf, true)
 	removeUndesirableTmConfigEntries(fields)
 	return conf, fields, nil
+}
+
+func DefaultTmConfig() *tmconfig.Config {
+	rv := tmconfig.DefaultConfig()
+	rv.Consensus.TimeoutCommit = 5 * time.Second
+	return rv
 }
 
 // removeUndesirableTmConfigEntries deletes some keys from the provided fields map that we don't want included.
@@ -143,19 +157,12 @@ func ExtractClientConfigAndMap(cmd *cobra.Command) (*ClientConfig, FieldValueMap
 	return conf, fields, nil
 }
 
-// DefaultAppConfig gets our default app config.
-func DefaultAppConfig() *serverconfig.Config {
-	rv := serverconfig.DefaultConfig()
-	rv.MinGasPrices = pioconfig.GetProvenanceConfig().ProvenanceMinGasPrices
-	return rv
-}
-
 // GetAllConfigDefaults gets a field map from the defaults of all the configs.
 func GetAllConfigDefaults() FieldValueMap {
 	rv := FieldValueMap{}
 	rv.AddEntriesFrom(
 		MakeFieldValueMap(DefaultAppConfig(), false),
-		removeUndesirableTmConfigEntries(MakeFieldValueMap(tmconfig.DefaultConfig(), false)),
+		removeUndesirableTmConfigEntries(MakeFieldValueMap(DefaultTmConfig(), false)),
 		MakeFieldValueMap(DefaultClientConfig(), false),
 	)
 	return rv
@@ -410,7 +417,7 @@ func loadUnpackedConfig(cmd *cobra.Command) error {
 	vpr := server.GetServerContextFromCmd(cmd).Viper
 
 	// Load the tendermint config defaults, then file if it exists.
-	tdErr := addFieldMapToViper(vpr, MakeFieldValueMap(tmconfig.DefaultConfig(), false))
+	tdErr := addFieldMapToViper(vpr, MakeFieldValueMap(DefaultTmConfig(), false))
 	if tdErr != nil {
 		return fmt.Errorf("tendermint config defaults load error: %w", tdErr)
 	}
@@ -487,7 +494,7 @@ func loadPackedConfig(cmd *cobra.Command) error {
 
 	// Start with the defaults
 	appConfigMap := MakeFieldValueMap(DefaultAppConfig(), false)
-	tmConfigMap := MakeFieldValueMap(tmconfig.DefaultConfig(), false)
+	tmConfigMap := MakeFieldValueMap(DefaultTmConfig(), false)
 	clientConfigMap := MakeFieldValueMap(DefaultClientConfig(), false)
 
 	// Apply the packed config entries to the defaults.
@@ -602,6 +609,11 @@ func applyConfigsToContexts(cmd *cobra.Command) error {
 	}
 	logger := zerolog.New(logWriter).Level(logLvl).With().Timestamp().Logger()
 	serverCtx.Logger = server.ZeroLogWrapper{Logger: logger}
+
+	// Copy all settings from our viper to the global viper since some stuff uses the global one.
+	if err = viper.MergeConfigMap(serverCtx.Viper.AllSettings()); err != nil {
+		return fmt.Errorf("error copying all settings to global viper: %w", err)
+	}
 
 	return nil
 }

--- a/cmd/provenanced/config/manager.go
+++ b/cmd/provenanced/config/manager.go
@@ -98,6 +98,13 @@ func ExtractTmConfig(cmd *cobra.Command) (*tmconfig.Config, error) {
 		return nil, fmt.Errorf("error extracting tendermint config: %w", err)
 	}
 	conf.SetRoot(GetHomeDir(cmd))
+	// When the RPCServers value is "", it gets read as []string{}.
+	// But from a packed config without that entry, it gets read as nil.
+	// The default is also nil.
+	// So, if there's nothing in it, just set it to nil for consistency.
+	if len(conf.StateSync.RPCServers) == 0 {
+		conf.StateSync.RPCServers = nil
+	}
 	return conf, nil
 }
 

--- a/cmd/provenanced/config/manager_test.go
+++ b/cmd/provenanced/config/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -13,13 +14,14 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	tmcmds "github.com/tendermint/tendermint/cmd/cometbft/commands"
+	tmconfig "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/libs/log"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/server"
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
 	sdksim "github.com/cosmos/cosmos-sdk/simapp"
-
-	tmconfig "github.com/tendermint/tendermint/config"
-	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/provenance-io/provenance/internal/pioconfig"
 )
@@ -46,7 +48,7 @@ func (s *ConfigManagerTestSuite) makeDummyCmd() *cobra.Command {
 		WithCodec(encodingConfig.Codec).
 		WithHomeDir(s.Home)
 	clientCtx.Viper = viper.New()
-	serverCtx := server.NewContext(clientCtx.Viper, tmconfig.DefaultConfig(), log.NewNopLogger())
+	serverCtx := server.NewContext(clientCtx.Viper, DefaultTmConfig(), log.NewNopLogger())
 
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, client.ClientContextKey, &clientCtx)
@@ -66,6 +68,19 @@ func (s *ConfigManagerTestSuite) makeDummyCmd() *cobra.Command {
 	dummyCmd, err = dummyCmd.ExecuteContextC(ctx)
 	s.Require().NoError(err, "dummy command execution")
 	return dummyCmd
+}
+
+func (s *ConfigManagerTestSuite) logFile(path string) {
+	if !FileExists(path) {
+		s.T().Logf("File does not exist: %s", path)
+		return
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		s.T().Logf("Error reading %s: %v", path, err)
+		return
+	}
+	s.T().Logf("File: %s\nContents:\n%s", path, contents)
 }
 
 func (s *ConfigManagerTestSuite) TestConfigIndexEventsWriteRead() {
@@ -107,7 +122,7 @@ func (s *ConfigManagerTestSuite) TestPackedConfigCosmosLoadDefaults() {
 	dCmd := s.makeDummyCmd()
 
 	appConfig := DefaultAppConfig()
-	tmConfig := tmconfig.DefaultConfig()
+	tmConfig := DefaultTmConfig()
 	clientConfig := DefaultClientConfig()
 	generateAndWritePackedConfig(dCmd, appConfig, tmConfig, clientConfig, false)
 	s.Require().NoError(loadPackedConfig(dCmd))
@@ -127,7 +142,7 @@ func (s *ConfigManagerTestSuite) TestPackedConfigCosmosLoadGlobalLabels() {
 	appConfig := serverconfig.DefaultConfig()
 	appConfig.Telemetry.GlobalLabels = append(appConfig.Telemetry.GlobalLabels, []string{"key1", "value1"})
 	appConfig.Telemetry.GlobalLabels = append(appConfig.Telemetry.GlobalLabels, []string{"key2", "value2"})
-	tmConfig := tmconfig.DefaultConfig()
+	tmConfig := DefaultTmConfig()
 	clientConfig := DefaultClientConfig()
 	generateAndWritePackedConfig(dCmd, appConfig, tmConfig, clientConfig, false)
 	s.Require().NoError(loadPackedConfig(dCmd))
@@ -166,13 +181,13 @@ func (s *ConfigManagerTestSuite) TestUnmanagedConfig() {
 		vpr := ctx.Viper
 		actual := vpr.GetString("db_backend")
 		assert.NotEqual(t, "still bananas", actual, "unmanaged field value")
-		assert.Equal(t, tmconfig.DefaultConfig().DBBackend, actual, "unmanaged field default value")
+		assert.Equal(t, DefaultTmConfig().DBBackend, actual, "unmanaged field default value")
 	})
 
 	s.T().Run("unmanaged config is read with unpacked files", func(t *testing.T) {
 		dCmd := s.makeDummyCmd()
 		uFile := GetFullPathToUnmanagedConf(dCmd)
-		SaveConfigs(dCmd, DefaultAppConfig(), tmconfig.DefaultConfig(), DefaultClientConfig(), false)
+		SaveConfigs(dCmd, DefaultAppConfig(), DefaultTmConfig(), DefaultClientConfig(), false)
 		require.NoError(t, os.WriteFile(uFile, []byte("my-custom-entry = \"stuff\"\n"), 0o644), "writing unmanaged config")
 		require.NoError(t, LoadConfigFromFiles(dCmd))
 		ctx := client.GetClientContextFromCmd(dCmd)
@@ -184,7 +199,7 @@ func (s *ConfigManagerTestSuite) TestUnmanagedConfig() {
 	s.T().Run("unmanaged config is read with packed config", func(t *testing.T) {
 		dCmd := s.makeDummyCmd()
 		uFile := GetFullPathToUnmanagedConf(dCmd)
-		SaveConfigs(dCmd, DefaultAppConfig(), tmconfig.DefaultConfig(), DefaultClientConfig(), false)
+		SaveConfigs(dCmd, DefaultAppConfig(), DefaultTmConfig(), DefaultClientConfig(), false)
 		require.NoError(t, PackConfig(dCmd), "packing config")
 		require.NoError(t, os.WriteFile(uFile, []byte("other-custom-entry = 8\n"), 0o644), "writing unmanaged config")
 		require.NoError(t, LoadConfigFromFiles(dCmd))
@@ -244,7 +259,7 @@ func (s *ConfigManagerTestSuite) TestConfigMinGasPrices() {
 
 	s.Run("tm and client files but no app file", func() {
 		cmd1 := s.makeDummyCmd()
-		SaveConfigs(cmd1, nil, tmconfig.DefaultConfig(), DefaultClientConfig(), false)
+		SaveConfigs(cmd1, nil, DefaultTmConfig(), DefaultClientConfig(), false)
 		appCfgFile := GetFullPathToAppConf(cmd1)
 		_, err := os.Stat(appCfgFile)
 		fileExists := !os.IsNotExist(err)
@@ -262,7 +277,7 @@ func (s *ConfigManagerTestSuite) TestConfigMinGasPrices() {
 		cmd1 := s.makeDummyCmd()
 		appCfg := DefaultAppConfig()
 		appCfg.MinGasPrices = ""
-		SaveConfigs(cmd1, appCfg, tmconfig.DefaultConfig(), DefaultClientConfig(), false)
+		SaveConfigs(cmd1, appCfg, DefaultTmConfig(), DefaultClientConfig(), false)
 		appCfgFile := GetFullPathToAppConf(cmd1)
 		_, err := os.Stat(appCfgFile)
 		fileExists := !os.IsNotExist(err)
@@ -280,7 +295,7 @@ func (s *ConfigManagerTestSuite) TestConfigMinGasPrices() {
 		cmd1 := s.makeDummyCmd()
 		appCfg := DefaultAppConfig()
 		appCfg.MinGasPrices = "something else"
-		SaveConfigs(cmd1, appCfg, tmconfig.DefaultConfig(), DefaultClientConfig(), false)
+		SaveConfigs(cmd1, appCfg, DefaultTmConfig(), DefaultClientConfig(), false)
 		appCfgFile := GetFullPathToAppConf(cmd1)
 		_, err := os.Stat(appCfgFile)
 		fileExists := !os.IsNotExist(err)
@@ -296,7 +311,7 @@ func (s *ConfigManagerTestSuite) TestConfigMinGasPrices() {
 
 	s.Run("packed config without min-gas-prices", func() {
 		cmd1 := s.makeDummyCmd()
-		SaveConfigs(cmd1, DefaultAppConfig(), tmconfig.DefaultConfig(), DefaultClientConfig(), false)
+		SaveConfigs(cmd1, DefaultAppConfig(), DefaultTmConfig(), DefaultClientConfig(), false)
 		s.Require().NoError(PackConfig(cmd1), "PackConfig")
 		packedCfgFile := GetFullPathToPackedConf(cmd1)
 		_, err := os.Stat(packedCfgFile)
@@ -316,7 +331,7 @@ func (s *ConfigManagerTestSuite) TestConfigMinGasPrices() {
 
 	s.Run("packed config with min-gas-prices", func() {
 		cmd1 := s.makeDummyCmd()
-		SaveConfigs(cmd1, DefaultAppConfig(), tmconfig.DefaultConfig(), DefaultClientConfig(), false)
+		SaveConfigs(cmd1, DefaultAppConfig(), DefaultTmConfig(), DefaultClientConfig(), false)
 		s.Require().NoError(PackConfig(cmd1), "PackConfig")
 		packedCfgFile := GetFullPathToPackedConf(cmd1)
 		_, err := os.Stat(packedCfgFile)
@@ -332,5 +347,48 @@ func (s *ConfigManagerTestSuite) TestConfigMinGasPrices() {
 		s.Require().NoError(err, "ExtractAppConfig")
 		actual := cfg.MinGasPrices
 		s.Assert().Equal("65blue", actual)
+	})
+}
+
+func (s *ConfigManagerTestSuite) TestDefaultTmConfig() {
+	cfg := DefaultTmConfig()
+
+	s.Run("consensus.commit_timeout", func() {
+		exp := 5 * time.Second
+		act := cfg.Consensus.TimeoutCommit
+		s.Assert().Equal(exp, act, "cfg.Consensus.TimeoutCommit")
+	})
+}
+
+func (s *ConfigManagerTestSuite) TestPackedConfigTmLoadDefaults() {
+	dCmd := s.makeDummyCmd()
+	dCmd.Flags().String("home", s.Home, "home dir")
+
+	appConfig := DefaultAppConfig()
+	tmConfig := DefaultTmConfig()
+	tmConfig.SetRoot(s.Home)
+	clientConfig := DefaultClientConfig()
+	generateAndWritePackedConfig(dCmd, appConfig, tmConfig, clientConfig, false)
+	s.logFile(GetFullPathToPackedConf(dCmd))
+	s.Require().NoError(loadPackedConfig(dCmd), "loadPackedConfig")
+
+	s.Run("tmcmds.ParseConfig", func() {
+		var tmConfig2 *tmconfig.Config
+		var err error
+		s.Require().NotPanics(func() {
+			tmConfig2, err = tmcmds.ParseConfig(dCmd)
+		})
+		s.Require().NoError(err, "tmcmds.ParseConfig")
+		s.Assert().Equal(tmConfig, tmConfig2)
+	})
+
+	s.Run("ExtractTmConfig", func() {
+		var tmConfig2 *tmconfig.Config
+		var err error
+		s.Require().NotPanics(func() {
+			tmConfig2, err = ExtractTmConfig(dCmd)
+		})
+		s.Require().NoError(err, "ExtractTmConfig")
+		s.Assert().Equal(tmConfig, tmConfig2)
 	})
 }

--- a/cmd/provenanced/main.go
+++ b/cmd/provenanced/main.go
@@ -10,10 +10,13 @@ import (
 )
 
 func main() {
-	rootCmd, _ := cmd.NewRootCmd()
+	rootCmd, _ := cmd.NewRootCmd(true)
 	if err := cmd.Execute(rootCmd); err != nil {
-		var srvErr *server.ErrorCode
+		var srvErrP *server.ErrorCode
+		var srvErr server.ErrorCode
 		switch {
+		case errors.As(err, &srvErrP):
+			os.Exit(srvErrP.Code)
 		case errors.As(err, &srvErr):
 			os.Exit(srvErr.Code)
 		default:

--- a/scripts/initialize.sh
+++ b/scripts/initialize.sh
@@ -25,6 +25,8 @@ The following environment variables control the behavior of this script:
                         Default: testing
   SHOW_START ---------- Whether to output how to start the chain (at the end).
                         Default: true
+  TIMEOUT_COMMIT ------ The consensus.timeout_commit value to set.
+                        Default: 1s
 
 EOF
             exit 0
@@ -47,6 +49,7 @@ PIO_TESTNET="${PIO_TESTNET:-true}"
 PIO_KEYRING_BACKEND="${PIO_KEYRING_BACKEND:-test}"
 PIO_CHAIN_ID="${PIO_CHAIN_ID:-testing}"
 SHOW_START="${SHOW_START:-true}"
+TIMEOUT_COMMIT="${TIMEOUT_COMMIT:-1s}"
 
 # When the PROV_CMD is a docker thing, env vars don't get passed.
 # So just always provide the needed ones as args.
@@ -89,7 +92,7 @@ $PROV_CMD add-genesis-msg-fee /provenance.attribute.v1.MsgAddAttributeRequest "1
 $PROV_CMD add-genesis-msg-fee /provenance.metadata.v1.MsgWriteScopeRequest "10000000000$DENOM"
 $PROV_CMD add-genesis-custom-floor "${MIN_FLOOR_PRICE}${DENOM}"
 $PROV_CMD collect-gentxs
-$PROV_CMD config set minimum-gas-prices "${MIN_FLOOR_PRICE}${DENOM}"
+$PROV_CMD config set minimum-gas-prices "${MIN_FLOOR_PRICE}${DENOM}" consensus.timeout_commit "$TIMEOUT_COMMIT"
 set +ex
 
 [ -n "$VERBOSE" ] && printf '\nProvenance Blockchain initialized at: %s\n' "$PIO_HOME"

--- a/x/attribute/simulation/operations_test.go
+++ b/x/attribute/simulation/operations_test.go
@@ -57,8 +57,7 @@ func (s *SimTestSuite) LogOperationMsg(operationMsg simtypes.OperationMsg) {
 // Use this if there's a possible error that we probably don't care about (but might).
 func (s *SimTestSuite) LogIfError(err error, format string, args ...interface{}) {
 	if err != nil {
-		args = append(args, err)
-		s.T().Logf(format+": %v", args)
+		s.T().Logf(format+" error: %v", append(args, err)...)
 	}
 }
 

--- a/x/name/simulation/operations_test.go
+++ b/x/name/simulation/operations_test.go
@@ -55,8 +55,7 @@ func (s *SimTestSuite) LogOperationMsg(operationMsg simtypes.OperationMsg) {
 // The error is automatically added to the format and args.
 func (s *SimTestSuite) LogIfError(err error, format string, args ...interface{}) {
 	if err != nil {
-		args = append(args, err)
-		s.T().Logf(format+": %v", args)
+		s.T().Logf(format+" error: %v", append(args, err)...)
 	}
 }
 


### PR DESCRIPTION
## Description

This PR:
1. Creates the `provenanced pre-upgrade` command as outlined by cosmovisor documentation. It will update the config files to the new formats and set `consensus.timeout_commit` to 5 seconds.
2. Adds an error message to the log if the `consensus.timeout_commit` is too low.
3. Fixes an issue where the `minimum-gas-prices` value was being set to "" when either rewriting a packed config or calling `provenanced config pack` on an already packed config.
4. Fixes the `provenanced debug pubkey-raw` command that was trying to add a flag with a `-t` shorthand that conflicted with the `--testnet`/`-t` persistent flag on the root command.


---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
