### PR TITLE
Remove rust upgrades

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -126,6 +126,8 @@ var upgrades = map[string]appUpgrade{
 				return nil, err
 			}
 
+			removeInactiveValidatorDelegations(ctx, app)
+
 			return vm, nil
 		},
 	},
@@ -137,6 +139,8 @@ var upgrades = map[string]appUpgrade{
 			if err != nil {
 				return nil, err
 			}
+
+			removeInactiveValidatorDelegations(ctx, app)
 
 			return vm, nil
 		},

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -11,22 +11,16 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	govtypesv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
-	govtypesv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	icqtypes "github.com/cosmos/ibc-apps/modules/async-icq/v6/types"
 	transfertypes "github.com/cosmos/ibc-go/v6/modules/apps/transfer/types"
 
-	attributekeeper "github.com/provenance-io/provenance/x/attribute/keeper"
-	attributetypes "github.com/provenance-io/provenance/x/attribute/types"
 	"github.com/provenance-io/provenance/x/exchange"
 	"github.com/provenance-io/provenance/x/hold"
 	ibchookstypes "github.com/provenance-io/provenance/x/ibchooks/types"
 	ibcratelimit "github.com/provenance-io/provenance/x/ibcratelimit"
 	markertypes "github.com/provenance-io/provenance/x/marker/types"
-	msgfeetypes "github.com/provenance-io/provenance/x/msgfees/types"
 	oracletypes "github.com/provenance-io/provenance/x/oracle/types"
-	triggertypes "github.com/provenance-io/provenance/x/trigger/types"
 )
 
 // appUpgrade is an internal structure for defining all things for an upgrade.
@@ -54,57 +48,6 @@ type appUpgrade struct {
 // If something is happening in the rc upgrade(s) that isn't being applied in the non-rc,
 // or vice versa, please add comments explaining why in both entries.
 var upgrades = map[string]appUpgrade{
-	"rust-rc1": { // upgrade for v1.16.0-rc1
-		Handler: func(ctx sdk.Context, app *App, vm module.VersionMap) (module.VersionMap, error) {
-			var err error
-			vm, err = runModuleMigrations(ctx, app, vm)
-			if err != nil {
-				return nil, err
-			}
-
-			removeInactiveValidatorDelegations(ctx, app)
-
-			err = setAccountDataNameRecord(ctx, app.AccountKeeper, &app.NameKeeper)
-			if err != nil {
-				return nil, err
-			}
-
-			// We only need to call addGovV1SubmitFee on testnet.
-			addGovV1SubmitFee(ctx, app)
-
-			removeP8eMemorializeContractFee(ctx, app)
-
-			fixNameIndexEntries(ctx, app)
-
-			return vm, nil
-		},
-		Added: []string{triggertypes.ModuleName},
-	},
-	"rust": { // upgrade for v1.16.0
-		Handler: func(ctx sdk.Context, app *App, vm module.VersionMap) (module.VersionMap, error) {
-			var err error
-			vm, err = runModuleMigrations(ctx, app, vm)
-			if err != nil {
-				return nil, err
-			}
-
-			removeInactiveValidatorDelegations(ctx, app)
-
-			err = setAccountDataNameRecord(ctx, app.AccountKeeper, &app.NameKeeper)
-			if err != nil {
-				return nil, err
-			}
-
-			// No need to call addGovV1SubmitFee in here as mainnet already has it defined.
-
-			removeP8eMemorializeContractFee(ctx, app)
-
-			fixNameIndexEntries(ctx, app)
-
-			return vm, nil
-		},
-		Added: []string{triggertypes.ModuleName},
-	},
 	"saffron-rc1": { // upgrade for v1.17.0-rc1
 		Handler: func(ctx sdk.Context, app *App, vm module.VersionMap) (module.VersionMap, error) {
 			var err error
@@ -281,62 +224,6 @@ func runModuleMigrations(ctx sdk.Context, app *App, vm module.VersionMap) (modul
 // nor complains about a nolint:unused directive that isn't needed because the function is used.
 var _ = runModuleMigrations
 
-// addGovV1SubmitFee adds a msg-fee for the gov v1 MsgSubmitProposal if there isn't one yet.
-// TODO: Remove with the rust handlers.
-func addGovV1SubmitFee(ctx sdk.Context, app *App) {
-	typeURL := sdk.MsgTypeURL(&govtypesv1.MsgSubmitProposal{})
-
-	ctx.Logger().Info(fmt.Sprintf("Creating message fee for %q if it doesn't already exist.", typeURL))
-	// At the time of writing this, the only way GetMsgFee returns an error is if it can't unmarshall state.
-	// If that's the case for the v1 entry, we want to fix it anyway, so we just ignore any error here.
-	fee, _ := app.MsgFeesKeeper.GetMsgFee(ctx, typeURL)
-	// If there's already a fee for it, do nothing.
-	if fee != nil {
-		ctx.Logger().Info(fmt.Sprintf("Message fee for %q already exists with amount %q. Nothing to do.", fee.MsgTypeUrl, fee.AdditionalFee.String()))
-		return
-	}
-
-	// Copy the fee from the beta entry if it exists, otherwise, just make it fresh.
-	betaTypeURL := sdk.MsgTypeURL(&govtypesv1beta1.MsgSubmitProposal{})
-	// Here too, if there's an error getting the beta fee, just ignore it.
-	betaFee, _ := app.MsgFeesKeeper.GetMsgFee(ctx, betaTypeURL)
-	if betaFee != nil {
-		fee = betaFee
-		fee.MsgTypeUrl = typeURL
-		ctx.Logger().Info(fmt.Sprintf("Copying %q fee to %q.", betaTypeURL, fee.MsgTypeUrl))
-	} else {
-		fee = &msgfeetypes.MsgFee{
-			MsgTypeUrl:           typeURL,
-			AdditionalFee:        sdk.NewInt64Coin("nhash", 100_000_000_000), // 100 hash
-			Recipient:            "",
-			RecipientBasisPoints: 0,
-		}
-		ctx.Logger().Info(fmt.Sprintf("Creating %q fee.", fee.MsgTypeUrl))
-	}
-
-	// At the time of writing this, SetMsgFee always returns nil.
-	_ = app.MsgFeesKeeper.SetMsgFee(ctx, *fee)
-	ctx.Logger().Info(fmt.Sprintf("Successfully set fee for %q with amount %q.", fee.MsgTypeUrl, fee.AdditionalFee.String()))
-}
-
-// removeP8eMemorializeContractFee removes the message fee for the now-non-existent MsgP8eMemorializeContractRequest.
-// TODO: Remove with the rust handlers.
-func removeP8eMemorializeContractFee(ctx sdk.Context, app *App) {
-	typeURL := "/provenance.metadata.v1.MsgP8eMemorializeContractRequest"
-
-	ctx.Logger().Info(fmt.Sprintf("Removing message fee for %q if one exists.", typeURL))
-	// Get the existing fee for log output, but ignore any errors so we try to delete the entry either way.
-	fee, _ := app.MsgFeesKeeper.GetMsgFee(ctx, typeURL)
-	// At the time of writing this, the only error that RemoveMsgFee can return is ErrMsgFeeDoesNotExist.
-	// So ignore any error here and just use fee != nil for the different log messages.
-	_ = app.MsgFeesKeeper.RemoveMsgFee(ctx, typeURL)
-	if fee == nil {
-		ctx.Logger().Info(fmt.Sprintf("Message fee for %q already does not exist. Nothing to do.", typeURL))
-	} else {
-		ctx.Logger().Info(fmt.Sprintf("Successfully removed message fee for %q with amount %q.", fee.MsgTypeUrl, fee.AdditionalFee.String()))
-	}
-}
-
 // removeInactiveValidatorDelegations unbonds all delegations from inactive validators, triggering their removal from the validator set.
 // This should be applied in most upgrades.
 func removeInactiveValidatorDelegations(ctx sdk.Context, app *App) {
@@ -368,21 +255,6 @@ func removeInactiveValidatorDelegations(ctx sdk.Context, app *App) {
 		}
 	}
 	ctx.Logger().Info(fmt.Sprintf("a total of %d inactive (unbonded) validators have had all their delegators removed", removalCount))
-}
-
-// fixNameIndexEntries fixes the name module's address to name index entries.
-// TODO: Remove with the rust handlers.
-func fixNameIndexEntries(ctx sdk.Context, app *App) {
-	ctx.Logger().Info("Fixing name module store index entries.")
-	app.NameKeeper.DeleteInvalidAddressIndexEntries(ctx)
-	ctx.Logger().Info("Done fixing name module store index entries.")
-}
-
-// setAccountDataNameRecord makes sure the account data name record exists, is restricted,
-// and is owned by the attribute module. An error is returned if it fails to make it so.
-// TODO: Remove with the rust handlers.
-func setAccountDataNameRecord(ctx sdk.Context, accountK attributetypes.AccountKeeper, nameK attributetypes.NameKeeper) (err error) {
-	return attributekeeper.EnsureModuleAccountAndAccountDataNameRecord(ctx, accountK, nameK)
 }
 
 // setupICQ sets the correct default values for ICQKeeper.

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -281,6 +281,7 @@ func updateMaxSupply(ctx sdk.Context, app *App) {
 }
 
 // addMarkerNavs adds navs to existing markers
+// TODO: Remove with the saffron handlers.
 func addMarkerNavs(ctx sdk.Context, app *App, denomToNav map[string]markertypes.NetAssetValue) {
 	ctx.Logger().Info("Adding marker net asset values")
 	for denom, nav := range denomToNav {


### PR DESCRIPTION
## Description

Remove the rust upgrades now that both `mainnet` and `testnet` are no longer on them.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
