### PR TITLE
Mark v1.19.1 and fix mainnet CLI queries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,19 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ---
 
+## [v1.19.1](https://github.com/provenance-io/provenance/releases/tag/v1.19.1) - 2024-07-25
+
+### Bug Fixes
+
+* Use the correct HRP in the CLI queries [#2108](https://github.com/provenance-io/provenance/issues/2108).
+
+### Full Commit History
+
+* https://github.com/provenance-io/provenance/compare/v1.19.0...v1.19.1
+* https://github.com/provenance-io/provenance/compare/v1.18.0...v1.19.1
+
+---
+
 ## [v1.19.0](https://github.com/provenance-io/provenance/releases/tag/v1.19.0) - 2024-07-19
 
 ### Features

--- a/cmd/provenanced/cmd/root.go
+++ b/cmd/provenanced/cmd/root.go
@@ -64,8 +64,7 @@ func NewRootCmd(sealConfig bool) (*cobra.Command, params.EncodingConfig) {
 	sdk.SetAddrCacheEnabled(false)
 	defer sdk.SetAddrCacheEnabled(true)
 
-	// We initially set the config as testnet so commands that run before start work for testing such as gentx.
-	app.SetConfig(true, false)
+	app.SetConfig(isTestnetFlagSet(), false)
 
 	tempApp := app.New(log.NewNopLogger(), dbm.NewMemDB(), nil, true, simtestutil.NewAppOptionsWithFlagHome(tempDir))
 	encodingConfig := tempApp.GetEncodingConfig()
@@ -437,4 +436,20 @@ func getIAVLCacheSize(options servertypes.AppOptions) int {
 		return cast.ToInt(serverconfig.DefaultConfig().IAVLCacheSize)
 	}
 	return iavlCacheSize
+}
+
+// isTestnetFlagSet returns true if the command was invoked with the --testnet flag.
+// This should be the same as viper.Get("testnet"), but can be used without needing
+// to set up viper.
+func isTestnetFlagSet() bool {
+	ev := os.Getenv("PIO_TESTNET")
+	if len(ev) > 0 {
+		return cast.ToBool(ev)
+	}
+	for _, arg := range os.Args[1:] {
+		if arg == "-t" || arg == "--testnet" {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Description

This is a frontport of the following PR to `main`:
* #2108 

It updates the changelog to mark `v1.19.1` and fixes the mainnet queries.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
