### PR TITLE
Use the default store loader when an upgrade doesn't need a custom one.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 * Prevent funds from going to or from a marker without the transfer agent having deposit or withdraw access (respectively) [#1834](https://github.com/provenance-io/provenance/issues/1834).
+* Ensure the store loader isn't nil when the handling an upgrade [1852](https://github.com/provenance-io/provenance/pull/1852).
 
 ### API Breaking
 

--- a/app/app.go
+++ b/app/app.go
@@ -1059,7 +1059,7 @@ func New(
 	}
 
 	// Currently in an upgrade hold for this block.
-	storeLoader := baseapp.DefaultStoreLoader
+	var storeLoader baseapp.StoreLoader
 	if upgradeInfo.Name != "" && upgradeInfo.Height == app.LastBlockHeight()+1 {
 		if app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 			app.Logger().Info("Skipping upgrade based on height",
@@ -1076,6 +1076,9 @@ func New(
 			// See if we have a custom store loader to use for upgrades.
 			storeLoader = GetUpgradeStoreLoader(app, upgradeInfo)
 		}
+	}
+	if storeLoader == nil {
+		storeLoader = baseapp.DefaultStoreLoader
 	}
 
 	// Verify configuration settings


### PR DESCRIPTION
## Description

This fixes an issue in `app/app.go#New` where the store loader could end up being `nil`, which leads to an NPE when we it's being called.

---

While testing the `tournaline-rc2` upgrade, I ran into the following panic:
```
11:45AM INF Managing upgrade lastHeight=56 plan=tourmaline-rc2 upgradeHeight=57
11:45AM INF No store upgrades required height=57 plan=tourmaline-rc2
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1024362e8]

goroutine 10 [running]:
github.com/provenance-io/provenance/app.ValidateWrapper.func1({0x104a41b50, 0x14001168fd0})
	github.com/provenance-io/provenance/app/store_loader.go:29 +0x58
github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).LoadLatestVersion(0x14000e45680)
	github.com/cosmos/cosmos-sdk@v0.46.13/baseapp/baseapp.go:306 +0x34
github.com/provenance-io/provenance/app.New({0x104a1ec30, 0x14001540690}, {0x104a34aa8, 0x14000010028}, {0x0, 0x0}, 0x1, 0x140011d52f0, {0x16f8310a6, 0x37}, ...)
	github.com/provenance-io/provenance/app/app.go:1086 +0xc9ec
github.com/provenance-io/provenance/cmd/provenanced/cmd.newApp({0x104a1ec30, 0x14001540690}, {0x104a34aa8, 0x14000010028}, {0x0, 0x0}, {0x1049f3ba0?, 0x140016f6000?})
	github.com/provenance-io/provenance/cmd/provenanced/cmd/root.go:318 +0x6c8
github.com/cosmos/cosmos-sdk/server.startInProcess(_, {{0x0, 0x0, 0x0}, {0x104a42168, 0x14001179110}, 0x0, {0x1400012b750, 0x7}, {0x104a3a8f8, ...}, ...}, ...)
	github.com/cosmos/cosmos-sdk@v0.46.13/server/start.go:281 +0x278
github.com/cosmos/cosmos-sdk/server.StartCmd.func2.2()
	github.com/cosmos/cosmos-sdk@v0.46.13/server/start.go:147 +0x48
github.com/cosmos/cosmos-sdk/server.wrapCPUProfile.func2()
	github.com/cosmos/cosmos-sdk@v0.46.13/server/start.go:537 +0x30
created by github.com/cosmos/cosmos-sdk/server.wrapCPUProfile
	github.com/cosmos/cosmos-sdk@v0.46.13/server/start.go:536 +0x1dc
make: *** [run] Error 2
```

The problem was that `GetUpgradeStoreLoader` returns `nil` in some instances (e.g. `tourmaline-rc2` that doesn't have any store changes). So when we tried to invoke that `nil` as a function, we got this NPE.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Ensured the application remains stable during upgrades by fixing a potential issue with store loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->