### PR TITLE
Backport: 1883 (Allow NAVs to have a greater volume than the marker's supply).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * Add a `tourmaline-rc3` upgrade handler to set some new exchange module params related to payments [#1703](https://github.com/provenance-io/provenance/issues/1703).
 * Remove the startup warning issued when disable-iavl-fastnode is true (we recommend keeping it as true if you already have it that way) [#1874](https://github.com/provenance-io/provenance/pull/1874).
 * Switch to `github.com/cometbft/cometbft-db` `v0.7.0` (from `github.com/tendermint/tm-db` `v0.6.7`) [#1874](https://github.com/provenance-io/provenance/pull/1874).
+* Allow NAV volume to exceed a marker's supply [#1883](https://github.com/provenance-io/provenance/pull/1883).
 
 ### Bug Fixes
 

--- a/x/exchange/client/cli/cli_test.go
+++ b/x/exchange/client/cli/cli_test.go
@@ -533,6 +533,8 @@ type txCmdTestCase struct {
 	args []string
 	// addedFees is any fees to add to the default 10<bond> amount.
 	addedFees sdk.Coins
+	// gas is the amount of gas to include. Default is 250,000.
+	gas int
 	// expInErr are strings to expect in an error from the cmd.
 	// Errors that come from the endpoint will not be here; use expInRawLog for those.
 	expInErr []string
@@ -563,9 +565,14 @@ func (s *CmdTestSuite) runTxCmdTestCase(tc txCmdTestCase) {
 		fees = fees.Add(tc.addedFees...)
 	}
 
+	gas := "250000"
+	if tc.gas > 0 {
+		gas = fmt.Sprintf("%d", tc.gas)
+	}
+
 	args := append(tc.args, extraArgs...)
 	args = append(args,
-		"--"+flags.FlagGas, "250000",
+		"--"+flags.FlagGas, gas,
 		"--"+flags.FlagFees, fees.String(),
 		"--"+flags.FlagBroadcastMode, flags.BroadcastBlock,
 		"--"+flags.FlagSkipConfirmation,

--- a/x/exchange/client/cli/tx_test.go
+++ b/x/exchange/client/cli/tx_test.go
@@ -447,6 +447,7 @@ func (s *CmdTestSuite) TestCmdTxMarketSettle() {
 				return args, s.assertBalancesFollowup(expBals)
 			},
 			args:         []string{"settle", "--from", s.addr1.String(), "--market", "5"},
+			gas:          300_000,
 			expectedCode: 0,
 		},
 	}

--- a/x/marker/keeper/keeper.go
+++ b/x/marker/keeper/keeper.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/tendermint/tendermint/libs/log"
 
-	"cosmossdk.io/math"
-
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -310,15 +308,11 @@ func (k Keeper) SetNetAssetValue(ctx sdk.Context, marker types.MarkerAccountI, n
 	}
 
 	key := types.NetAssetValueKey(marker.GetAddress(), netAssetValue.Price.Denom)
-	store := ctx.KVStore(k.storeKey)
-	if math.NewIntFromUint64(netAssetValue.Volume).GT(marker.GetSupply().Amount) {
-		return fmt.Errorf("volume (%v) cannot exceed %q marker supply (%v)", netAssetValue.Volume, marker.GetDenom(), marker.GetSupply())
-	}
-
 	bz, err := k.cdc.Marshal(&netAssetValue)
 	if err != nil {
 		return err
 	}
+	store := ctx.KVStore(k.storeKey)
 	store.Set(key, bz)
 
 	return nil

--- a/x/marker/keeper/keeper_test.go
+++ b/x/marker/keeper/keeper_test.go
@@ -2562,8 +2562,8 @@ func TestAddSetNetAssetValues(t *testing.T) {
 			marker:    redMarker,
 			navs:      []types.NetAssetValue{newNav("3blue", 1001)},
 			source:    "val",
-			expErr:    "cannot set net asset value: volume (1001) cannot exceed \"red\" marker supply (1000red)",
 			expEvents: sdk.Events{navEvent("red", "3blue", 1001, "val")},
+			expNavs:   []types.NetAssetValue{newNav("3blue", 1001)},
 		},
 		{
 			name:      "one nav: success",
@@ -2581,12 +2581,12 @@ func TestAddSetNetAssetValues(t *testing.T) {
 			expErr: "cannot set net asset value: marker net asset value volume must be positive value",
 		},
 		{
-			name:      "usd nav: too much volume",
+			name:      "usd nav: volume greater than supply",
 			marker:    blueMarker,
 			navs:      []types.NetAssetValue{newNav("55"+types.UsdDenom, 1005)},
 			source:    "wynne",
 			expEvents: sdk.Events{navEvent("blue", "55"+types.UsdDenom, 1005, "wynne")},
-			expErr:    "cannot set net asset value: volume (1005) cannot exceed \"blue\" marker supply (1000blue)",
+			expNavs:   []types.NetAssetValue{newNav("55"+types.UsdDenom, 1005)},
 		},
 		{
 			name:      "usd nav: success",
@@ -2611,11 +2611,11 @@ func TestAddSetNetAssetValues(t *testing.T) {
 		{
 			name:   "three navs: error on first",
 			marker: whiteMarker,
-			navs:   []types.NetAssetValue{newNav("7blue", 1001), newNav("167red", 66), newNav("377yellow", 89)},
+			navs:   []types.NetAssetValue{newNav("7blue", 0), newNav("167red", 66), newNav("377yellow", 89)},
 			source: "knox",
-			expErr: "cannot set net asset value: volume (1001) cannot exceed \"white\" marker supply (1000white)",
+			expErr: "cannot set net asset value: marker net asset value volume must be positive value",
 			expEvents: sdk.Events{
-				navEvent("white", "7blue", 1001, "knox"),
+				// no blue event because the nav is invalid.
 				navEvent("white", "167red", 66, "knox"),
 				navEvent("white", "377yellow", 89, "knox"),
 			},
@@ -2646,20 +2646,6 @@ func TestAddSetNetAssetValues(t *testing.T) {
 				// no white event because it's the same denom as the marker.
 			},
 			expNavs: []types.NetAssetValue{newNav("788blue", 14), newNav("215red", 3)},
-		},
-		{
-			name:   "three navs: error on all",
-			marker: whiteMarker,
-			navs:   []types.NetAssetValue{newNav("44blue", 1001), newNav("55red", 0), newNav("66yellow", 1002)},
-			source: "lynn",
-			expErr: "cannot set net asset value: volume (1001) cannot exceed \"white\" marker supply (1000white)" + "\n" +
-				"cannot set net asset value: marker net asset value volume must be positive value" + "\n" +
-				"cannot set net asset value: volume (1002) cannot exceed \"white\" marker supply (1000white)",
-			expEvents: sdk.Events{
-				navEvent("white", "44blue", 1001, "lynn"),
-				// nav 2 is invalid, so no event from it.
-				navEvent("white", "66yellow", 1002, "lynn"),
-			},
 		},
 	}
 


### PR DESCRIPTION
## Description

This PR backports the following PR to `release/v1.18.x`:
* #1883

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
