### PR TITLE
Put the wasm dir back in wasm/wasm.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * Add the (empty) `umber-rc2` upgrade [#2069](https://github.com/provenance-io/provenance/pull/2069).
 * Update the Swagger API documentation [#2063](https://github.com/provenance-io/provenance/pull/2063).
 
+### Bug Fixes
+
+* Put the location of the wasm directory back to where it is in previous versions: data/wasm/wasm [#2071](https://github.com/provenance-io/provenance/pull/2071).
+
 ### Dependencies
 
 - Bump `github.com/hashicorp/go-getter` from 1.7.4 to 1.7.5 ([#2057](https://github.com/provenance-io/provenance/pull/2057))

--- a/app/app.go
+++ b/app/app.go
@@ -620,7 +620,7 @@ func New(
 	icqIBCModule := icq.NewIBCModule(app.ICQKeeper)
 
 	// Init CosmWasm module
-	wasmDir := filepath.Join(homePath, "data")
+	wasmDir := filepath.Join(homePath, "data", "wasm")
 
 	wasmWrap := WasmWrapper{Wasm: wasmtypes.DefaultWasmConfig()}
 	err = viper.Unmarshal(&wasmWrap)


### PR DESCRIPTION
## Description

Put the wasm directory back to `data/wasm/wasm`. That is what it is in `v1.18` (and before).

Yesterday, I worked on adding a step to the upgrade that would move the directory, but that comes with complications that would be better to not rush. Specifically, during the app initialization, the wasm module creates some stuff in there (if it doesn't already exist). And it looks like there's some new stuff in there. So we'd have to do some sort of merger of the old and new, and do it in a way that, upon a failure, doesn't really screw things up for people.

We can try to move it again later, when we've got more time to evaluate the sticking points and get some decent testing on it first.



---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved issue with the incorrect location of the `wasm` directory.

- **Documentation**
  - Updated the Swagger API documentation.

- **Chores**
  - Upgraded dependencies, including `github.com/hashicorp/go-getter`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->