### PR TITLE
Backport: 1852: Use the default store loader when an upgrade doesn't need a custom one.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 * Prevent funds from going to or from a marker without the transfer agent having deposit or withdraw access (respectively) [#1834](https://github.com/provenance-io/provenance/issues/1834).
+* Ensure the store loader isn't nil when the handling an upgrade [1852](https://github.com/provenance-io/provenance/pull/1852).
 
 ### API Breaking
 

--- a/RELEASE_CHANGELOG.md
+++ b/RELEASE_CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Bug Fixes
 
 * Prevent funds from going to or from a marker without the transfer agent having deposit or withdraw access (respectively) [#1834](https://github.com/provenance-io/provenance/issues/1834).
+* Ensure the store loader isn't nil when the handling an upgrade [1852](https://github.com/provenance-io/provenance/pull/1852).
 
 ### API Breaking
 

--- a/app/app.go
+++ b/app/app.go
@@ -1059,7 +1059,7 @@ func New(
 	}
 
 	// Currently in an upgrade hold for this block.
-	storeLoader := baseapp.DefaultStoreLoader
+	var storeLoader baseapp.StoreLoader
 	if upgradeInfo.Name != "" && upgradeInfo.Height == app.LastBlockHeight()+1 {
 		if app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 			app.Logger().Info("Skipping upgrade based on height",
@@ -1076,6 +1076,9 @@ func New(
 			// See if we have a custom store loader to use for upgrades.
 			storeLoader = GetUpgradeStoreLoader(app, upgradeInfo)
 		}
+	}
+	if storeLoader == nil {
+		storeLoader = baseapp.DefaultStoreLoader
 	}
 
 	// Verify configuration settings


### PR DESCRIPTION
## Description

This PR backports the following PR to `release/v1.18.x`:
* #1852 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
