### PR TITLE
Allow restricted coins to be quarantined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * Fix ibcnet relayer creating multiple connections on restart [#1620](https://github.com/provenance-io/provenance/issues/1620).
 * Fix for incorrect resource-id type casting on contract specification [#1647](https://github.com/provenance-io/provenance/issues/1647).
 * Allow restricted coins to be quarantined [#1626](https://github.com/provenance-io/provenance/issues/1626).
+* Prevent marker forced transfers from module accounts [#1626](https://github.com/provenance-io/provenance/issues/1626).
 
 ### Client Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * Fix ibcnet relayer creating multiple connections on restart [#1620](https://github.com/provenance-io/provenance/issues/1620).
 * Fix for incorrect resource-id type casting on contract specification [#1647](https://github.com/provenance-io/provenance/issues/1647).
+* Allow restricted coins to be quarantined [#1626](https://github.com/provenance-io/provenance/issues/1626).
 
 ### Client Breaking
 

--- a/app/app.go
+++ b/app/app.go
@@ -479,8 +479,19 @@ func New(
 		appCodec, keys[metadatatypes.StoreKey], app.GetSubspace(metadatatypes.ModuleName), app.AccountKeeper, app.AuthzKeeper, app.AttributeKeeper,
 	)
 
+	markerWhitelistAddrs := []sdk.AccAddress{
+		authtypes.NewModuleAddress(authtypes.FeeCollectorName),     // Allow collecting fees in restricted coins.
+		authtypes.NewModuleAddress(rewardtypes.ModuleName),         // Allow rewards to hold onto restricted coins.
+		authtypes.NewModuleAddress(quarantine.ModuleName),          // Allow quarantine to hold onto restricted coins.
+		authtypes.NewModuleAddress(govtypes.ModuleName),            // Allow restricted coins in deposits.
+		authtypes.NewModuleAddress(distrtypes.ModuleName),          // Allow bond denom to be a restricted coin.
+		authtypes.NewModuleAddress(stakingtypes.BondedPoolName),    // Allow bond denom to be a restricted coin.
+		authtypes.NewModuleAddress(stakingtypes.NotBondedPoolName), // Allow bond denom to be a restricted coin.
+	}
 	app.MarkerKeeper = markerkeeper.NewKeeper(
-		appCodec, keys[markertypes.StoreKey], app.GetSubspace(markertypes.ModuleName), app.AccountKeeper, app.BankKeeper, app.AuthzKeeper, app.FeeGrantKeeper, app.AttributeKeeper, app.NameKeeper, app.TransferKeeper,
+		appCodec, keys[markertypes.StoreKey], app.GetSubspace(markertypes.ModuleName),
+		app.AccountKeeper, app.BankKeeper, app.AuthzKeeper, app.FeeGrantKeeper,
+		app.AttributeKeeper, app.NameKeeper, app.TransferKeeper, markerWhitelistAddrs,
 	)
 
 	pioMessageRouter := MessageRouterFunc(func(msg sdk.Msg) baseapp.MsgServiceHandler {

--- a/app/app.go
+++ b/app/app.go
@@ -484,7 +484,7 @@ func New(
 		authtypes.NewModuleAddress(rewardtypes.ModuleName),         // Allow rewards to hold onto restricted coins.
 		authtypes.NewModuleAddress(quarantine.ModuleName),          // Allow quarantine to hold onto restricted coins.
 		authtypes.NewModuleAddress(govtypes.ModuleName),            // Allow restricted coins in deposits.
-		authtypes.NewModuleAddress(distrtypes.ModuleName),          // Allow bond denom to be a restricted coin.
+		authtypes.NewModuleAddress(distrtypes.ModuleName),          // Allow fee denoms to be restricted coins.
 		authtypes.NewModuleAddress(stakingtypes.BondedPoolName),    // Allow bond denom to be a restricted coin.
 		authtypes.NewModuleAddress(stakingtypes.NotBondedPoolName), // Allow bond denom to be a restricted coin.
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -479,7 +479,7 @@ func New(
 		appCodec, keys[metadatatypes.StoreKey], app.GetSubspace(metadatatypes.ModuleName), app.AccountKeeper, app.AuthzKeeper, app.AttributeKeeper,
 	)
 
-	markerWhitelistAddrs := []sdk.AccAddress{
+	markerReqAttrBypassAddrs := []sdk.AccAddress{
 		authtypes.NewModuleAddress(authtypes.FeeCollectorName),     // Allow collecting fees in restricted coins.
 		authtypes.NewModuleAddress(rewardtypes.ModuleName),         // Allow rewards to hold onto restricted coins.
 		authtypes.NewModuleAddress(quarantine.ModuleName),          // Allow quarantine to hold onto restricted coins.
@@ -491,7 +491,7 @@ func New(
 	app.MarkerKeeper = markerkeeper.NewKeeper(
 		appCodec, keys[markertypes.StoreKey], app.GetSubspace(markertypes.ModuleName),
 		app.AccountKeeper, app.BankKeeper, app.AuthzKeeper, app.FeeGrantKeeper,
-		app.AttributeKeeper, app.NameKeeper, app.TransferKeeper, markerWhitelistAddrs,
+		app.AttributeKeeper, app.NameKeeper, app.TransferKeeper, markerReqAttrBypassAddrs,
 	)
 
 	pioMessageRouter := MessageRouterFunc(func(msg sdk.Msg) baseapp.MsgServiceHandler {

--- a/x/marker/keeper/export_test.go
+++ b/x/marker/keeper/export_test.go
@@ -14,3 +14,8 @@ func (k Keeper) GetMarkerModuleAddr() sdk.AccAddress {
 func (k Keeper) GetIbcTransferModuleAddr() sdk.AccAddress {
 	return k.ibcTransferModuleAddr
 }
+
+// CanForceTransferFrom is a TEST ONLY exposure of the canForceTransferFrom value.
+func (k Keeper) CanForceTransferFrom(ctx sdk.Context, from sdk.AccAddress) bool {
+	return k.canForceTransferFrom(ctx, from)
+}

--- a/x/marker/keeper/keeper.go
+++ b/x/marker/keeper/keeper.go
@@ -78,7 +78,7 @@ type Keeper struct {
 	// Used to transfer the ibc marker
 	ibcTransferServer types.IbcTransferMsgServer
 
-	whitelistAddrs []sdk.AccAddress
+	reqAttrBypassAddrs []sdk.AccAddress
 }
 
 // NewKeeper returns a marker keeper. It handles:
@@ -97,7 +97,7 @@ func NewKeeper(
 	attrKeeper types.AttrKeeper,
 	nameKeeper types.NameKeeper,
 	ibcTransferServer types.IbcTransferMsgServer,
-	whitelistAddrs []sdk.AccAddress,
+	reqAttrBypassAddrs []sdk.AccAddress,
 ) Keeper {
 	if !paramSpace.HasKeyTable() {
 		paramSpace = paramSpace.WithKeyTable(types.ParamKeyTable())
@@ -117,7 +117,7 @@ func NewKeeper(
 		markerModuleAddr:      authtypes.NewModuleAddress(types.CoinPoolName),
 		ibcTransferModuleAddr: authtypes.NewModuleAddress(ibctypes.ModuleName),
 		ibcTransferServer:     ibcTransferServer,
-		whitelistAddrs:        whitelistAddrs,
+		reqAttrBypassAddrs:    reqAttrBypassAddrs,
 	}
 	bankKeeper.AppendSendRestriction(rv.SendRestrictionFn)
 	return rv
@@ -212,19 +212,19 @@ func (k Keeper) RemoveSendDeny(ctx sdk.Context, markerAddr, senderAddr sdk.AccAd
 	store.Delete(types.DenySendKey(markerAddr, senderAddr))
 }
 
-// GetWhitelistAddrs returns a deep copy of the whitelisted addresses.
-func (k Keeper) GetWhitelistAddrs() []sdk.AccAddress {
-	rv := make([]sdk.AccAddress, len(k.whitelistAddrs))
-	for i, addr := range k.whitelistAddrs {
+// GetReqAttrBypassAddrs returns a deep copy of the addresses that bypass the required attributes checking.
+func (k Keeper) GetReqAttrBypassAddrs() []sdk.AccAddress {
+	rv := make([]sdk.AccAddress, len(k.reqAttrBypassAddrs))
+	for i, addr := range k.reqAttrBypassAddrs {
 		rv[i] = make(sdk.AccAddress, len(addr))
 		copy(rv[i], addr)
 	}
 	return rv
 }
 
-// IsWhitelistAddr returns true if the provided addr has been whitelisted.
-func (k Keeper) IsWhitelistAddr(addr sdk.AccAddress) bool {
-	for _, w := range k.whitelistAddrs {
+// IsReqAttrBypassAddr returns true if the provided addr can bypass the required attributes checking.
+func (k Keeper) IsReqAttrBypassAddr(addr sdk.AccAddress) bool {
+	for _, w := range k.reqAttrBypassAddrs {
 		if addr.Equals(w) {
 			return true
 		}

--- a/x/marker/keeper/keeper.go
+++ b/x/marker/keeper/keeper.go
@@ -79,6 +79,10 @@ type Keeper struct {
 	ibcTransferServer types.IbcTransferMsgServer
 
 	// reqAttrBypassAddrs is a set of addresses that are allowed to bypass the required attribute check.
+	// When sending to one of these, if there are required attributes, it behaves as if the addr has them;
+	// if there aren't required attributes, the sender still needs transfer permission.
+	// When sending from one of these, if there are required attributes, the destination must have them;
+	// if there aren't required attributes, it behaves as if the sender has transfer permission.
 	reqAttrBypassAddrs []sdk.AccAddress
 }
 

--- a/x/marker/keeper/keeper.go
+++ b/x/marker/keeper/keeper.go
@@ -122,7 +122,7 @@ func NewKeeper(
 		markerModuleAddr:      authtypes.NewModuleAddress(types.CoinPoolName),
 		ibcTransferModuleAddr: authtypes.NewModuleAddress(ibctypes.ModuleName),
 		ibcTransferServer:     ibcTransferServer,
-		reqAttrBypassAddrs:    reqAttrBypassAddrs,
+		reqAttrBypassAddrs:    deepCopyAccAddresses(reqAttrBypassAddrs),
 	}
 	bankKeeper.AppendSendRestriction(rv.SendRestrictionFn)
 	return rv
@@ -219,12 +219,7 @@ func (k Keeper) RemoveSendDeny(ctx sdk.Context, markerAddr, senderAddr sdk.AccAd
 
 // GetReqAttrBypassAddrs returns a deep copy of the addresses that bypass the required attributes checking.
 func (k Keeper) GetReqAttrBypassAddrs() []sdk.AccAddress {
-	rv := make([]sdk.AccAddress, len(k.reqAttrBypassAddrs))
-	for i, addr := range k.reqAttrBypassAddrs {
-		rv[i] = make(sdk.AccAddress, len(addr))
-		copy(rv[i], addr)
-	}
-	return rv
+	return deepCopyAccAddresses(k.reqAttrBypassAddrs)
 }
 
 // IsReqAttrBypassAddr returns true if the provided addr can bypass the required attributes checking.
@@ -235,4 +230,16 @@ func (k Keeper) IsReqAttrBypassAddr(addr sdk.AccAddress) bool {
 		}
 	}
 	return false
+}
+
+// deepCopyAccAddresses creates a deep copy of the provided slice of acc addresses.
+// A copy of each entry is made and placed into a new slice.
+func deepCopyAccAddresses(orig []sdk.AccAddress) []sdk.AccAddress {
+	rv := make([]sdk.AccAddress, len(orig))
+	for i, addr := range orig {
+		rv[i] = make(sdk.AccAddress, len(addr))
+		copy(rv[i], addr)
+	}
+	return rv
+
 }

--- a/x/marker/keeper/keeper.go
+++ b/x/marker/keeper/keeper.go
@@ -235,11 +235,13 @@ func (k Keeper) IsReqAttrBypassAddr(addr sdk.AccAddress) bool {
 // deepCopyAccAddresses creates a deep copy of the provided slice of acc addresses.
 // A copy of each entry is made and placed into a new slice.
 func deepCopyAccAddresses(orig []sdk.AccAddress) []sdk.AccAddress {
+	if orig == nil {
+		return nil
+	}
 	rv := make([]sdk.AccAddress, len(orig))
 	for i, addr := range orig {
 		rv[i] = make(sdk.AccAddress, len(addr))
 		copy(rv[i], addr)
 	}
 	return rv
-
 }

--- a/x/marker/keeper/keeper.go
+++ b/x/marker/keeper/keeper.go
@@ -78,6 +78,7 @@ type Keeper struct {
 	// Used to transfer the ibc marker
 	ibcTransferServer types.IbcTransferMsgServer
 
+	// reqAttrBypassAddrs is a set of addresses that are allowed to bypass the required attribute check.
 	reqAttrBypassAddrs []sdk.AccAddress
 }
 

--- a/x/marker/keeper/keeper_test.go
+++ b/x/marker/keeper/keeper_test.go
@@ -1493,8 +1493,8 @@ func TestUpdateSendDenyList(t *testing.T) {
 	}
 }
 
-func TestWhitelistAddrs(t *testing.T) {
-	// Tests both GetWhitelistAddrs and IsWhitelistAddr.
+func TestReqAttrBypassAddrs(t *testing.T) {
+	// Tests both GetReqAttrBypassAddrs and IsReqAttrBypassAddr.
 	expectedNames := []string{
 		authtypes.FeeCollectorName,
 		rewardtypes.ModuleName,
@@ -1517,35 +1517,35 @@ func TestWhitelistAddrs(t *testing.T) {
 	for _, name := range expectedNames {
 		t.Run(fmt.Sprintf("get: contains %s", name), func(t *testing.T) {
 			expAddr := authtypes.NewModuleAddress(name)
-			actual := app.MarkerKeeper.GetWhitelistAddrs()
-			assert.Contains(t, actual, expAddr, "GetWhitelistAddrs()")
+			actual := app.MarkerKeeper.GetReqAttrBypassAddrs()
+			assert.Contains(t, actual, expAddr, "GetReqAttrBypassAddrs()")
 		})
 	}
 	t.Run("get: only has expected entries", func(t *testing.T) {
 		// This assumes each expectedNames test passed. This is designed to fail if a new entry
 		// is added to the list (in app.go). When that happens, update the expectedNames with
 		// the new entry so it's harder for it to accidentally go missing.
-		actual := app.MarkerKeeper.GetWhitelistAddrs()
-		assert.Len(t, actual, len(expectedNames), "GetWhitelistAddrs()")
+		actual := app.MarkerKeeper.GetReqAttrBypassAddrs()
+		assert.Len(t, actual, len(expectedNames), "GetReqAttrBypassAddrs()")
 	})
 
 	t.Run("get: called twice equal but not same", func(t *testing.T) {
-		expected := app.MarkerKeeper.GetWhitelistAddrs()
-		actual := app.MarkerKeeper.GetWhitelistAddrs()
-		if assert.Equal(t, expected, actual, "GetWhitelistAddrs()") {
-			if assert.NotSame(t, expected, actual, "GetWhitelistAddrs()") {
+		expected := app.MarkerKeeper.GetReqAttrBypassAddrs()
+		actual := app.MarkerKeeper.GetReqAttrBypassAddrs()
+		if assert.Equal(t, expected, actual, "GetReqAttrBypassAddrs()") {
+			if assert.NotSame(t, expected, actual, "GetReqAttrBypassAddrs()") {
 				for i := range expected {
-					assert.NotSame(t, expected[i], actual[i], "GetWhitelistAddrs()[%d]", i)
+					assert.NotSame(t, expected[i], actual[i], "GetReqAttrBypassAddrs()[%d]", i)
 				}
 			}
 		}
 	})
 
 	t.Run("get: changes to result not reflected in next result", func(t *testing.T) {
-		actual1 := app.MarkerKeeper.GetWhitelistAddrs()
+		actual1 := app.MarkerKeeper.GetReqAttrBypassAddrs()
 		origActual100 := actual1[0][0]
 		actual1[0][0] = incByte(origActual100)
-		actual2 := app.MarkerKeeper.GetWhitelistAddrs()
+		actual2 := app.MarkerKeeper.GetReqAttrBypassAddrs()
 		actual200 := actual2[0][0]
 		assert.Equal(t, origActual100, actual200, "first byte of first address after changing it in an earlier result")
 	})
@@ -1553,8 +1553,8 @@ func TestWhitelistAddrs(t *testing.T) {
 	for _, name := range expectedNames {
 		t.Run(fmt.Sprintf("is: %s", name), func(t *testing.T) {
 			addr := authtypes.NewModuleAddress(name)
-			actual := app.MarkerKeeper.IsWhitelistAddr(addr)
-			assert.True(t, actual, "IsWhitelistAddr(NewModuleAddress(%q))", name)
+			actual := app.MarkerKeeper.IsReqAttrBypassAddr(addr)
+			assert.True(t, actual, "IsReqAttrBypassAddr(NewModuleAddress(%q))", name)
 		})
 	}
 
@@ -1575,8 +1575,8 @@ func TestWhitelistAddrs(t *testing.T) {
 
 	for _, tc := range negativeIsTests {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := app.MarkerKeeper.IsWhitelistAddr(tc.addr)
-			assert.False(t, actual, "IsWhitelistAddr(...)")
+			actual := app.MarkerKeeper.IsReqAttrBypassAddr(tc.addr)
+			assert.False(t, actual, "IsReqAttrBypassAddr(...)")
 		})
 	}
 }

--- a/x/marker/keeper/marker.go
+++ b/x/marker/keeper/marker.go
@@ -665,7 +665,7 @@ func (k Keeper) TransferCoin(ctx sdk.Context, from, to, admin sdk.AccAddress, am
 	return ctx.EventManager().EmitTypedEvent(markerTransferEvent)
 }
 
-// canForceTransferFrom returns true if funds can be forcefully transfered out of the provided address.
+// canForceTransferFrom returns true if funds can be forcefully transferred out of the provided address.
 func (k Keeper) canForceTransferFrom(ctx sdk.Context, from sdk.AccAddress) bool {
 	acc := k.authKeeper.GetAccount(ctx, from)
 	// If acc is nil, there's no funds in it, so the transfer will fail anyway.

--- a/x/marker/keeper/marker.go
+++ b/x/marker/keeper/marker.go
@@ -634,10 +634,15 @@ func (k Keeper) TransferCoin(ctx sdk.Context, from, to, admin sdk.AccAddress, am
 	if !m.AddressHasAccess(admin, types.Access_Transfer) {
 		return fmt.Errorf("%s is not allowed to broker transfers", admin.String())
 	}
-	if !admin.Equals(from) && !m.AllowsForcedTransfer() {
-		err = k.authzHandler(ctx, admin, from, to, amount)
-		if err != nil {
-			return err
+	if !admin.Equals(from) {
+		switch {
+		case !m.AllowsForcedTransfer():
+			err = k.authzHandler(ctx, admin, from, to, amount)
+			if err != nil {
+				return err
+			}
+		case !k.canForceTransferFrom(ctx, from):
+			return fmt.Errorf("funds are not allowed to be removed from %s", from)
 		}
 	}
 	if k.bankKeeper.BlockedAddr(to) {
@@ -658,6 +663,18 @@ func (k Keeper) TransferCoin(ctx sdk.Context, from, to, admin sdk.AccAddress, am
 	)
 
 	return ctx.EventManager().EmitTypedEvent(markerTransferEvent)
+}
+
+// canForceTransferFrom returns true if funds can be forcefully transfered out of the provided address.
+func (k Keeper) canForceTransferFrom(ctx sdk.Context, from sdk.AccAddress) bool {
+	acc := k.authKeeper.GetAccount(ctx, from)
+	// If acc is nil, there's no funds in it, so the transfer will fail anyway.
+	// In that case, return true from here so it can fail later with a more accurate message.
+	// If there is an account, only allow force transfers if the sequence number isn't zero.
+	// This is to prevent forced transfer from module accounts and smart contracts.
+	// It will also block forced transfers from new or dead accounts, though.
+	// If the forced transfer is absolutely required, use a governance proposal with a MsgSend.
+	return acc == nil || acc.GetSequence() != 0
 }
 
 // IbcTransferCoin transfers restricted coins between two chains when the administrator account holds the transfer

--- a/x/marker/keeper/proposal_handler_test.go
+++ b/x/marker/keeper/proposal_handler_test.go
@@ -34,7 +34,7 @@ type IntegrationTestSuite struct {
 func (s *IntegrationTestSuite) SetupSuite() {
 	s.app = provenance.Setup(s.T())
 	s.ctx = s.app.BaseApp.NewContext(false, tmproto.Header{})
-	s.k = markerkeeper.NewKeeper(s.app.AppCodec(), s.app.GetKey(markertypes.ModuleName), s.app.GetSubspace(markertypes.ModuleName), s.app.AccountKeeper, s.app.BankKeeper, s.app.AuthzKeeper, s.app.FeeGrantKeeper, s.app.AttributeKeeper, s.app.NameKeeper, s.app.TransferKeeper)
+	s.k = markerkeeper.NewKeeper(s.app.AppCodec(), s.app.GetKey(markertypes.ModuleName), s.app.GetSubspace(markertypes.ModuleName), s.app.AccountKeeper, s.app.BankKeeper, s.app.AuthzKeeper, s.app.FeeGrantKeeper, s.app.AttributeKeeper, s.app.NameKeeper, s.app.TransferKeeper, nil)
 	s.accountAddr = sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
 }
 

--- a/x/marker/keeper/send_restrictions.go
+++ b/x/marker/keeper/send_restrictions.go
@@ -78,7 +78,7 @@ func (k Keeper) validateSendDenom(ctx sdk.Context, fromAddr, toAddr sdk.AccAddre
 	}
 
 	// If there aren't any required attributes, transfer permission is required unless coming from a bypass account.
-	// It's assumed that the only way the restricted coins with required attributes can got into a bypass
+	// It's assumed that the only way the restricted coins without required attributes can got into a bypass
 	// account is by someone with transfer permission, which is then conveyed for this transfer too.
 	if len(reqAttr) == 0 {
 		if k.IsReqAttrBypassAddr(fromAddr) {

--- a/x/marker/keeper/send_restrictions_test.go
+++ b/x/marker/keeper/send_restrictions_test.go
@@ -798,3 +798,212 @@ func TestMatchAttribute(t *testing.T) {
 		})
 	}
 }
+
+func TestQuarantineOfRestrictedCoins(t *testing.T) {
+	// Directly tests the bug described in https://github.com/provenance-io/provenance/issues/1626
+
+	app := simapp.Setup(t)
+	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+	owner := sdk.AccAddress("owner_address_______")
+	app.AccountKeeper.SetAccount(ctx, app.AccountKeeper.NewAccountWithAddress(ctx, owner))
+	reqAttr := "quarantinetest.provenance.io"
+	require.NoError(t, app.NameKeeper.SetNameRecord(ctx, reqAttr, owner, false), "SetNameRecord(%q)", reqAttr)
+
+	// Two source addresses, one with transfer on both markers, one without on either.
+	addrWithTransfer := sdk.AccAddress("addrWithTransfer____")
+	addrWithWithdraw := sdk.AccAddress("addrWithWithdraw____")
+	addrWithoutTransfer := sdk.AccAddress("addrWithoutTransfer_")
+
+	newMarker := func(denom string, reqAttrs []string) *types.MarkerAccount {
+		rv := types.NewMarkerAccount(
+			app.AccountKeeper.NewAccountWithAddress(ctx, types.MustGetMarkerAddress(denom)).(*authtypes.BaseAccount),
+			sdk.NewInt64Coin(denom, 1000),
+			owner,
+			[]types.AccessGrant{
+				{Address: addrWithTransfer.String(), Permissions: types.AccessList{types.Access_Transfer}},
+				{Address: addrWithWithdraw.String(), Permissions: types.AccessList{types.Access_Withdraw}},
+			},
+			types.StatusProposed,
+			types.MarkerType_RestrictedCoin,
+			true,  // supply fixed
+			true,  // allow gov
+			false, // no force transfer
+			reqAttrs,
+		)
+		err := app.MarkerKeeper.AddFinalizeAndActivateMarker(ctx, rv)
+		require.NoError(t, err, "AddFinalizeAndActivateMarker(%s)", denom)
+		return rv
+	}
+
+	// Two markers, one with a required attribute, one without any.
+	denomNoReqAttr := "denomNoReqAttr"
+	denom1ReqAttr := "denom1ReqAttr"
+
+	coinsNoReqAttr := sdk.NewCoins(sdk.NewInt64Coin(denomNoReqAttr, 3))
+	coins1ReqAttr := sdk.NewCoins(sdk.NewInt64Coin(denom1ReqAttr, 2))
+
+	newMarker(denomNoReqAttr, nil)
+	newMarker(denom1ReqAttr, []string{reqAttr})
+
+	mustWithdraw := func(recipient sdk.AccAddress, denom string) {
+		coins := sdk.NewCoins(sdk.NewInt64Coin(denom, 100))
+		err := app.MarkerKeeper.WithdrawCoins(ctx, addrWithWithdraw, recipient, denom, coins)
+		require.NoError(t, err, "WithdrawCoins(%q, %q)", string(recipient), coins)
+	}
+	mustWithdraw(addrWithTransfer, denomNoReqAttr)
+	mustWithdraw(addrWithTransfer, denom1ReqAttr)
+	mustWithdraw(addrWithoutTransfer, denomNoReqAttr)
+	mustWithdraw(addrWithoutTransfer, denom1ReqAttr)
+
+	// Create two quarantined address: one with the required attributes, one without.
+	optIn := func(t *testing.T, addr sdk.AccAddress) {
+		require.NoError(t, app.QuarantineKeeper.SetOptIn(ctx, addr), "SetOptIn(%q)", string(addr))
+	}
+	addrQWithAttr := sdk.AccAddress("addrQWithReqAttrs____")
+	addrQWithoutAttr := sdk.AccAddress("addrQWithoutReqAttrs____")
+	optIn(t, addrQWithAttr)
+	optIn(t, addrQWithoutAttr)
+
+	attrVal := []byte("string value")
+	setAttr := func(t *testing.T, addr sdk.AccAddress) {
+		attr := attrTypes.Attribute{
+			Name:          reqAttr,
+			Value:         attrVal,
+			Address:       addr.String(),
+			AttributeType: attrTypes.AttributeType_String,
+		}
+		err := app.AttributeKeeper.SetAttribute(ctx, attr, owner)
+		require.NoError(t, err, "SetAttribute(%q, %q)", string(addr), attr.Name)
+	}
+	setAttr(t, addrQWithAttr)
+
+	noTransErr := addrWithoutTransfer.String() + " does not have transfer permissions"
+	noAttrErr := func(addr sdk.AccAddress) string {
+		return fmt.Sprintf("address %s does not contain the %q required attribute: %q", addr, denom1ReqAttr, reqAttr)
+	}
+
+	quarantineModAddr := authtypes.NewModuleAddress("quarantine")
+
+	tests := []struct {
+		name         string
+		fromAddr     sdk.AccAddress
+		toAddr       sdk.AccAddress
+		amt          sdk.Coins
+		expSendErr   string
+		expAcceptErr string
+	}{
+		{
+			name:     "no req attrs from addr with transfer to quarantined",
+			fromAddr: addrWithTransfer,
+			toAddr:   addrQWithoutAttr,
+			amt:      coinsNoReqAttr,
+		},
+		{
+			name:       "no req attrs from addr without transfer to quarantined",
+			fromAddr:   addrWithoutTransfer,
+			toAddr:     addrQWithoutAttr,
+			amt:        coinsNoReqAttr,
+			expSendErr: noTransErr,
+		},
+		{
+			name:         "with req attrs from addr with transfer to quarantined without attrs",
+			fromAddr:     addrWithTransfer,
+			toAddr:       addrQWithoutAttr,
+			amt:          coins1ReqAttr,
+			expAcceptErr: noAttrErr(addrQWithoutAttr),
+		},
+		{
+			name:     "with req attrs from addr with transfer to quarantined with attrs",
+			fromAddr: addrWithTransfer,
+			toAddr:   addrQWithAttr,
+			amt:      coins1ReqAttr,
+		},
+		{
+			name:       "with req attrs from addr without transfer to quarantined without attrs",
+			fromAddr:   addrWithoutTransfer,
+			toAddr:     addrQWithoutAttr,
+			amt:        coins1ReqAttr,
+			expSendErr: noAttrErr(addrQWithoutAttr),
+		},
+		{
+			name:     "with req attrs from addr without transfer to quarantined with attrs",
+			fromAddr: addrWithoutTransfer,
+			toAddr:   addrQWithAttr,
+			amt:      coins1ReqAttr,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if t.Failed() {
+					t.Logf("fromAddr: %s", tc.fromAddr)
+					t.Logf("  toAddr: %s", tc.toAddr)
+					t.Logf("quarantine module address: %s", quarantineModAddr)
+				}
+			}()
+			sendErr := app.BankKeeper.SendCoins(ctx, tc.fromAddr, tc.toAddr, tc.amt)
+			if len(tc.expSendErr) != 0 {
+				require.EqualError(t, sendErr, tc.expSendErr, "SendCoins")
+			} else {
+				require.NoError(t, sendErr, "SendCoins")
+			}
+			if sendErr != nil {
+				return
+			}
+			amt, acceptErr := app.QuarantineKeeper.AcceptQuarantinedFunds(ctx, tc.toAddr, tc.fromAddr)
+			if len(tc.expAcceptErr) != 0 {
+				require.EqualError(t, acceptErr, tc.expAcceptErr, "AcceptQuarantinedFunds")
+			} else {
+				require.NoError(t, acceptErr, "AcceptQuarantinedFunds")
+				assert.Equal(t, tc.amt.String(), amt.String(), "accepted quarantined funds")
+			}
+		})
+	}
+
+	t.Run("attr deleted after funds quarantined", func(t *testing.T) {
+		fromAddr := addrWithoutTransfer
+		toAddr := sdk.AccAddress("addr_attr_del_______")
+		amt := coins1ReqAttr
+		optIn(t, toAddr)
+		setAttr(t, toAddr)
+		sendErr := app.BankKeeper.SendCoins(ctx, fromAddr, toAddr, amt)
+		require.NoError(t, sendErr, "SendCoins")
+		delErr := app.AttributeKeeper.DeleteAttribute(ctx, toAddr.String(), reqAttr, &attrVal, owner)
+		require.NoError(t, delErr, "DeleteAttribute")
+		expAcceptErr := noAttrErr(toAddr)
+		_, acceptErr := app.QuarantineKeeper.AcceptQuarantinedFunds(ctx, toAddr, fromAddr)
+		require.EqualError(t, acceptErr, expAcceptErr, "AcceptQuarantinedFunds")
+	})
+
+	t.Run("attr added after funds quarantined", func(t *testing.T) {
+		fromAddr := addrWithTransfer
+		toAddr := sdk.AccAddress("addr_attr_add_______")
+		amt := coins1ReqAttr
+		optIn(t, toAddr)
+		sendErr := app.BankKeeper.SendCoins(ctx, fromAddr, toAddr, amt)
+		require.NoError(t, sendErr, "SendCoins")
+		setAttr(t, toAddr)
+		acceptedAmt, acceptErr := app.QuarantineKeeper.AcceptQuarantinedFunds(ctx, toAddr, fromAddr)
+		require.NoError(t, acceptErr, "AcceptQuarantinedFunds error")
+		assert.Equal(t, amt.String(), acceptedAmt.String(), "AcceptQuarantinedFunds amount")
+	})
+
+	t.Run("marker restriction applied before quarantine", func(t *testing.T) {
+		// This test makes sure that the marker SendRestrictionFn is being applied before the quarantine one.
+		// If the quarantine one is applied first, then the toAddr in the marker's restriction will be the
+		// quarantine module, which will have a bypass.
+		// So we attempt to send from the addr without transfer permission to the address without the required attribute.
+		// If we get an error about the attribute not being there, we're good.
+		// If we don't get an error, the toAddr was probably the quarantine module which bypasses that attribute check.
+		fromAddr := addrWithoutTransfer
+		toAddr := addrQWithoutAttr
+		amt := coins1ReqAttr
+
+		err := app.BankKeeper.SendCoins(ctx, fromAddr, toAddr, amt)
+		require.Error(t, err, "SendCoins error\n"+
+			"If this assertion fails, it's probably because the quarantine\n"+
+			"SendRestrictionFn is being applied before the marker's")
+		require.EqualError(t, err, noAttrErr(toAddr))
+	})
+}

--- a/x/marker/keeper/send_restrictions_test.go
+++ b/x/marker/keeper/send_restrictions_test.go
@@ -910,6 +910,7 @@ func TestQuarantineOfRestrictedCoins(t *testing.T) {
 			fromAddr:     addrWithTransfer,
 			toAddr:       addrQWithoutAttr,
 			amt:          coins1ReqAttr,
+			expSendErr:   "",
 			expAcceptErr: noAttrErr(addrQWithoutAttr),
 		},
 		{

--- a/x/marker/simulation/proposals_test.go
+++ b/x/marker/simulation/proposals_test.go
@@ -42,6 +42,7 @@ func TestProposalContents(t *testing.T) {
 			app.AttributeKeeper,
 			app.NameKeeper,
 			app.TransferKeeper,
+			nil,
 		),
 	)
 	require.Len(t, weightedProposalContent, 6)

--- a/x/marker/spec/03_messages.md
+++ b/x/marker/spec/03_messages.md
@@ -22,6 +22,7 @@ All created/modified state objects specified by each message are defined within 
   - [Msg/GrantAllowanceRequest](#msggrantallowancerequest)
   - [Msg/SupplyIncreaseProposalRequest](#msgsupplyincreaseproposalrequest)
   - [Msg/UpdateRequiredAttributesRequest](#msgupdaterequiredattributesrequest)
+  - [Msg/UpdateSendDenyListRequest](#msgupdatesenddenylistrequest)
   - [Msg/UpdateForcedTransferRequest](#msgupdateforcedtransferrequest)
   - [Msg/SetAccountDataRequest](#msgsetaccountdatarequest)
 

--- a/x/marker/spec/12_transfers.md
+++ b/x/marker/spec/12_transfers.md
@@ -1,0 +1,254 @@
+# Transfers
+
+There are some complex interactions involved with transfers of restricted coins.
+
+<!-- TOC -->
+
+## General
+
+Accounting of restricted coins is handled by the bank module. Restricted funds can be moved using the bank module's `MsgSend` or `MsgMutliSend`. They can also be moved using the marker module's `MsgTransferRequest`.
+
+During such transfers several things are checked using a `SendRestrictionFn` injected into the bank module. This restriction is applied in almost all instances when funds are being moved between accounts. The exceptions are delegations, undelegations, minting, burning, and marker withdrawals.
+
+<!-- TODO: Add notes about IBC movement too -->
+
+## Definitions
+
+### Transfer Permission
+
+One permission that can be granted to an address is `transfer`. An address with `transfer` permission can utilize `MsgTransferRequest` to move restricted funds from one account to another. If the marker allows forced transfer, the source account can be any account, otherwise, it must be the admin's own account.
+
+`MsgSend` and `MsgMultiSend` can also be used by an address with `transfer` permission to move funds out of their own account.
+
+### Required Attributes
+
+Required attributes are something that can be configured for a restricted marker. Accounts with the required attributes are allowed to receive those marker's coins regardless of whether the sender has `transfer` authority.
+
+For example, say account A has some restricted coins of a marker that has required attributes. Also say account B has all of those required attributes, and account C does not. Account A could use a `MsgSend` to send those restricted coins to account B. However, account B could not send them to account C (unless B also has `transfer` permission).
+
+If a restricted coin marker does not have any required attributes defined, the only way the funds can be moved is by someone with `transfer` permisison.
+
+### Individuality
+
+If multiple restricted coin denoms are being moved at once, each denom is considered separately.
+For example, if the sender has `transfer` permission on one of them, it does not also apply to the other(s).
+
+### Deposits
+
+A deposit is when any funds are being sent to a marker's account. The funds being sent do not have to be in the denom of the destination marker.
+
+Whenever funds are being deposited into a marker, the sender must have `deposit` permission on the target marker. If the funds to deposit are restricted coins, the sender also needs `transfer` permission on the funds being moved; required attributes are not taken into account.
+
+### Bypass Accounts
+
+There are several hard-coded module account addresses that are given special consideration:
+
+* `authtypes.FeeCollectorName` - Allows paying fees with restricted coins.
+* `reward` - Allows reward programs to use restricted coins.
+* `quarantine` - Allows quarantine and acceptance of quarantined coins.
+* `gov` - Allows deposits to have quarantined coins.
+* `distribution` - Allows collection of delegation rewards in restricted coins.
+* `stakingtypes.BondedPoolName` - Allows delegation of restricted coins.
+* `stakingtypes.NotBondedPoolName` - Allows delegation of restricted coins.
+
+All of these are treated equally in the application of a marker's send restrictions.
+
+For restricted markers without required attributes:
+* If the `toAddr` is a bypass account, the `fromAddr` must have transfer authority.
+* If the `fromAddr` is a bypass account, it's assumed that the funds got where they currently are because someone with transfer authority got them there, so this transfer is allowed.
+
+For restricted markers with required attributes:
+* If the `toAddr` is a bypass account, the transfer is allowed regardless of whether the `fromAddr` has transfer authority. It's assumed that the next destination's attributes will be properly checked before allowing the funds to leave the bypass account.
+* If the `fromAddr` is a bypass account, the `toAddr` must have the required attributes.
+
+## Send Restrictions
+
+The marker module injects a `SendRestrictionFn` into the bank module. This function is responsible for deciding whether any given transfer is allowed from the marker module's point of view.
+
+### Flowcharts
+
+This `SendRestrictionFn` uses the following flow.
+
+```mermaid
+%%{ init: { 'flowchart': { 'curve': 'monotoneY'} } }%%
+flowchart TD
+    start["SendRestrictionFn(Sender, Receiver, Amount)"]
+    qhasbp{{"Does context have bypass?"}}
+    nextd["Get next Denom from Amount."]
+    vsd[["validateSendDenom(Sender, Receiver, Denom)"]]
+    isdok{{"Is Denom transfer allowed?"}}
+    mored{{"Does Amount have another Denom?"}}
+    ok(["Send allowed."])
+    style ok fill:#bbffaa,stroke:#1b8500,stroke-width:3px
+    denied(["Send denied."])
+    style denied fill:#ffaaaa,stroke:#b30000,stroke-width:3px
+    start --> qhasbp
+    qhasbp ------>|yes| ok
+    qhasbp -.->|no| denomloop
+    subgraph denomloop ["Denom Loop"]
+    isdok -->|yes| mored
+    vsd --> isdok
+    mored -->|yes| nextd
+    nextd --> vsd
+    end
+    mored -.->|no| ok
+    isdok -.->|no| denied
+
+    style denomloop fill:#000000
+    linkStyle 8 stroke:#b30000,color:#b30000
+    linkStyle 1,7 stroke:#1b8500,color:#1b8500
+```
+
+Each `Denom` is checked using `validateSendDenom`, which has this flow:
+
+```mermaid
+%%{ init: { 'flowchart': { 'curve': 'monotoneY'} } }%%
+flowchart TD
+    start[["validateSendDenom(Sender, Receiver, Denom)"]]
+    qisrdep{{"Is Receiver a restricted coin marker account?"}}
+    qhasdep{{"Does Sender have Deposit\non Receiver marker?"}}
+    qisrc{{"Is Denom a restricted coin?"}}
+    qisdeny{{"Is Sender on marker's deny list?"}}
+    qhastrans{{"Does Sender have\ntransfer for Denom?"}}
+    qisdep{{"Is Receiver a marker account?"}}
+    qmhasattr{{"Does Denom have\nrequired attributes?"}}
+    qissbp{{"Is Sender a\nbypass account?"}}
+    qisrbp{{"Is Receiver a\nbypass account?"}}
+    qrhasattr{{"Does Receiver have\nthe required attributes?"}}
+    ok(["Denom transfer allowed."])
+    style ok fill:#bbffaa,stroke:#1b8500,stroke-width:3px
+    denied(["Send denied."])
+    style denied fill:#ffaaaa,stroke:#b30000,stroke-width:3px
+    start --> qisrdep
+    qisrdep -->|yes| qhasdep
+    qisrdep -.->|no| qisrc
+    qhasdep -.->|no| denied
+    qhasdep -->|yes| qisrc
+    qisrc -->|yes| qisdeny
+    qisrc -.->|no| ok
+    qisdeny -->|yes| denied
+    qisdeny -.->|no| qhastrans
+    qhastrans -.->|no| qisdep
+    qhastrans -->|yes| ok
+    qisdep -->|yes| denied
+    qisdep -.->|no| qmhasattr
+    qmhasattr -.->|no| qissbp
+    qmhasattr -->|yes| qisrbp
+    qissbp -..->|no| denied
+    qissbp --->|yes| ok
+    qisrbp -.->|no| qrhasattr
+    qisrbp -->|yes| ok
+    qrhasattr -.->|no| denied
+    qrhasattr -->|yes| ok
+
+    linkStyle 3,7,11,15,19 stroke:#b30000,color:#b30000
+    linkStyle 6,10,16,18,20 stroke:#1b8500,color:#1b8500
+```
+
+### Quarantine Complexities
+
+There are some noteable complexities involving restricted coins and quarantined accounts.
+
+#### Sending Restricted Coins to a Quarantined Account
+
+The marker module's `SendRestrictionFn` is applied before the quarantine module's. So, when funds are being sent to a quarantined account, the marker module runs its check using the original `Sender` and `Receiver` (i.e. the `Receiver` is not `QFH`).
+
+If the `Receiver` is a quarantined account, we can assume that it is neither a marker, nor a bypass account. Then, assuming the `Sender` is not on the deny list, the `validateSendDenom` flow can be simplified to this for restricted coins.
+
+```mermaid
+%%{ init: { 'flowchart': { 'curve': 'monotoneY'} } }%%
+flowchart LR
+    vsd[["validateSendDenom(Sender, Receiver, Denom)"]]
+    transq{{"Does Sender have\ntransfer for Denom?"}}
+    mreqattr{{"Does Denom have\nrequired attributes?"}}
+    treqattr{{"Does Receiver have\nthose attributes?"}}
+    ok(["Denom transfer allowed."])
+    style ok fill:#bbffaa,stroke:#1b8500,stroke-width:3px
+    denied(["Send denied."])
+    style denied fill:#ffaaaa,stroke:#b30000,stroke-width:3px
+    transq -->|yes| ok
+    transq -.->|no| mreqattr
+    mreqattr -->|yes| treqattr
+    mreqattr -.->|no| denied
+    treqattr -->|yes| ok
+    treqattr -.->|no| denied
+
+    linkStyle 3,5 stroke:#b30000,color:#b30000
+    linkStyle 0,4 stroke:#1b8500,color:#1b8500
+```
+
+If the `Send` is allowed, and the `Receiver` is a quarantined account, the quarantine module's `SendRestrictionFn` will then change the `Send`'s destination to `QFH` (the Quarantined-funds-holder account) and make a record of the transfer. The `Send` then transfers funds from the `Sender` to `QFH`.
+
+The marker's `SendRestrictionFn` should never have `QFH` as a `Receiver`. The only way this would happen is if `MsgSend` is used to send funds directly to `QFH`.
+
+#### Accepting Quarantined Restricted Coins
+
+Once funds have been sent to `QFH`, the `Receiver` will probably want to accept them, and have them sent to their account. They issue an `Accept` to the quarantine module which utilizes the bank module's `Send` functionality to try to transfer funds from `QFH` to the `Receiver`.
+
+`QFH` is a bypass account. Since `Receiver` is a quarantined account, we can assume that it is neither a marker nor bypass account. So, the `validateSendDenom` flow can be simplified to this for restricted coins.
+
+```mermaid
+%%{ init: { 'flowchart': { 'curve': 'monotoneY'} } }%%
+flowchart LR
+    vsd[["validateSendDenom(Sender, Receiver, Denom)"]]
+    mreqattr{{"Does Denom have\nrequired attributes?"}}
+    treqattr{{"Does Receiver have\nthose attributes?"}}
+    ok(["Denom transfer allowed."])
+    style ok fill:#bbffaa,stroke:#1b8500,stroke-width:3px
+    denied(["Send denied."])
+    style denied fill:#ffaaaa,stroke:#b30000,stroke-width:3px
+    mreqattr -->|yes| treqattr
+    mreqattr -.->|no| ok
+    treqattr -->|yes| ok
+    treqattr -.->|no| denied
+
+    linkStyle 3 stroke:#b30000,color:#b30000
+    linkStyle 1,2 stroke:#1b8500,color:#1b8500
+
+```
+
+If the `Send` is allowed, the requested funds are transferred from `QFH` to `Receiver`.
+
+If the `Send` is denied, the funds remain with `QFH`.
+
+An important subtle part of this process is the rechecking of `Receiver` attributes. It's possible for the initial send to be okay (causing funds to be quarantined), then later, during this `Accept`, the send is not okay, and the quarantined funds are effectively locked with`QFH` until the `Receiver` gets the required attributes.
+
+If the marker does not have required attributes though, it's assumed that they were originally sent by someone with transfer authority, so they are allowed to continue to from here too.
+
+#### Successful Quarantine and Accept Sequence
+
+When restricted coin funds are sent to a quarantined account (1), the marker's `SendRestrictionFn` is called using the original `Sender` and `Receiver` (2). Then, the quarantine's `SendRestrictionFn` is called (4) which will return `QFH` for the new destination (5). Funds are then transferred from `Sender` to `QFH` (6).
+
+When the `Receiver` attempts to `Accept` those quarantined funds (7), the marker's `SendRestrictionFn` is called again, this time using `QFH` (as the sender) and `Receiver` (9). The quarantine's `SendRestrictionFn` is bypassed (11), so the destination is not changed (12). Funds are then transferred from `QFH` to `Receiver` (13).
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Sender
+    actor Receiver
+    participant Bank Module
+    participant Quarantine Module
+    participant Marker Restriction
+    participant Quarantine Restriction
+    participant QFH
+    Sender ->>+ Bank Module: Send(sender, receiver)
+    Bank Module ->>+ Marker Restriction: Is this send  from Sender to Receiver allowed?
+    Marker Restriction -->>- Bank Module: Yes
+    Bank Module ->>+ Quarantine Restriction: Is Receiver quarantined?
+    Quarantine Restriction -->>- Bank Module: Yes. Change destination to QFH.
+    Sender ->> QFH: Funds transferred from Sender to QFH.
+    deactivate Bank Module
+
+    Note over Sender,QFH: Some Time Later
+
+    Receiver ->>+ Quarantine Module: Accept(receiver, sender)
+    Quarantine Module ->> Bank Module: Send(QFH, receiver)
+    activate Bank Module
+    Bank Module ->>+ Marker Restriction: Is this send  from QFH to Receiver allowed?
+    Marker Restriction -->>- Bank Module: Yes
+    Bank Module ->>+ Quarantine Restriction: Is Receiver quarantined?
+    Quarantine Restriction -->>- Bank Module: Restriction bypassed. No change.  
+    QFH ->> Receiver: Funds transferred from QFH to Receiver.
+    deactivate Bank Module
+    deactivate Quarantine Module
+```

--- a/x/marker/spec/12_transfers.md
+++ b/x/marker/spec/12_transfers.md
@@ -3,6 +3,16 @@
 There are some complex interactions involved with transfers of restricted coins.
 
 <!-- TOC -->
+  - [General](#general)
+  - [Definitions](#definitions)
+    - [Transfer Permission](#transfer-permission)
+    - [Required Attributes](#required-attributes)
+    - [Individuality](#individuality)
+    - [Deposits](#deposits)
+    - [Bypass Accounts](#bypass-accounts)
+  - [Send Restrictions](#send-restrictions)
+    - [Flowcharts](#flowcharts)
+    - [Quarantine Complexities](#quarantine-complexities)
 
 ## General
 

--- a/x/marker/spec/12_transfers.md
+++ b/x/marker/spec/12_transfers.md
@@ -6,6 +6,7 @@ There are some complex interactions involved with transfers of restricted coins.
   - [General](#general)
   - [Definitions](#definitions)
     - [Transfer Permission](#transfer-permission)
+    - [Forced Transfers](#forced-transfers)
     - [Required Attributes](#required-attributes)
     - [Individuality](#individuality)
     - [Deposits](#deposits)
@@ -26,13 +27,17 @@ During such transfers several things are checked using a `SendRestrictionFn` inj
 
 ### Transfer Permission
 
-One permission that can be granted to an address is `transfer`. An address with `transfer` permission can utilize `MsgTransferRequest` to move restricted funds from one account to another. If the marker allows forced transfer, the source account can be any account, otherwise, it must be the admin's own account.
+One permission that can be granted to an address is `transfer`.  The `transfer` permission is granted to accounts that represent a "Transfer Agent" or "Transfer Authority" for restricted marker tokens. An address with `transfer` permission can utilize `MsgTransferRequest` to move restricted funds from one account to another. If the marker allows forced transfer, the source account can be any account, otherwise, it must be the admin's own account.
 
 `MsgSend` and `MsgMultiSend` can also be used by an address with `transfer` permission to move funds out of their own account.
 
+### Forced Transfers
+
+A restricted coin marker can be configured to allow forced transfers. If allowed, an account with `transfer` permission can use a `MsgTransferRequest` to transfer the restricted coins out of almost any account to another. Forced transfer cannot be used to move restricted coins out of module accounts or smart contract accounts, though.
+
 ### Required Attributes
 
-Required attributes are something that can be configured for a restricted marker. Accounts with the required attributes are allowed to receive those marker's coins regardless of whether the sender has `transfer` authority.
+Required attributes allow a marker Transfer Authority to define a set of account attestations created with the name/attribute modules to certify an account as an approved holder of the token.  Accounts that possess all of the required attributes are considered authorized by the Transfer Authority to receive the token from normal bank send operations without a specific Transfer Authority approval. Required attributes are only supported on restricted markers.
 
 For example, say account A has some restricted coins of a marker that has required attributes. Also say account B has all of those required attributes, and account C does not. Account A could use a `MsgSend` to send those restricted coins to account B. However, account B could not send them to account C (unless B also has `transfer` permission).
 
@@ -270,7 +275,7 @@ If the `Send` is denied, the funds remain with `QFH`.
 
 An important subtle part of this process is the rechecking of `Receiver` attributes. It's possible for the initial send to be okay (causing funds to be quarantined), then later, during this `Accept`, the send is not okay, and the quarantined funds are effectively locked with`QFH` until the `Receiver` gets the required attributes.
 
-If the marker does not have required attributes though, it's assumed that they were originally sent by someone with transfer authority, so they are allowed to continue to from here too.
+If the marker does not have required attributes though, it's assumed that they were originally sent by someone with transfer authority, so they are allowed to continue from here too.
 
 #### Successful Quarantine and Accept Sequence
 

--- a/x/marker/spec/12_transfers.md
+++ b/x/marker/spec/12_transfers.md
@@ -104,7 +104,7 @@ flowchart TD
     mored -.->|no| ok
     isdok -.->|no| denied
 
-    style denomloop fill:#000000
+    style denomloop fill:#bbffff
     linkStyle 8 stroke:#b30000,color:#b30000
     linkStyle 1,7 stroke:#1b8500,color:#1b8500
 ```

--- a/x/marker/spec/12_transfers.md
+++ b/x/marker/spec/12_transfers.md
@@ -179,8 +179,8 @@ flowchart TD
     qadminfrom{{"Does Sender == Admin?"}}
     qallowft{{"Is forced transfer allowed for Denom?"}}
     qauthz{{"Has Sender granted Admin\npermission with authz?"}}
-    qmodacc{{"Is Sender a module account?"}}
-    qblocked{{"Is Receiver a blocked address?"}}
+    qmodacc{{"Is Sender a\nmodule account?"}}
+    qblocked{{"Is Receiver an\naddress blocked by\nthe bank module?"}}
     ok(["Transfer allowed."])
     style ok fill:#bbffaa,stroke:#1b8500,stroke-width:3px
     denied(["Transfer denied."])

--- a/x/marker/spec/README.md
+++ b/x/marker/spec/README.md
@@ -41,3 +41,4 @@ transfer by the marker itself when invoked by a user/process with appropriate pe
 1. **[Params](09_params.md)**
 1. **[Governance](10_governance.md)**
 1. **[Authorization](11_authorization.md)**
+1. **[Transfers](12_transfers.md)**

--- a/x/marker/types/immutable_addresses.go
+++ b/x/marker/types/immutable_addresses.go
@@ -1,0 +1,48 @@
+package types
+
+import sdk "github.com/cosmos/cosmos-sdk/types"
+
+// ImmutableAccAddresses holds some AccAddresses in a way that they cannot be changed after creation.
+type ImmutableAccAddresses struct {
+	// addrsSlice is a deep copy of the originally provided addresses slice.
+	addrsSlice []sdk.AccAddress
+	// addrsMap contains the same addresses as addrsSlice for easier checking.
+	// Each key is an sdk.AccAddress cast to a string (not converted to bech32).
+	addrsMap map[string]bool
+}
+
+// NewImmutableAccAddresses creates a new ImmutableAccAddresses containing the provided addresses.
+func NewImmutableAccAddresses(addrs []sdk.AccAddress) ImmutableAccAddresses {
+	rv := ImmutableAccAddresses{
+		addrsSlice: deepCopyAccAddresses(addrs),
+		addrsMap:   make(map[string]bool),
+	}
+	for _, addr := range addrs {
+		rv.addrsMap[string(addr)] = true
+	}
+	return rv
+}
+
+// GetSlice returns a copy of the addresses known to this ImmutableAccAddresses.
+func (i ImmutableAccAddresses) GetSlice() []sdk.AccAddress {
+	return deepCopyAccAddresses(i.addrsSlice)
+}
+
+// Has returns true if the provided address is known to this ImmutableAccAddresses.
+func (i ImmutableAccAddresses) Has(addr sdk.AccAddress) bool {
+	return i.addrsMap[string(addr)]
+}
+
+// deepCopyAccAddresses creates a deep copy of the provided slice of acc addresses.
+// A copy of each entry is made and placed into a new slice.
+func deepCopyAccAddresses(orig []sdk.AccAddress) []sdk.AccAddress {
+	if orig == nil {
+		return nil
+	}
+	rv := make([]sdk.AccAddress, len(orig))
+	for i, addr := range orig {
+		rv[i] = make(sdk.AccAddress, len(addr))
+		copy(rv[i], addr)
+	}
+	return rv
+}

--- a/x/marker/types/immutable_addresses_test.go
+++ b/x/marker/types/immutable_addresses_test.go
@@ -1,0 +1,183 @@
+package types
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// newAddr creates a new sdk.AccAddress for the given index.
+func newAddr(i int) sdk.AccAddress {
+	return sdk.AccAddress(fmt.Sprintf("addr_%d______________", i))[:20]
+}
+
+// addrz creates a new slice of addresses with the given number of entries.
+func addrz(count int) []sdk.AccAddress {
+	rv := make([]sdk.AccAddress, count)
+	for i := range rv {
+		rv[i] = newAddr(i + 1)
+	}
+	return rv
+}
+
+func TestImmutableAccAddresses(t *testing.T) {
+	newGetTests := []struct {
+		name  string
+		addrs []sdk.AccAddress
+	}{
+		{name: "nil", addrs: nil},
+		{name: "empty", addrs: []sdk.AccAddress{}},
+		{name: "one addr", addrs: addrz(1)},
+		{name: "two addr", addrs: addrz(2)},
+		{name: "five addrs", addrs: addrz(5)},
+	}
+
+	for _, tc := range newGetTests {
+		t.Run("new+get:"+tc.name, func(t *testing.T) {
+			var iAddrs ImmutableAccAddresses
+			testFunc := func() {
+				iAddrs = NewImmutableAccAddresses(tc.addrs)
+			}
+			require.NotPanics(t, testFunc, "NewImmutableAccAddresses")
+
+			// Get the addrs and make sure the result is equal to what we provided,
+			// but isn't the exact same slice that we provided. Also make sure each
+			// address was copied to a new slice too.
+			addrs := iAddrs.GetSlice()
+			require.Equal(t, tc.addrs, addrs, "GetSlice() compared to expected")
+			require.NotSame(t, tc.addrs, addrs, "GetSlice() compared to expected")
+			for i := range tc.addrs {
+				require.NotSame(t, tc.addrs[i], addrs[i], "GetSlice()[%d] compared to expected", i)
+			}
+
+			// Get the slice five more times and make sure each one is a fresh copy.
+			for x := 1; x <= 5; x++ {
+				addrs2 := iAddrs.GetSlice()
+				require.Equal(t, addrs, addrs2, "[%d]: GetSlice() compared to previous result", x)
+				require.NotSame(t, addrs, addrs2, "[%d]: GetSlice() compared to previous result", x)
+				for i := range tc.addrs {
+					require.NotSame(t, addrs[i], addrs2[i], "[%d]: GetSlice()[%d] compared to previous result", x, i)
+				}
+				addrs = addrs2
+			}
+		})
+	}
+
+	firstWDiffFirst := newAddr(1)
+	firstWDiffFirst[0] = 'b'
+	firstWDiffLast := newAddr(1)
+	firstWDiffLast[len(firstWDiffLast)-1]++
+	firstWDiffMiddle := newAddr(1)
+	firstWDiffMiddle[12]--
+
+	iAddrsHasTester := NewImmutableAccAddresses(addrz(5))
+
+	hasTests := []struct {
+		name string
+		addr sdk.AccAddress
+		exp  bool
+	}{
+		{name: "nil", addr: nil, exp: false},
+		{name: "empty", addr: sdk.AccAddress{}, exp: false},
+		{name: "zeroth address", addr: newAddr(0), exp: false},
+		{name: "first address", addr: newAddr(1), exp: true},
+		{name: "second address", addr: newAddr(2), exp: true},
+		{name: "third address", addr: newAddr(3), exp: true},
+		{name: "fourth address", addr: newAddr(4), exp: true},
+		{name: "fifth address", addr: newAddr(5), exp: true},
+		{name: "sixth address", addr: newAddr(6), exp: false},
+		{name: "first address without last byte", addr: newAddr(1)[:19], exp: false},
+		{name: "first address without first byte", addr: newAddr(1)[1:], exp: false},
+		{name: "first address with first byte changed", addr: firstWDiffFirst, exp: false},
+		{name: "first address with last byte changed", addr: firstWDiffLast, exp: false},
+		{name: "first address with a middle byte changed", addr: firstWDiffMiddle, exp: false},
+		{name: "first address with extra byte at end", addr: append(newAddr(1), '_'), exp: false},
+		{name: "first address with extra byte at start", addr: append(sdk.AccAddress{'_'}, newAddr(1)...), exp: false},
+	}
+
+	for _, tc := range hasTests {
+		t.Run("has:"+tc.name, func(t *testing.T) {
+			var has bool
+			testFunc := func() {
+				has = iAddrsHasTester.Has(tc.addr)
+			}
+			require.NotPanics(t, testFunc, "Has")
+			assert.Equal(t, tc.exp, has, "Has")
+		})
+	}
+
+	t.Run("change to slice provided to NewImmutableAccAddresses", func(t *testing.T) {
+		// This test makes sure that a change to the slice provided to NewImmutableAccAddresses
+		// does not alter anything inside the resulting ImmutableAccAddresses.
+		input := addrz(3)
+		expected00 := input[0][0]
+		iaddrs := NewImmutableAccAddresses(input)
+		input[0][0] = 'b'
+		addrs := iaddrs.GetSlice()
+		actual00 := addrs[0][0]
+		assert.Equal(t, expected00, actual00, "first byte of first address returned by GetSlice()")
+		hasChanged := iaddrs.Has(input[0])
+		assert.False(t, hasChanged, "Has(address that was changed)")
+		hasOrig := iaddrs.Has(newAddr(1))
+		assert.True(t, hasOrig, "Has(address before it was changed)")
+	})
+
+	t.Run("change to slice returned by GetSlice", func(t *testing.T) {
+		// This test makes sure that a change to the result of a GetSlice()
+		// doesn't somehow change anything in the ImmutableAccAddresses.
+		iaddrs := NewImmutableAccAddresses(addrz(4))
+		addrs := iaddrs.GetSlice()
+		expected00 := addrs[0][0]
+		addrs[0][0] = 'b'
+		actual := iaddrs.GetSlice()
+		actual00 := actual[0][0]
+		assert.Equal(t, expected00, actual00, "first byte of first address returned by GetSlice()")
+		hasChanged := iaddrs.Has(addrs[0])
+		assert.False(t, hasChanged, "Has(address that was changed)")
+		hasOrig := iaddrs.Has(newAddr(1))
+		assert.True(t, hasOrig, "Has(address before it was changed)")
+	})
+}
+
+func TestDeepCopyAccAddresses(t *testing.T) {
+	tests := []struct {
+		name string
+		orig []sdk.AccAddress
+	}{
+		{name: "nil", orig: nil},
+		{name: "empty", orig: []sdk.AccAddress{}},
+		{name: "one address", orig: addrz(1)},
+		{name: "two address", orig: addrz(2)},
+		{name: "five address", orig: addrz(5)},
+		{name: "same address 3 times", orig: []sdk.AccAddress{newAddr(1), newAddr(1), newAddr(1)}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			expCap := len(tc.orig) // Result should not have extra capacity.
+			var actual []sdk.AccAddress
+			testFunc := func() {
+				actual = deepCopyAccAddresses(tc.orig)
+			}
+			require.NotPanics(t, testFunc, "deepCopyAccAddresses")
+
+			// Make sure the result is equal to what was provided, but in a different slice.
+			// Also make sure each entry slice was also copied.
+			if assert.Equal(t, tc.orig, actual, "deepCopyAccAddresses result") {
+				if assert.NotSame(t, tc.orig, actual, "deepCopyAccAddresses result") {
+					for i := range tc.orig {
+						assert.NotSame(t, tc.orig[i], actual[i], "deepCopyAccAddresses result[%d]", i)
+					}
+				}
+			}
+
+			// Make sure there isn't any extra capacity
+			actualCap := cap(actual)
+			assert.Equal(t, expCap, actualCap, "capacity of deepCopyAccAddresses result")
+		})
+	}
+}


### PR DESCRIPTION
## Description

closes: #1626 

This PR fixes a bug related to quarantine of restricted coins, and also enables the use of restricted coins for other things that require an intermediary holding account. It also prevents forced transfers from module accounts.

Quarantine of restricted coins is fixed by adding a hard-coded list of addresses that bypass the required attributes checking. That list consists of the following module account addresses: 

- `authtypes.FeeCollectorName` - Allows paying fees with restricted coins.
- `reward` - Allows reward programs to use restricted coins.
- `quarantine` - Allows quarantine and acceptance of quarantined coins.
- `gov` - Allows deposits to have quarantined coins.
- `distribution` - Allows collection of delegation and fee rewards in restricted coins.
- `stakingtypes.BondedPoolName` - Allows delegation of restricted coins.
- `stakingtypes.NotBondedPoolName` - Allows delegation of restricted coins.

For restricted markers without required attributes:
* If the `toAddr` is a bypass account, the `fromAddr` must have transfer authority.
* If the `fromAddr` is a bypass account, it's assumed that the funds got where they currently are because someone with transfer authority got them there, so this transfer is allowed.

For restricted markers with required attributes:
* If the `toAddr` is a bypass account, the transfer is allowed regardless of whether the `fromAddr` has transfer authority. It's assumed that the next destination's attributes will be properly checked before allowing the funds to leave the bypass account.
* If the `fromAddr` is a bypass account, the `toAddr` must have the required attributes.

Transfers of restricted markers between bypass accounts is allowed (e.g. bonded to not-bonded, or fee collector to distribution).

There's a special case when the `toAddr` is a marker. In that case, no matter what, the `fromAddr` must have deposit permissions on that marker. That will almost certainly not be the case for these bypass accounts, so a "deposit" from, e.g. a rewards program will not work.

---

When a transfer of restricted coins is being sent to an account that's opted into quarantine, there's some possibly confusing flow behavior.

The marker's `SendRestrictionFn` is applied before quarantine's.

The initial send will get into the marker's send restriction with the same `to` and `from` as the send request. I.e. neither will be a bypass account. Any restricted coins without required attributes will require transfer authority. Any restricted coins with required attributes will require that the `to` has them. If there isn't a problem, it'll then get to the quarantine restriction which will change the destination to the quarantine module.

Later, when the user attempts to accept the funds, the `from` will be the quarantine module, which is a bypass account. Any restricted coins without required attributes are okayed. Any restricted coins with required attributes will again require the `to` to have them.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Review `Codecov Report` in the comment section below once CI passes
