### PR TITLE
Switch maven publishing and buf.lock PR creation to provenanceio-bot.

### DIFF
--- a/.github/workflows/proto-registry.yml
+++ b/.github/workflows/proto-registry.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - dwedul/provio-bot
     paths:
       - "third_party/**.proto"
       - ".github/workflows/proto-registry.yml"

--- a/.github/workflows/proto-registry.yml
+++ b/.github/workflows/proto-registry.yml
@@ -25,18 +25,12 @@ on:
 # This helps avoid a buf push failure due to a new third party proto reference.
 jobs:
   push_third_party:
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Buf setup action
         uses: bufbuild/buf-setup-action@v1.21.0
-      - name: Buf push 'third_party/proto'
-        uses: bufbuild/buf-push-action@v1
-        with:
-          input: 'third_party/proto'
-          buf_token: ${{ secrets.BUF_TOKEN }}
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v5
@@ -51,6 +45,7 @@ jobs:
           cd proto
           buf mod update
           cd ..
+          printf 'New file\n' >> a-new-file.txt
           git add .
           git commit -S -m "Update buf.lock to latest commit hash"
       - name: Create Pull Request

--- a/.github/workflows/proto-registry.yml
+++ b/.github/workflows/proto-registry.yml
@@ -25,12 +25,18 @@ on:
 # This helps avoid a buf push failure due to a new third party proto reference.
 jobs:
   push_third_party:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Buf setup action
         uses: bufbuild/buf-setup-action@v1.21.0
+      - name: Buf push 'third_party/proto'
+        uses: bufbuild/buf-push-action@v1
+        with:
+          input: 'third_party/proto'
+          buf_token: ${{ secrets.BUF_TOKEN }}
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v5
@@ -45,7 +51,6 @@ jobs:
           cd proto
           buf mod update
           cd ..
-          printf 'New file\n' >> a-new-file.txt
           git add .
           git commit -S -m "Update buf.lock to latest commit hash"
       - name: Create Pull Request

--- a/.github/workflows/proto-registry.yml
+++ b/.github/workflows/proto-registry.yml
@@ -40,8 +40,9 @@ jobs:
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v5
         with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          # Use a key associated with the provenanceio-bot github account.
+          gpg_private_key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.BOT_GPG_PRIVATE_KEY_PW }}
           git_user_signingkey: true
           git_commit_gpgsign: true
       - name: Update buf.lock
@@ -59,7 +60,9 @@ jobs:
           branch: create-pull-request/patch-buf-lock
           delete-branch: true
           # GitHub Personal Access Token (from the same account where the GPG key is stored)
-          token: ${{ secrets.CPR_PAT }}
+          # When this expires, you'll need to log into the provenanceio-bot github account,
+          # regenerate a new one, and update the secret to have the new value.
+          token: ${{ secrets.BOT_CPR_PAT }}
           committer: ${{ steps.import_gpg.outputs.name }} <${{ steps.import_gpg.outputs.email }}>
           author: ${{ steps.import_gpg.outputs.name }} <${{ steps.import_gpg.outputs.email }}>
           signoff: true

--- a/.github/workflows/proto-registry.yml
+++ b/.github/workflows/proto-registry.yml
@@ -57,7 +57,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5.0.2
         with:
           base: main
-          branch: create-pull-request/patch-buf-lock
+          branch: provenanceio-bot/patch-buf-lock
           delete-branch: true
           # GitHub Personal Access Token (from the same account where the GPG key is stored)
           # When this expires, you'll need to log into the provenanceio-bot github account,

--- a/.github/workflows/proto-registry.yml
+++ b/.github/workflows/proto-registry.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - dwedul/provio-bot
     paths:
       - "third_party/**.proto"
       - ".github/workflows/proto-registry.yml"

--- a/protoBindings/bindings/java/build.gradle.kts
+++ b/protoBindings/bindings/java/build.gradle.kts
@@ -123,6 +123,8 @@ publishing {
                         id.set(project.property("developer.id") as String)
                         name.set(project.property("developer.name") as String)
                         email.set(project.property("developer.email") as String)
+                        organization.set(project.property("developer.organization") as String)
+                        organizationUrl.set(project.property("developer.organizationUrl") as String)
                     }
                 }
 

--- a/protoBindings/bindings/kotlin/build.gradle.kts
+++ b/protoBindings/bindings/kotlin/build.gradle.kts
@@ -147,6 +147,8 @@ publishing {
                         id.set(project.property("developer.id") as String)
                         name.set(project.property("developer.name") as String)
                         email.set(project.property("developer.email") as String)
+                        organization.set(project.property("developer.organization") as String)
+                        organizationUrl.set(project.property("developer.organizationUrl") as String)
                     }
                 }
 

--- a/protoBindings/gradle.properties
+++ b/protoBindings/gradle.properties
@@ -25,9 +25,11 @@ license.name=The Apache License, Version 2.0
 license.url=https://www.apache.org/licenses/LICENSE-2.0.txt
 
 # Developers
-developer.id=egaxhaj
-developer.name=Ergels Gaxhaj
-developer.email=egaxhaj@provenance.io
+developer.id=provenanceio
+developer.name=Provenance Blockchain
+developer.email=provenanceio-bot@provenance.io
+developer.organization=Provenance Blockchain Foundation
+developer.organizationUrl=https://provenance.io/
 
 scm.connection=git@github.com:provenance-io/provenance.git
 scm.developerConnection=git@github.com/provenance-io/provenance.git


### PR DESCRIPTION
## Description

* Publish the java/kotlin libraries using `provenanceio-bot` instead of a specific developer.
* When `buf.lock` needs updating, create the PR using `provenanceio-bot`.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
