### PR TITLE
Change config load order so custom.toml is last

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * Bump cometbft to v0.34.29 (from v0.34.28) [PR 1649](https://github.com/provenance-io/provenance/pull/1649).
 * Add genesis/init for Marker module send deny list addresses. [#1660](https://github.com/provenance-io/provenance/issues/1660)
 * Add automatic changelog entries for dependabot. [#1674](https://github.com/provenance-io/provenance/issues/1674)
+* Change config load order so custom.toml is last [#1262](https://github.com/provenance-io/provenance/issues/1262)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,6 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * Bump cometbft to v0.34.29 (from v0.34.28) [PR 1649](https://github.com/provenance-io/provenance/pull/1649).
 * Add genesis/init for Marker module send deny list addresses. [#1660](https://github.com/provenance-io/provenance/issues/1660)
 * Add automatic changelog entries for dependabot. [#1674](https://github.com/provenance-io/provenance/issues/1674)
-* Change config load order so custom.toml is last [#1262](https://github.com/provenance-io/provenance/issues/1262)
 
 ### Bug Fixes
 
@@ -71,6 +70,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * Fix for incorrect resource-id type casting on contract specification [#1647](https://github.com/provenance-io/provenance/issues/1647).
 * Allow restricted coins to be quarantined [#1626](https://github.com/provenance-io/provenance/issues/1626).
 * Prevent marker forced transfers from module accounts [#1626](https://github.com/provenance-io/provenance/issues/1626).
+* Change config load order so custom.toml can override other config. [#1262](https://github.com/provenance-io/provenance/issues/1262)
 
 ### Client Breaking
 

--- a/cmd/provenanced/config/manager.go
+++ b/cmd/provenanced/config/manager.go
@@ -385,11 +385,13 @@ func unquote(str string) string {
 }
 
 // LoadConfigFromFiles loads configurations appropriately.
-func LoadConfigFromFiles(cmd *cobra.Command) error {
+func LoadConfigFromFiles(cmd *cobra.Command) (err error) {
 	if IsPacked(cmd) {
-		return loadPackedConfig(cmd)
+		err = loadPackedConfig(cmd)
+	} else {
+		err = loadUnpackedConfig(cmd)
 	}
-	if err := loadUnpackedConfig(cmd); err != nil {
+	if err != nil {
 		return err
 	}
 	return loadUnmanagedConfig(cmd)

--- a/cmd/provenanced/config/manager.go
+++ b/cmd/provenanced/config/manager.go
@@ -386,13 +386,13 @@ func unquote(str string) string {
 
 // LoadConfigFromFiles loads configurations appropriately.
 func LoadConfigFromFiles(cmd *cobra.Command) error {
-	if err := loadUnmanagedConfig(cmd); err != nil {
-		return err
-	}
 	if IsPacked(cmd) {
 		return loadPackedConfig(cmd)
 	}
-	return loadUnpackedConfig(cmd)
+	if err := loadUnpackedConfig(cmd); err != nil {
+		return err
+	}
+	return loadUnmanagedConfig(cmd)
 }
 
 // loadUnmanagedConfig reads the unmanaged config file into viper. It does not apply anything to any contexts though.

--- a/cmd/provenanced/config/manager_test.go
+++ b/cmd/provenanced/config/manager_test.go
@@ -196,6 +196,27 @@ func (s *ConfigManagerTestSuite) TestUnmanagedConfig() {
 		assert.Equal(t, "stuff", actual, "unmanaged field value")
 	})
 
+	s.T().Run("unmanaged config is read with invalid packed files", func(t *testing.T) {
+		dCmd := s.makeDummyCmd()
+		uFile := GetFullPathToUnmanagedConf(dCmd)
+		pFile := GetFullPathToPackedConf(dCmd)
+		SaveConfigs(dCmd, DefaultAppConfig(), DefaultTmConfig(), DefaultClientConfig(), false)
+		require.NoError(t, os.WriteFile(uFile, []byte("my-custom-entry = \"stuff\"\n"), 0o644), "writing unmanaged config")
+		require.NoError(t, os.WriteFile(pFile, []byte("kl234508923u5jl"), 0o644), "writing invalid data to packed config")
+		require.EqualError(t, LoadConfigFromFiles(dCmd), "packed config file parse error: invalid character 'k' looking for beginning of value", "should throw error with invalid packed config")
+		require.NoError(t, os.Remove(pFile), "removing packed config")
+	})
+
+	s.T().Run("unmanaged config is read with invalid unpacked files", func(t *testing.T) {
+		dCmd := s.makeDummyCmd()
+		uFile := GetFullPathToUnmanagedConf(dCmd)
+		pFile := GetFullPathToAppConf(dCmd)
+		SaveConfigs(dCmd, DefaultAppConfig(), DefaultTmConfig(), DefaultClientConfig(), false)
+		require.NoError(t, os.WriteFile(uFile, []byte("my-custom-entry = \"stuff\"\n"), 0o644), "writing unmanaged config")
+		require.NoError(t, os.WriteFile(pFile, []byte("kl234508923u5jl"), 0o644), "writing invalid data to app config")
+		require.EqualError(t, LoadConfigFromFiles(dCmd), "app config file merge error: While parsing config: toml: expected = after a key, but the document ends there", "should throw error with invalid packed config")
+	})
+
 	s.T().Run("unmanaged config is read with packed config", func(t *testing.T) {
 		dCmd := s.makeDummyCmd()
 		uFile := GetFullPathToUnmanagedConf(dCmd)

--- a/cmd/provenanced/config/manager_test.go
+++ b/cmd/provenanced/config/manager_test.go
@@ -170,7 +170,7 @@ func (s *ConfigManagerTestSuite) TestUnmanagedConfig() {
 		assert.Equal(t, "bananas", actual, "unmanaged field value")
 	})
 
-	s.T().Run("unmanaged config entry does not override other config", func(t *testing.T) {
+	s.T().Run("unmanaged config entry does override other config", func(t *testing.T) {
 		dCmd := s.makeDummyCmd()
 		configDir := GetFullPathToConfigDir(dCmd)
 		uFile := GetFullPathToUnmanagedConf(dCmd)
@@ -180,8 +180,8 @@ func (s *ConfigManagerTestSuite) TestUnmanagedConfig() {
 		ctx := client.GetClientContextFromCmd(dCmd)
 		vpr := ctx.Viper
 		actual := vpr.GetString("db_backend")
-		assert.NotEqual(t, "still bananas", actual, "unmanaged field value")
-		assert.Equal(t, DefaultTmConfig().DBBackend, actual, "unmanaged field default value")
+		assert.Equal(t, "still bananas", actual, "unmanaged field value")
+		assert.NotEqual(t, DefaultTmConfig().DBBackend, actual, "unmanaged field default value")
 	})
 
 	s.T().Run("unmanaged config is read with unpacked files", func(t *testing.T) {

--- a/cmd/provenanced/config/manager_test.go
+++ b/cmd/provenanced/config/manager_test.go
@@ -170,7 +170,7 @@ func (s *ConfigManagerTestSuite) TestUnmanagedConfig() {
 		assert.Equal(t, "bananas", actual, "unmanaged field value")
 	})
 
-	s.T().Run("unmanaged config entry does override other config", func(t *testing.T) {
+	s.T().Run("unmanaged config entry overrides other config", func(t *testing.T) {
 		dCmd := s.makeDummyCmd()
 		configDir := GetFullPathToConfigDir(dCmd)
 		uFile := GetFullPathToUnmanagedConf(dCmd)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This updates the configuration load order so that custom.toml is the last. This allows any custom changes to overwrite anything that comes packed or unpacked config.

closes: #1262 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
