### PR TITLE
Mark v1.19.0-rc5 and rename umber-rc2 to umber-rc4.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,21 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ---
 
+## [v1.19.0-rc5](https://github.com/provenance-io/provenance/releases/tag/v1.19.0-rc5) - 2024-07-12
+
+### Full Commit History
+
+* https://github.com/provenance-io/provenance/compare/v1.19.0-rc4...v1.19.0-rc5
+* https://github.com/provenance-io/provenance/compare/v1.18.0...v1.19.0-rc5
+
+---
+
+### Bug Fixes
+
+* Change the umber-rc2 upgrade to umber-rc4. [#2091](https://github.com/provenance-io/provenance/pull/2091).
+
+---
+
 ## [v1.19.0-rc4](https://github.com/provenance-io/provenance/releases/tag/v1.19.0-rc4) - 2024-07-12
 
 ### Dependencies

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -105,7 +105,9 @@ var upgrades = map[string]appUpgrade{
 			return vm, nil
 		},
 	},
-	"umber-rc2": {}, // upgrade for v1.19.0-rc3
+	"umber-rc2": {}, // not used.
+	"umber-rc3": {}, // not used.
+	"umber-rc4": {}, // upgrade for v1.19.0-rc5
 	"umber": { // upgrade for v1.19.0
 		Added:   []string{crisistypes.ModuleName, circuittypes.ModuleName, consensusparamtypes.ModuleName},
 		Deleted: []string{"reward"},

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -402,8 +402,8 @@ func (s *UpgradeTestSuite) TestUmberRC1() {
 	s.AssertUpgradeHandlerLogs("umber-rc1", expInLog, nil)
 }
 
-func (s *UpgradeTestSuite) TestUmberRC2() {
-	key := "umber-rc2"
+func (s *UpgradeTestSuite) TestUmberRC4() {
+	key := "umber-rc4"
 	s.Assert().Contains(upgrades, key, "%q defined upgrades map", key)
 
 	entry := upgrades[key]


### PR DESCRIPTION
## Description

This PR marks `v1.19.0-rc5` in the changelog (in `main`), and adds the `umber-rc3` and `umber-rc4` upgrades (both empty).

The upgrades were needed because I messed up when I submitted the upgrade proposal and said it was for the `umber-rc4` upgrade. So we needed a new version that actually had that upgrade.

This is a frontport of this PR:
* #2091

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
