### PR TITLE
Switch to a provenanceio-bot PAT for the dependabot changelog action.

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -19,8 +19,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           # Depending on your needs, you can use a token that will re-trigger workflows
-          # See https://github.com/stefanzweifel/git-auto-commit-action#commits-of-this-action-do-not-trigger-new-workflow-runs
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # See https://github.com/stefanzweifel/git-auto-commit-action#commits-made-by-this-action-do-not-trigger-new-workflow-runs
+          token: ${{ secrets.BOT_CPR_PAT }}
 
       # All commits must be signed, import key and sign commit of updated change log.
       - name: Import GPG key
@@ -39,8 +39,8 @@ jobs:
           activationLabel: 'dependencies'
           changelogPath: './CHANGELOG.md'
 
-      # This step is required for committing the changes to your branch. 
-      # See https://github.com/stefanzweifel/git-auto-commit-action#commits-of-this-action-do-not-trigger-new-workflow-runs 
+      # This step is required for committing the changes to your branch.
+      # See https://github.com/stefanzweifel/git-auto-commit-action#commits-made-by-this-action-do-not-trigger-new-workflow-runs
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_user_name: "Provenance-io Bot"


### PR DESCRIPTION
## Description

I also gave the `BOT_CPR_PAT` access to read/write workflows/actions. Hopefully this will cause the actions to be triggered on the dependabot changes after the changelog is updated.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
