### PR TITLE
Fix the dependabot changelog action from using wrong flag for get-deps script.

### DIFF
--- a/.changelog/dependabot-changelog.sh
+++ b/.changelog/dependabot-changelog.sh
@@ -126,7 +126,7 @@ where_i_am="$( cd "$( dirname "${BASH_SOURCE:-$0}" )"; pwd -P )"
 [[ -n "$verbose" ]] && printf 'Looking for go.mod dependency changes.\n'
 # Run the script to create the entry from the changes in go.mod.
 # The $verbose variable is purposely not quoted so that it doesn't count as an arg if it's empty.
-"$where_i_am/get-dep-changes.sh" --pr "$pr" --name "$branch_fn" $verbose --force --target-branch "$target_branch"
+"$where_i_am/get-dep-changes.sh" --pr "$pr" --id "$branch_fn" $verbose --force --target-branch "$target_branch"
 ec=$?
 [[ -n "$verbose" ]] && printf 'Exit code from get-dep-changes.sh: %d\n' "$ec"
 


### PR DESCRIPTION
## Description

The dependabot changelog action script was incorrectly providing a `--name` flag when it should have been `--id`.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the script for dependency change logging by modifying the branch identification parameter from `--name` to `--id`. This improves the clarity and accuracy of branch processing in future dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->