### PR TITLE
Change the default consensus.timeout_commit to 1500ms.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,12 +39,12 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Features
 
-* Add pre-upgrade command that updates config files to newest format and sets `consensus.timeout_commit` to `5s` [PR 1594](https://github.com/provenance-io/provenance/pull/1594)
+* Add pre-upgrade command that updates config files to newest format and sets `consensus.timeout_commit` to `1500ms` [PR 1594](https://github.com/provenance-io/provenance/pull/1594), [PR 1600](https://github.com/provenance-io/provenance/pull/1600).
 
 ### Bug Fixes
 
 * Add `NewUpdateAccountAttributeExpirationCmd` to the CLI [#1592](https://github.com/provenance-io/provenance/issues/1592).
-* Fix `minimum-gas-prices` from sometimes getting unset in the configs [PR 1594](https://github.com/provenance-io/provenance/pull/1594)
+* Fix `minimum-gas-prices` from sometimes getting unset in the configs [PR 1594](https://github.com/provenance-io/provenance/pull/1594).
 
 ---
 

--- a/cmd/provenanced/cmd/config_test.go
+++ b/cmd/provenanced/cmd/config_test.go
@@ -247,7 +247,7 @@ func (s *ConfigTestSuite) TestConfigCmdGet() {
 		// Tendermint header and a few entries.
 		{"tendermint header", regexp.MustCompile(`(?m)^Tendermint Config: .*/config/` + s.BaseFNTM + ` \(or env\)$`)},
 		{"tendermint fast_sync", regexp.MustCompile(`(?m)^fast_sync=true$`)},
-		{"tendermint consensus.timeout_commit", regexp.MustCompile(`(?m)^consensus.timeout_commit="5s"$`)},
+		{"tendermint consensus.timeout_commit", regexp.MustCompile(`(?m)^consensus.timeout_commit="1.5s"$`)},
 		{"tendermint mempool.size", regexp.MustCompile(`(?m)^mempool.size=5000$`)},
 		{"tendermint statesync.trust_period", regexp.MustCompile(`(?m)^statesync.trust_period="168h0m0s"$`)},
 		{"tendermint p2p.recv_rate", regexp.MustCompile(`(?m)^p2p.recv_rate=5120000$`)},
@@ -609,7 +609,7 @@ func (s *ConfigTestSuite) TestConfigCmdSet() {
 		},
 		{
 			name:    "consensus.timeout_commit",
-			oldVal:  `"5s"`,
+			oldVal:  `"1.5s"`,
 			newVal:  `"2s"`,
 			toMatch: []*regexp.Regexp{reTMConfigUpdated},
 		},
@@ -701,7 +701,7 @@ func (s *ConfigTestSuite) TestConfigSetMulti() {
 			out: s.makeMultiLine(
 				s.makeTMConfigUpdateLines(),
 				s.makeKeyUpdatedLine("log_format", `"plain"`, `"json"`),
-				s.makeKeyUpdatedLine("consensus.timeout_commit", `"5s"`, `"950ms"`),
+				s.makeKeyUpdatedLine("consensus.timeout_commit", `"1.5s"`, `"950ms"`),
 				""),
 		},
 		{

--- a/cmd/provenanced/cmd/config_test.go
+++ b/cmd/provenanced/cmd/config_test.go
@@ -247,7 +247,7 @@ func (s *ConfigTestSuite) TestConfigCmdGet() {
 		// Tendermint header and a few entries.
 		{"tendermint header", regexp.MustCompile(`(?m)^Tendermint Config: .*/config/` + s.BaseFNTM + ` \(or env\)$`)},
 		{"tendermint fast_sync", regexp.MustCompile(`(?m)^fast_sync=true$`)},
-		{"tendermint consensus.timeout_commit", regexp.MustCompile(`(?m)^consensus.timeout_commit="1.5s"$`)},
+		{"tendermint consensus.timeout_commit", regexp.MustCompile(`(?m)^consensus.timeout_commit=` + fmt.Sprintf("%q", provconfig.DefaultConsensusTimeoutCommit) + `$`)},
 		{"tendermint mempool.size", regexp.MustCompile(`(?m)^mempool.size=5000$`)},
 		{"tendermint statesync.trust_period", regexp.MustCompile(`(?m)^statesync.trust_period="168h0m0s"$`)},
 		{"tendermint p2p.recv_rate", regexp.MustCompile(`(?m)^p2p.recv_rate=5120000$`)},
@@ -609,7 +609,7 @@ func (s *ConfigTestSuite) TestConfigCmdSet() {
 		},
 		{
 			name:    "consensus.timeout_commit",
-			oldVal:  `"1.5s"`,
+			oldVal:  fmt.Sprintf("%q", provconfig.DefaultConsensusTimeoutCommit),
 			newVal:  `"2s"`,
 			toMatch: []*regexp.Regexp{reTMConfigUpdated},
 		},
@@ -701,7 +701,7 @@ func (s *ConfigTestSuite) TestConfigSetMulti() {
 			out: s.makeMultiLine(
 				s.makeTMConfigUpdateLines(),
 				s.makeKeyUpdatedLine("log_format", `"plain"`, `"json"`),
-				s.makeKeyUpdatedLine("consensus.timeout_commit", `"1.5s"`, `"950ms"`),
+				s.makeKeyUpdatedLine("consensus.timeout_commit", fmt.Sprintf("%q", provconfig.DefaultConsensusTimeoutCommit), `"950ms"`),
 				""),
 		},
 		{

--- a/cmd/provenanced/cmd/pre_upgrade.go
+++ b/cmd/provenanced/cmd/pre_upgrade.go
@@ -82,9 +82,9 @@ func UpdateConfig(cmd *cobra.Command) error {
 	}
 
 	if clientCfg.ChainID == "pio-mainnet-1" {
-		// Update the timeout commit if it's too low.
+		// Update the timeout commit.
 		timeoutCommit := config.DefaultConsensusTimeoutCommit
-		if tmCfg.Consensus.TimeoutCommit < timeoutCommit/2 {
+		if tmCfg.Consensus.TimeoutCommit != timeoutCommit {
 			cmd.Printf("Updating consensus.timeout_commit config value to %q (from %q)\n",
 				timeoutCommit, tmCfg.Consensus.TimeoutCommit)
 			tmCfg.Consensus.TimeoutCommit = timeoutCommit

--- a/cmd/provenanced/cmd/root_test.go
+++ b/cmd/provenanced/cmd/root_test.go
@@ -1,15 +1,204 @@
 package cmd
 
 import (
+	"bytes"
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/spf13/cast"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/server"
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
+	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	sdksim "github.com/cosmos/cosmos-sdk/simapp"
+
+	"github.com/provenance-io/provenance/cmd/provenanced/config"
 )
 
 func TestIAVLConfig(t *testing.T) {
 	require.Equal(t, getIAVLCacheSize(sdksim.EmptyAppOptions{}), cast.ToInt(serverconfig.DefaultConfig().IAVLCacheSize))
+}
+
+type testOpts map[string]interface{}
+
+var _ servertypes.AppOptions = (*testOpts)(nil)
+
+func (o testOpts) Get(key string) interface{} {
+	return o[key]
+}
+
+type panicOpts struct{}
+
+var _ servertypes.AppOptions = (*panicOpts)(nil)
+
+func (o panicOpts) Get(key string) interface{} {
+	panic(fmt.Errorf("panic forced while getting option %q", key))
+}
+
+func TestWarnAboutSettings(t *testing.T) {
+	keyChainID := flags.FlagChainID
+	keySkipTimeoutCommit := "consensus.skip_timeout_commit"
+	keyTimeoutCommit := "consensus.timeout_commit"
+
+	upperLimit := config.DefaultConsensusTimeoutCommit + 2*time.Second
+	overUpperLimit := upperLimit + 1*time.Millisecond
+	mainnetChainID := "pio-mainnet-1"
+	notMainnetChainID := "not-" + mainnetChainID
+
+	tooHighMsg := func(timeoutCommit time.Duration) string {
+		return fmt.Sprintf("ERR Your consensus.timeout_commit config value is too high and should be decreased to at most %q. The recommended value is %q. Your current value is %q.",
+			upperLimit, config.DefaultConsensusTimeoutCommit, timeoutCommit)
+	}
+
+	mainnetOpts := func(skipTimeoutCommit bool, timeoutCommit time.Duration) testOpts {
+		return testOpts{
+			keyChainID:           mainnetChainID,
+			keySkipTimeoutCommit: skipTimeoutCommit,
+			keyTimeoutCommit:     timeoutCommit,
+		}
+	}
+	notMainnetOpts := func(skipTimeoutCommit bool, timeoutCommit time.Duration) testOpts {
+		return testOpts{
+			keyChainID:           notMainnetChainID,
+			keySkipTimeoutCommit: skipTimeoutCommit,
+			keyTimeoutCommit:     timeoutCommit,
+		}
+	}
+
+	tests := []struct {
+		name      string
+		appOpts   servertypes.AppOptions
+		expLogged []string
+	}{
+		{
+			name:      "mainnet not skipped value over upper limit",
+			appOpts:   mainnetOpts(false, overUpperLimit),
+			expLogged: []string{tooHighMsg(overUpperLimit)},
+		},
+		{
+			name:    "mainnet not skipped value at limit",
+			appOpts: mainnetOpts(false, upperLimit),
+		},
+		{
+			name:    "mainnet not skipped value at default",
+			appOpts: mainnetOpts(false, config.DefaultConsensusTimeoutCommit),
+		},
+		{
+			name:    "mainnet not skipped value at zero",
+			appOpts: mainnetOpts(false, 0),
+		},
+		{
+			name:    "mainnet skipped value over upper limit",
+			appOpts: mainnetOpts(true, overUpperLimit),
+		},
+		{
+			name:    "mainnet skipped value at upper limit",
+			appOpts: mainnetOpts(true, upperLimit),
+		},
+		{
+			name:    "mainnet skipped value at default",
+			appOpts: mainnetOpts(true, config.DefaultConsensusTimeoutCommit),
+		},
+		{
+			name:    "mainnet skipped value at zero",
+			appOpts: mainnetOpts(true, 0),
+		},
+		{
+			name:    "not mainnet not skipped value over upper limit",
+			appOpts: notMainnetOpts(false, overUpperLimit),
+		},
+		{
+			name:    "not mainnet not skipped value at upper limit",
+			appOpts: notMainnetOpts(false, upperLimit),
+		},
+		{
+			name:    "not mainnet not skipped value at default",
+			appOpts: notMainnetOpts(false, config.DefaultConsensusTimeoutCommit),
+		},
+		{
+			name:    "not mainnet not skipped value at zero",
+			appOpts: notMainnetOpts(false, 0),
+		},
+		{
+			name:    "not mainnet skipped value over upper limit",
+			appOpts: notMainnetOpts(true, overUpperLimit),
+		},
+		{
+			name:    "not mainnet skipped value at upper limit",
+			appOpts: notMainnetOpts(true, upperLimit),
+		},
+		{
+			name:    "not mainnet skipped value at default",
+			appOpts: notMainnetOpts(true, config.DefaultConsensusTimeoutCommit),
+		},
+		{
+			name:    "not mainnet skipped value at zero",
+			appOpts: notMainnetOpts(true, 0),
+		},
+		{
+			name:    "timeout commit opt not a duration",
+			appOpts: testOpts{keyChainID: mainnetChainID, keySkipTimeoutCommit: false, keyTimeoutCommit: "nope"},
+		},
+		{
+			name:    "empty opts",
+			appOpts: testOpts{},
+		},
+		{
+			name:    "only chain-id mainnet",
+			appOpts: testOpts{keyChainID: mainnetChainID},
+		},
+		{
+			name:    "only chain-id not mainnet",
+			appOpts: testOpts{keyChainID: mainnetChainID},
+		},
+		{
+			name:    "mainnet not skipped no timeout commit opt",
+			appOpts: testOpts{keyChainID: mainnetChainID, keySkipTimeoutCommit: false},
+		},
+		{
+			name:    "panic from getter",
+			appOpts: panicOpts{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// If expLogged isn't defined, we're expecting zero logged lines.
+			if tc.expLogged == nil {
+				tc.expLogged = make([]string, 0)
+			}
+
+			// Create a logger wrapped around our own buffer so we can see what was logged.
+			var buf bytes.Buffer
+			lw := zerolog.ConsoleWriter{
+				Out:          &buf,
+				NoColor:      true,
+				PartsExclude: []string{"time"}, // Without this, each line starts with "<nil> "
+			}
+			// Error log lines will start with "ERR ".
+			// Info log lines will start with "INF ".
+			// Debug log lines are omitted, but would start with "DBG ".
+			logger := server.ZeroLogWrapper{Logger: zerolog.New(lw).Level(zerolog.InfoLevel)}
+
+			// Make sure the function never panics.
+			require.NotPanics(t, func() { warnAboutSettings(logger, tc.appOpts) }, "warnAboutSettings")
+
+			// Make sure the logged output is as expected.
+			out := buf.String()
+			// Splitting it into lines and comparing the string slices makes test failure output nicer than
+			// if we just compare two multi-line strings.
+			loggedLines := strings.Split(out, "\n")
+			// Get rid of last "line" if it's just an empty string. Happens when out ends with "\n".
+			if len(loggedLines[len(loggedLines)-1]) == 0 {
+				loggedLines = loggedLines[:len(loggedLines)-1]
+			}
+			assert.Equal(t, tc.expLogged, loggedLines, "lines logged during warnAboutSettings")
+		})
+	}
 }

--- a/cmd/provenanced/config/manager.go
+++ b/cmd/provenanced/config/manager.go
@@ -23,7 +23,7 @@ import (
 )
 
 // DefaultConsensusTimeoutCommit is the default value used for the consensus.timeout_commit config value.
-var DefaultConsensusTimeoutCommit = 5 * time.Second
+var DefaultConsensusTimeoutCommit = 1500 * time.Millisecond
 
 // PackConfig generates and saves the packed config file then removes the individual config files.
 func PackConfig(cmd *cobra.Command) error {

--- a/cmd/provenanced/config/manager_test.go
+++ b/cmd/provenanced/config/manager_test.go
@@ -354,7 +354,7 @@ func (s *ConfigManagerTestSuite) TestDefaultTmConfig() {
 	cfg := DefaultTmConfig()
 
 	s.Run("consensus.commit_timeout", func() {
-		exp := 5 * time.Second
+		exp := 1500 * time.Millisecond
 		act := cfg.Consensus.TimeoutCommit
 		s.Assert().Equal(exp, act, "cfg.Consensus.TimeoutCommit")
 	})


### PR DESCRIPTION
## Description

* Change the default `consensus.timeout_commit` to `1500ms`.
* Make the `pre-upgrade` command always update the `consensus.timeout_commit` to `1500ms`.
* Change the `consensus.timeout_commit` log warning to only log about values being too large (more than `3500ms`).

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
