### PR TITLE
Bump cosmos-sdk to v0.46.13-pio-3 (from v0.46.13-pio-2).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - Bump `serde-json-wasm` from 1.0.0 to 1.0.1 in /testutil/contracts/rate-limiter ([#1836](https://github.com/provenance-io/provenance/pull/1836))
 - Bump `serde-json-wasm` from 0.5.1 to 0.5.2 in /testutil/contracts/counter ([#1837](https://github.com/provenance-io/provenance/pull/1837))
 - Bump `serde-json-wasm` from 0.5.1 to 0.5.2 in /testutil/contracts/echo ([#1838](https://github.com/provenance-io/provenance/pull/1838))
+- Bump `cosmos-sdk` from v0.46.13-pio-2 to v0.46.13-pio-3 ([#1848](https://github.com/provenance-io/provenance/pull/1848))
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/CosmWasm/wasmvm v1.2.6
 	github.com/armon/go-metrics v0.4.1
 	github.com/cosmos/cosmos-proto v1.0.0-beta.1
-	github.com/cosmos/cosmos-sdk v0.46.12
+	github.com/cosmos/cosmos-sdk v0.46.13
 	github.com/cosmos/go-bip39 v1.0.0
 	github.com/cosmos/ibc-apps/modules/async-icq/v6 v6.1.0
 	github.com/cosmos/ibc-go/v6 v6.2.0
@@ -183,7 +183,7 @@ require (
 
 replace github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
-replace github.com/cosmos/cosmos-sdk => github.com/provenance-io/cosmos-sdk v0.46.13-pio-2
+replace github.com/cosmos/cosmos-sdk => github.com/provenance-io/cosmos-sdk v0.46.13-pio-3
 
 replace github.com/cosmos/ibc-go/v6 => github.com/provenance-io/ibc-go/v6 v6.2.0-pio-1
 

--- a/go.sum
+++ b/go.sum
@@ -1002,8 +1002,8 @@ github.com/prometheus/procfs v0.3.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.9.0 h1:wzCHvIvM5SxWqYvwgVL7yJY8Lz3PKn49KQtpgMYJfhI=
 github.com/prometheus/procfs v0.9.0/go.mod h1:+pB4zwohETzFnmlpe6yd2lSc+0/46IYZRB/chUwxUZY=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/provenance-io/cosmos-sdk v0.46.13-pio-2 h1:P+MZTl8x1BoUYgwbXlKu12JRdQ9SIz/ZnASABJmNBek=
-github.com/provenance-io/cosmos-sdk v0.46.13-pio-2/go.mod h1:H7JTxq/UEPvM/LSs5bNYvMwmZlVl2NBT5UlqNe8tjEU=
+github.com/provenance-io/cosmos-sdk v0.46.13-pio-3 h1:3Nr5FCjzGNCqoo08/ebPzed61EAn92XIAlUW/lgtHrk=
+github.com/provenance-io/cosmos-sdk v0.46.13-pio-3/go.mod h1:H7JTxq/UEPvM/LSs5bNYvMwmZlVl2NBT5UlqNe8tjEU=
 github.com/provenance-io/ibc-go/v6 v6.2.0-pio-1 h1:IQ+H6+PiRJhGmSjNxA+5VmX34M3sWG5iQI99WbKgbeA=
 github.com/provenance-io/ibc-go/v6 v6.2.0-pio-1/go.mod h1:ZxvTNnra+3aTGaKeg0GR0C8do06lAVdSGmMJHe2fkOM=
 github.com/provenance-io/wasmd v0.30.0-pio-6 h1:pqlN1kE2nwYEXTcbN1LodaRaeKg+SG/cSMC+9vtEnRY=


### PR DESCRIPTION
## Description

This PR bumps `cosmos-sdk` to `v0.46.13-pio-3` (from `v0.46.13-pio-2`).

This brings in the periodic vesting blocked address fix.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
