### PR TITLE
fix(ci): point to correct provenanced binary in heighliner image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,9 +56,16 @@ jobs:
           local: true
           tag: ${{ steps.meta.outputs.version }}
           registry: provenanceio
+          dockerfile: cosmos
           build-target: |
             cd ..
             make install
+          binaries: |
+            - /go/bin/provenanced
+          build-env: |
+            - "WITH_LEDGER=false"
+            - "WITH_CLEVELDB=false"
+            - "BUILD_TAGS=muslc musl dynamic"
           additional-args: "--alpine-version 3.18"
           skip: ${{ github.event_name == 'pull_request' }}
 


### PR DESCRIPTION
The `heighliner-build-action` makes it seem like the `heighliner` repo `chains.yaml` is used as a default and overrides can be provided. In practice I was seeing a problem where `provenanced` could not be found on the recently built image. This adds the fields that exist in `chains.yaml` so this workflow itself can now be thought of as the canonical configuration rather than the `chains.yaml`.

## Tests
- [x] `docker run provenanceio/provenance@sha256:194ec608f295d753dd936ca6d12046ffb0308651735d66fc7fc594936f8de33e /bin/sh -c "provenanced init --chain-id testing -t network-1 ; provenanced start -t"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Docker build configurations in the workflow to enhance build process efficiency and customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->