### PR TITLE
Make prep-release.sh copy summary.md into unreleased for release candidates.

### DIFF
--- a/.changelog/prep-release.sh
+++ b/.changelog/prep-release.sh
@@ -579,6 +579,11 @@ rm "$new_ver_dir/.gitkeep" > /dev/null 2>&1
 [[ -n "$verbose" ]] && printf 'Creating new unreleased dir: [%s].\n' "$unreleased_dir"
 mkdir -p "$unreleased_dir" || clean_exit 1
 touch "$unreleased_dir/.gitkeep"
+if [[ -n "$v_rc" ]]; then
+    # If this was an rc, copy the summary back into unreleased.
+    [[ -n "$verbose" ]] && printf 'Copying summary.md back into unreleased.\n'
+    cp "${new_ver_dir}/summary.md" "$unreleased_sum_file" || clean_exit 1
+fi
 
 printf 'Done.\n'
 clean_exit 0

--- a/.changelog/prep-release.sh
+++ b/.changelog/prep-release.sh
@@ -280,7 +280,7 @@ if [[ "$v_patch" -ne '0' ]]; then
         handle_invalid_version 'Patch number is not sequential. Previous version: [%s].' "$prev_ver"
     fi
 elif [[ "$v_minor" -ne '0' ]]; then
-    if [[ "v${v_major}.$(( v_minor - 1 ))." != "$( sed -E 's/[^.]+$/' <<< "$prev_ver" )" ]]; then
+    if [[ "v${v_major}.$(( v_minor - 1 ))." != "$( sed -E 's/[^.]+$//' <<< "$prev_ver" )" ]]; then
         handle_invalid_version 'Minor number is not sequential. Previous version: [%s].' "$prev_ver"
     fi
 else

--- a/.changelog/unreleased/dependencies/2132-bump-go-to-1.23.md
+++ b/.changelog/unreleased/dependencies/2132-bump-go-to-1.23.md
@@ -1,2 +1,2 @@
-* `go` bumped to 1.23 (from 1.21) [#2132](https://github.com/provenance-io/provenance/pull/2132).
-* `golangci-lint` bumped to v1.60.2 (from v1.54.2) [#2132](https://github.com/provenance-io/provenance/pull/2132).
+* Bump `go` to 1.23 (from 1.21) [#2132](https://github.com/provenance-io/provenance/pull/2132).
+* Bump `golangci-lint` to v1.60.2 (from v1.54.2) [#2132](https://github.com/provenance-io/provenance/pull/2132).

--- a/.changelog/unreleased/dependencies/2132-bump-go-to-1.23.md
+++ b/.changelog/unreleased/dependencies/2132-bump-go-to-1.23.md
@@ -1,2 +1,2 @@
-* Bump `go` to 1.23 (from 1.21) [#2132](https://github.com/provenance-io/provenance/pull/2132).
-* Bump `golangci-lint` to v1.60.2 (from v1.54.2) [#2132](https://github.com/provenance-io/provenance/pull/2132).
+* `go` bumped to 1.23 (from 1.21) [#2132](https://github.com/provenance-io/provenance/pull/2132).
+* `golangci-lint` bumped to v1.60.2 (from v1.54.2) [#2132](https://github.com/provenance-io/provenance/pull/2132).

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/cometbft/cometbft-db v0.11.0
 	github.com/cosmos/cosmos-db v1.0.2
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5
-	github.com/cosmos/cosmos-sdk v0.50.7
+	github.com/cosmos/cosmos-sdk v0.50.10
 	github.com/cosmos/go-bip39 v1.0.0
 	github.com/cosmos/gogoproto v1.7.0
 	github.com/cosmos/ibc-apps/modules/async-icq/v8 v8.0.0


### PR DESCRIPTION
## Description

This PR:
* Fixes the `prep-release.sh` script to fix an invalid sed statement causing minor version validation to fail.
* Makes the `prep-release.sh` script copy the `summary.md` into `unreleased` when the new version is a release candidate.
* In `go.mod` changes the version on the import line for `cosmos-sdk`. There's no change to the replace line for it though, so it's not actually a version bump; it's just making that import line match the version of the SDK that our fork's replacement is based on.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
