### PR TITLE
Create the build-debug make target.

### DIFF
--- a/.changelog/unreleased/improvements/2062-build-debug.md
+++ b/.changelog/unreleased/improvements/2062-build-debug.md
@@ -1,0 +1,1 @@
+* Create the `build-debug` make target for building a provenanced binary that allows debugging [#2062](https://github.com/provenance-io/provenance/issues/2062).


### PR DESCRIPTION
## Description

closes: #2062 

This PR creates the `build-debug` make target. This will build a version of `provenanced` that a debugger can attach to. With debug builds, `-debug` is appended to the version string to help identify whether your `provenanced` allows debugging.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `build-debug` target for enhanced debugging capabilities during the build process.
- **Improvements**
	- Enhanced build configurations for better clarity and maintainability.
	- Updated version management for more flexible handling of version information.
	- Added new `GCFLAGS` for improved garbage collection control during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->