### PR TITLE
fix(ci): heighliner image build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,8 +25,6 @@ concurrency:
   cancel-in-progress: true
 jobs:
   heighliner-docker:
-    # temporarily disable heighliner docker build until issue fixed: https://github.com/strangelove-ventures/heighliner/issues/253
-    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -51,24 +49,30 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # use forked branch until https://github.com/strangelove-ventures/heighliner/issues/253 is fixed
+      # heighliner does not support the wasmvm pathing yet so a "pre-build" step is required
+      # lock to "linux/amd64" only for now due to differing "pre-build" steps
+      # https://github.com/CosmWasm/wasmvm/blob/main/docs/MIGRATING.md
       - uses: strangelove-ventures/heighliner-build-action@main
         with:
-          heighliner-tag: v1.5.5
+          heighliner-owner: ProvLabs
+          heighliner-tag: v1.6.3
           chain: provenance
           local: true
           tag: ${{ steps.meta.outputs.version }}
           registry: provenanceio
+          platform: linux/amd64
           dockerfile: cosmos
           build-target: |
             cd ..
             make install
           binaries: |
             - /go/bin/provenanced
+          pre-build: |
+            cp /lib/libwasmvm_muslc.a /lib/libwasmvm_muslc.x86_64.a
           build-env: |
             - "WITH_LEDGER=false"
-            - "WITH_CLEVELDB=false"
             - "BUILD_TAGS=muslc musl dynamic"
-          additional-args: "--alpine-version 3.18"
           skip: ${{ github.event_name == 'pull_request' }}
 
   docker:


### PR DESCRIPTION
* Uses a fork of `heighliner` and custom `pre-build` step in order to get [wasmvm 2.x](https://github.com/CosmWasm/wasmvm/blob/main/docs/MIGRATING.md) working.
* Use the default, alpine 3.19, now that we're on go 1.21.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Docker workflow to use heighliner tag `v1.6.3` and change owner to `ProvLabs`.
  - Enhanced pre-build steps and specified platform as `linux/amd64`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->