### PR TITLE
Allow bid order prices to not be evenly divisible by buyer settlement fee ratios.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * Add new force_transfer access that is required for an account to do a forced transfer ([#1829](https://github.com/provenance-io/provenance/issues/1829)).
 * Add exchange commitment stuff to CLI [PR 1830](https://github.com/provenance-io/provenance/pull/1830).
 * Update the MsgFees Params to set the nhash per usd-mil to 40,000,000 ($0.025/hash) [#1833](https://github.com/provenance-io/provenance/pull/1833).
+* Bid order prices are no longer restricted to amounts that can be evenly applied to a buyer settlement fee ratio [1834](https://github.com/provenance-io/provenance/pull/1843).
 
 ### API Breaking
 

--- a/x/exchange/keeper/market.go
+++ b/x/exchange/keeper/market.go
@@ -515,7 +515,7 @@ func calcBuyerSettlementRatioFeeOptions(store sdk.KVStore, marketID uint32, pric
 	var errs []error
 	rv := make([]sdk.Coin, 0, len(ratios))
 	for _, ratio := range ratios {
-		fee, ferr := ratio.ApplyTo(price)
+		fee, ferr := ratio.ApplyToLoosely(price)
 		if ferr != nil {
 			errs = append(errs, fmt.Errorf("buyer settlement fees: %w", ferr))
 		} else {
@@ -576,7 +576,7 @@ func validateBuyerSettlementFee(store sdk.KVStore, marketID uint32, price sdk.Co
 				ratioErrs = append(ratioErrs, fmt.Errorf("no ratio from price denom %s to fee denom %s",
 					price.Denom, feeCoin.Denom))
 			} else {
-				ratioFee, err := ratio.ApplyTo(price)
+				ratioFee, err := ratio.ApplyToLoosely(price)
 				switch {
 				case err != nil:
 					ratioErrs = append(ratioErrs, err)

--- a/x/exchange/spec/01_concepts.md
+++ b/x/exchange/spec/01_concepts.md
@@ -346,8 +346,7 @@ It can also have multiple entries with the same `price` denom or `fee` denom, bu
 E.g. a market can have `100chicken:1cow` and also `100chicken:7chicken`, `500cow:1cow`, and `5cow:1chicken`, but it couldn't also have `105chicken:2cow`.
 
 To calculate the buyer settlement ratio fee, the following formula is used: `<bid price> * <ratio fee> / <ratio price>`.
-If that is not a whole number, the chosen ratio is not applicable to the bid order's price and cannot be used.
-The user will need to either use a different ratio or change their bid price.
+If that is not a whole number, it is rounded up to the next whole number.
 
 The buyer settlement ratio fee should be added to the buyer settlement flat fee and provided in the `buyer_settlement_fees` in the bid order.
 The ratio and flat fees can be in any denoms allowed by the market, and do not have to be the same.


### PR DESCRIPTION
## Description

Before this PR, the buyer settlement fee ratios were only usable if they were evenly applicable to the bid order price.
After this PR, a buyer settlement fee ratio is applicable to a price as long as the ratio has the same price denom.
This allows more flexibility in both bid order price (chosen by a user) and the buyer settlement fee ratios (defined by a market).

If the ratio isn't evenly applicable to the given price, the result is rounded up.

For example, given the ratio `7peach:3fig', here's what the fee would be for various prices:

* `7peach` * `3fig`/`7peach` = `3fig`
* `12peach` * `3fig`/`7peach` =  5.14... => `6fig`
* `16peach` * `3fig`/`7peach` = 6.85... => `7fig`

Seller settlement fee ratios are already applied this way.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
