### PR TITLE
Change default iavl-disable-fastnode and indexer values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * Create a default market in `make run`, `localnet`, `devnet` and the `provenanced testnet` command [#1757](https://github.com/provenance-io/provenance/issues/1757).
 * Remove the rust upgrade handlers [PR 1774](https://github.com/provenance-io/provenance/pull/1774).
 * Add StoreLoader wrapper to check configuration settings [#1792](https://github.com/provenance-io/provenance/pull/1792).
+* Set the default `iavl-disable-fastnode` value to `false` and the default `tx_index.indexer` value to `"null"` [#1807](https://github.com/provenance-io/provenance/pull/1807).
 
 ### Bug Fixes
 

--- a/app/store_loader.go
+++ b/app/store_loader.go
@@ -50,8 +50,8 @@ func ValidateWrapper(logger log.Logger, appOpts servertypes.AppOptions, storeLoa
 			errs = append(errs, fmt.Sprintf("pruning-interval %d EXCEEDS %d AND IS NOT RECOMMENDED, AS IT CAN LEAD TO MISSED BLOCKS ON VALIDATORS", interval, MaxPruningInterval))
 		}
 
-		if indexer != "" {
-			errs = append(errs, fmt.Sprintf("indexer \"%s\" IS NOT RECOMMENDED, AND IT IS RECOMMENDED TO USE \"%s\"", indexer, ""))
+		if indexer != "" && indexer != "null" {
+			errs = append(errs, fmt.Sprintf("indexer \"%s\" IS NOT RECOMMENDED, AND IT IS RECOMMENDED TO USE \"%s\"", indexer, "null"))
 		}
 
 		if fastNode {

--- a/app/store_loader_test.go
+++ b/app/store_loader_test.go
@@ -4,12 +4,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tendermint/tendermint/libs/log"
+	dbm "github.com/tendermint/tm-db"
+
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/store/rootmulti"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/tendermint/tendermint/libs/log"
-	dbm "github.com/tendermint/tm-db"
 )
 
 func TestWrapStoreLoader(t *testing.T) {
@@ -67,6 +69,16 @@ func TestValidateWrapper(t *testing.T) {
 	}{
 		{
 			name: "recommended pruning, indexer, db, and fastnode should not wait",
+			appOpts: MockAppOptions{
+				pruning:  "13",
+				db:       "goleveldb",
+				fastNode: "false",
+				indexer:  "null",
+			},
+			delta: 0,
+		},
+		{
+			name: "recommended pruning, db, and fastnode and empty indexer should not wait",
 			appOpts: MockAppOptions{
 				pruning:  "13",
 				db:       "goleveldb",

--- a/cmd/provenanced/config/manager.go
+++ b/cmd/provenanced/config/manager.go
@@ -90,6 +90,7 @@ func ExtractAppConfigAndMap(cmd *cobra.Command) (*serverconfig.Config, FieldValu
 func DefaultAppConfig() *serverconfig.Config {
 	rv := serverconfig.DefaultConfig()
 	rv.MinGasPrices = pioconfig.GetProvenanceConfig().ProvenanceMinGasPrices
+	rv.IAVLDisableFastNode = false
 	return rv
 }
 
@@ -125,6 +126,7 @@ func ExtractTmConfigAndMap(cmd *cobra.Command) (*tmconfig.Config, FieldValueMap,
 func DefaultTmConfig() *tmconfig.Config {
 	rv := tmconfig.DefaultConfig()
 	rv.Consensus.TimeoutCommit = DefaultConsensusTimeoutCommit
+	rv.TxIndex.Indexer = "null"
 	return rv
 }
 


### PR DESCRIPTION
## Description

This PR changes the default `iavl-disable-fastnode` value to `false` and the default `tx_index.indexer` value to `"null"`. It also allows the `tx_index.indexer` value to be either `""` or `"null"` without issuing a warning.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
