### PR TITLE
Remove the build-tests github actions.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,29 +117,6 @@ jobs:
           name: "${{ needs.setup-tests.outputs.file-prefix }}-${{ matrix.part }}-coverage"
           path: ./${{ matrix.part }}profile.out
 
-  build-tests:
-    # TODO[1760]: Delete this build-tests action once the tests reliably pass again.
-    needs: setup-tests
-    strategy:
-      fail-fast: false
-      matrix:
-        part: ["00", "01", "02", "03"]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        if: needs.setup-tests.outputs.should-run
-        with:
-          go-version: ${{ needs.setup-tests.outputs.go-version }}
-      - uses: actions/download-artifact@v4
-        if: needs.setup-tests.outputs.should-run
-        with:
-          name: "${{ needs.setup-tests.outputs.file-prefix }}-pkgs.txt.part.${{ matrix.part }}"
-      - name: build tests
-        if: needs.setup-tests.outputs.should-run
-        run: |
-          cat pkgs.txt.part.${{ matrix.part }} | xargs go test -mod=readonly -timeout 30m -tags='norace ledger test_ledger_mock' -run='ZYX_NOPE_NOPE_XYZ'
-
   #  This action performs a code coverage assessment but filters out generated code from proto based types
   #  and grpc services
   upload-coverage-report:


### PR DESCRIPTION
## Description

This PR removes the `build-tests` GitHub actions. All the tests pass again, and are required. Since building is a requirement for passing, there's no need to have a special action that just builds the tests.

Related to:
* #1760 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated CI/CD configuration by removing the `build-tests` job to adjust testing strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->