### PR TITLE
feat(ci): build heighliner provenance docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,13 +2,19 @@ name: Docker Build and Push
 # Build & Push builds the simapp docker image on every push to master
 # and pushes the image to https://hub.docker.com/u/provenanceio
 on:
+  pull_request:
+    paths:
+      - docker/blockchain/Dockerfile
+      - .github/workflows/docker.yml
   push:
     branches:
       - main
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+" # Push events to matching v*, i.e. v1.0, v20.15.10
-      - "v[0-9]+.[0-9]+.[0-9]+-rc*" # Push events to matching v*, i.e. v1.0-rc1, v20.15.10-rc5
-      
+      - '**'
+
+env:
+  DOCKER_IMAGE: "provenanceio/provenance"
+
 # Set concurrency for this workflow to cancel in-progress jobs if retriggered.
 # The github.ref is only available when triggered by a PR so fall back to github.run_id for other cases.
 # The github.run_id is unique for each run, giving each such invocation it's own unique concurrency group.
@@ -18,68 +24,80 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 jobs:
-  docker:
+  heighliner-docker:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/setup-qemu-action@v2
+
+      - uses: docker/metadata-action@v5
+        id: meta
         with:
-          fetch-depth: 0
+          images: ${{ env.DOCKER_IMAGE }}
+          flavor: |
+            prefix=heighliner-,onlatest=true
+          tags: |
+            type=edge
+            type=ref,event=pr
+            type=ref,event=tag
 
-      - name: Setup go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.21'
-
-      - name: Go mod vendor
-        run: |
-         go mod vendor
-
-      - name: Prepare
-        id: prep
-        run: |
-          DOCKER_IMAGE=provenanceio/provenance
-          VERSION=noop
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/}
-          elif [[ $GITHUB_REF == refs/heads/* ]]; then
-            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
-            if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
-              VERSION=latest
-            fi
-          fi
-          TAGS="${DOCKER_IMAGE}:${VERSION}"
-          if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-            TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION}"
-          fi
-          echo "Setting output: version=${VERSION}"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Setting output: tags=${TAGS}"
-          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
-          created="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-          echo "Setting output: created=$created"
-          echo "created=$created" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Available platforms
-        run: echo ${{ steps.buildx.outputs.platforms }}
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
+      - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Publish to Docker Hub
-        uses: docker/build-push-action@v5
+      - uses: strangelove-ventures/heighliner-build-action@main
+        with:
+          heighliner-tag: v1.5.5
+          chain: provenance
+          local: true
+          tag: ${{ steps.meta.outputs.version }}
+          registry: provenanceio
+          build-target: |
+            cd ..
+            make install
+          additional-args: "--alpine-version 3.18"
+          skip: ${{ github.event_name == 'pull_request' }}
+
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+
+      - run: go mod vendor
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/setup-qemu-action@v2
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.DOCKER_IMAGE }}
+          tags: |
+            type=edge
+            type=ref,event=pr
+            type=ref,event=tag
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v5
         with:
           context: .
           target: run
           build-args: |
-            VERSION=${{ steps.prep.outputs.version }}
+            VERSION=${{ steps.meta.outputs.version }}
           platforms: linux/amd64,linux/arm64
           file: docker/blockchain/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.prep.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## Description

Builds heighliner docker images and pushes to the official `provenanceio` registry rather than relying on heighliner `ghcr`.
This will allow us to better track when builds are failing and also allow us to push all previous tag builds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced Docker setup and build process for continuous integration.
  - Enabled Docker image builds on pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->