### PR TITLE
change provwasm stargate query plugin to use protocodec

### DIFF
--- a/internal/provwasm/query_plugins.go
+++ b/internal/provwasm/query_plugins.go
@@ -15,6 +15,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/gogoproto/proto"
+
+	provwasmtypes "github.com/provenance-io/provenance/x/wasm/types"
 )
 
 // The maximum querier result size allowed, ~10MB.
@@ -44,10 +46,18 @@ func (qr *QuerierRegistry) RegisterQuerier(route string, querier Querier) {
 }
 
 // QueryPlugins provides provenance query support for smart contracts.
-func QueryPlugins(registry *QuerierRegistry, queryRouter baseapp.GRPCQueryRouter, codec codec.Codec) *wasmkeeper.QueryPlugins {
+func QueryPlugins(registry *QuerierRegistry, queryRouter baseapp.GRPCQueryRouter, cdc codec.Codec) *wasmkeeper.QueryPlugins {
+
+	protoCdc, ok := cdc.(*codec.ProtoCodec)
+	if !ok {
+		panic(fmt.Errorf("codec must be *codec.ProtoCodec type: actual: %T", cdc))
+	}
+
+	stargateCdc := codec.NewProtoCodec(provwasmtypes.NewWasmInterfaceRegistry(protoCdc.InterfaceRegistry()))
+
 	return &wasmkeeper.QueryPlugins{
 		Custom:   customPlugins(registry),
-		Stargate: StargateQuerier(queryRouter, codec),
+		Stargate: StargateQuerier(queryRouter, stargateCdc),
 	}
 }
 

--- a/x/wasm/types/any.go
+++ b/x/wasm/types/any.go
@@ -1,0 +1,19 @@
+package types
+
+import fmt "fmt"
+
+// WasmAny represents the type with raw bytes value for codectypes.Any
+type WasmAny struct {
+	Value []byte
+}
+
+func (*WasmAny) ProtoMessage()             {}
+func (*WasmAny) XXX_WellKnownType() string { return "BytesValue" }
+func (m *WasmAny) Reset()                  { *m = WasmAny{} }
+func (m *WasmAny) String() string {
+	return fmt.Sprintf("%x", m.Value) // not compatible w/ pb oct
+}
+func (m *WasmAny) Unmarshal(b []byte) error {
+	m.Value = append([]byte(nil), b...)
+	return nil
+}

--- a/x/wasm/types/interface_registry.go
+++ b/x/wasm/types/interface_registry.go
@@ -1,0 +1,24 @@
+package types
+
+import (
+	"github.com/cosmos/gogoproto/proto"
+
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+)
+
+var _ codectypes.InterfaceRegistry = &WasmInterfaceRegistry{}
+
+// NewWasmInterfaceRegistry returns a new WasmInterfaceRegistry instance
+func NewWasmInterfaceRegistry(registry codectypes.InterfaceRegistry) WasmInterfaceRegistry {
+	return WasmInterfaceRegistry{registry}
+}
+
+// WasmInterfaceRegistry represents an interface registry with a custom any resolver
+type WasmInterfaceRegistry struct {
+	codectypes.InterfaceRegistry
+}
+
+// Resolve implements codectypes.InterfaceRegistry
+func (WasmInterfaceRegistry) Resolve(typeUrl string) (proto.Message, error) {
+	return new(WasmAny), nil
+}


### PR DESCRIPTION
…type

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This PR changes the codec for wasm Stargate (proto based) queries to use the protocodec. This gets around the issue of `Any` type messages returned from a wasm query missing their `type` information, thus breaking the deserialization to the contract level.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
