### PR TITLE
Mark v1.19.0-rc5 and rename umber-rc2 to umber-rc4.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,21 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ---
 
+## [v1.19.0-rc5](https://github.com/provenance-io/provenance/releases/tag/v1.19.0-rc5) - 2024-07-12
+
+### Full Commit History
+
+* https://github.com/provenance-io/provenance/compare/v1.19.0-rc4...v1.19.0-rc5
+* https://github.com/provenance-io/provenance/compare/v1.18.0...v1.19.0-rc5
+
+---
+
+### Bug Fixes
+
+* Change the umber-rc2 upgrade to umber-rc4. [#2091](https://github.com/provenance-io/provenance/pull/2091).
+
+---
+
 ## [v1.19.0-rc4](https://github.com/provenance-io/provenance/releases/tag/v1.19.0-rc4) - 2024-07-12
 
 ### Dependencies

--- a/RELEASE_CHANGELOG.md
+++ b/RELEASE_CHANGELOG.md
@@ -1,3 +1,12 @@
+## [v1.19.0-rc5](https://github.com/provenance-io/provenance/releases/tag/v1.19.0-rc5) - 2024-07-12
+
+### Full Commit History
+
+* https://github.com/provenance-io/provenance/compare/v1.19.0-rc4...v1.19.0-rc5
+* https://github.com/provenance-io/provenance/compare/v1.18.0...v1.19.0-rc5
+
+---
+
 ## [v1.19.0-rc4](https://github.com/provenance-io/provenance/releases/tag/v1.19.0-rc4) - 2024-07-12
 
 ### Dependencies

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -105,6 +105,8 @@ var upgrades = map[string]appUpgrade{
 			return vm, nil
 		},
 	},
+	"umber-rc2": {}, // not used.
+	"umber-rc3": {}, // not used.
 	"umber-rc4": {}, // upgrade for v1.19.0-rc5
 	"umber": { // upgrade for v1.19.0
 		Added:   []string{crisistypes.ModuleName, circuittypes.ModuleName, consensusparamtypes.ModuleName},

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -105,7 +105,7 @@ var upgrades = map[string]appUpgrade{
 			return vm, nil
 		},
 	},
-	"umber-rc2": {}, // upgrade for v1.19.0-rc3
+	"umber-rc4": {}, // upgrade for v1.19.0-rc5
 	"umber": { // upgrade for v1.19.0
 		Added:   []string{crisistypes.ModuleName, circuittypes.ModuleName, consensusparamtypes.ModuleName},
 		Deleted: []string{"reward"},

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -402,8 +402,8 @@ func (s *UpgradeTestSuite) TestUmberRC1() {
 	s.AssertUpgradeHandlerLogs("umber-rc1", expInLog, nil)
 }
 
-func (s *UpgradeTestSuite) TestUmberRC2() {
-	key := "umber-rc2"
+func (s *UpgradeTestSuite) TestUmberRC4() {
+	key := "umber-rc4"
 	s.Assert().Contains(upgrades, key, "%q defined upgrades map", key)
 
 	entry := upgrades[key]


### PR DESCRIPTION
## Description

I accidentally put the upgrade proposal in for "umber-rc4" which doesn't exist. So we need this so we can start again.

This PR also marks `v1.19.0-rc5` in the changelog.

This is going to `release/v1.19.x` first so we can get unstuck faster.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
