### PR TITLE
Mark v1.20.0-rc2

### DIFF
--- a/.changelog/v1.20.0-rc2/bug-fixes/2182-fix-release-changelog.md
+++ b/.changelog/v1.20.0-rc2/bug-fixes/2182-fix-release-changelog.md
@@ -1,0 +1,1 @@
+* Rename the RELEASE_NOTES.md file to RELEASE_CHANGELOG.md [PR 2182](https://github.com/provenance-io/provenance/pull/2182).

--- a/.changelog/v1.20.0-rc2/bug-fixes/2184-fix-heighliner.md
+++ b/.changelog/v1.20.0-rc2/bug-fixes/2184-fix-heighliner.md
@@ -1,0 +1,1 @@
+* Fix the heighliner build [PR 2184](https://github.com/provenance-io/provenance/pull/2184).

--- a/.changelog/v1.20.0-rc2/summary.md
+++ b/.changelog/v1.20.0-rc2/summary.md
@@ -1,0 +1,2 @@
+Building or installing `provenanced` from source now requires you to use [Go 1.23](https://golang.org/dl/).
+Linting now requires `golangci-lint` v1.60.2. You can update yours using `make golangci-lint-update` or install it using `make golangci-lint`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,19 @@ See: [.changelog/unreleased](.changelog/unreleased)
 
 ---
 
+## [v1.20.0-rc2](https://github.com/provenance-io/provenance/releases/tag/v1.20.0-rc2) 2024-10-15
+
+### Bug Fixes
+
+* Rename the RELEASE_NOTES.md file to RELEASE_CHANGELOG.md [PR 2182](https://github.com/provenance-io/provenance/pull/2182).
+
+### Full Commit History
+
+* https://github.com/provenance-io/provenance/compare/v1.20.0-rc1...v1.20.0-rc2
+* https://github.com/provenance-io/provenance/compare/v1.19.1...v1.20.0-rc2
+
+---
+
 ## [v1.20.0-rc1](https://github.com/provenance-io/provenance/releases/tag/v1.20.0-rc1) 2024-10-14
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,11 +52,12 @@ See: [.changelog/unreleased](.changelog/unreleased)
 
 ---
 
-## [v1.20.0-rc2](https://github.com/provenance-io/provenance/releases/tag/v1.20.0-rc2) 2024-10-15
+## [v1.20.0-rc2](https://github.com/provenance-io/provenance/releases/tag/v1.20.0-rc2) 2024-10-16
 
 ### Bug Fixes
 
 * Rename the RELEASE_NOTES.md file to RELEASE_CHANGELOG.md [PR 2182](https://github.com/provenance-io/provenance/pull/2182).
+* Fix the heighliner build [PR 2184](https://github.com/provenance-io/provenance/pull/2184).
 
 ### Full Commit History
 

--- a/RELEASE_CHANGELOG.md
+++ b/RELEASE_CHANGELOG.md
@@ -1,3 +1,19 @@
+## [v1.20.0-rc2](https://github.com/provenance-io/provenance/releases/tag/v1.20.0-rc2) 2024-10-15
+
+Building or installing `provenanced` from source now requires you to use [Go 1.23](https://golang.org/dl/).
+Linting now requires `golangci-lint` v1.60.2. You can update yours using `make golangci-lint-update` or install it using `make golangci-lint`.
+
+### Bug Fixes
+
+* Rename the RELEASE_NOTES.md file to RELEASE_CHANGELOG.md [PR 2182](https://github.com/provenance-io/provenance/pull/2182).
+
+### Full Commit History
+
+* https://github.com/provenance-io/provenance/compare/v1.20.0-rc1...v1.20.0-rc2
+* https://github.com/provenance-io/provenance/compare/v1.19.1...v1.20.0-rc2
+
+---
+
 ## [v1.20.0-rc1](https://github.com/provenance-io/provenance/releases/tag/v1.20.0-rc1) 2024-10-14
 
 Building or installing `provenanced` from source now requires you to use [Go 1.23](https://golang.org/dl/).

--- a/RELEASE_CHANGELOG.md
+++ b/RELEASE_CHANGELOG.md
@@ -1,4 +1,4 @@
-## [v1.20.0-rc2](https://github.com/provenance-io/provenance/releases/tag/v1.20.0-rc2) 2024-10-15
+## [v1.20.0-rc2](https://github.com/provenance-io/provenance/releases/tag/v1.20.0-rc2) 2024-10-16
 
 Building or installing `provenanced` from source now requires you to use [Go 1.23](https://golang.org/dl/).
 Linting now requires `golangci-lint` v1.60.2. You can update yours using `make golangci-lint-update` or install it using `make golangci-lint`.
@@ -6,6 +6,7 @@ Linting now requires `golangci-lint` v1.60.2. You can update yours using `make g
 ### Bug Fixes
 
 * Rename the RELEASE_NOTES.md file to RELEASE_CHANGELOG.md [PR 2182](https://github.com/provenance-io/provenance/pull/2182).
+* Fix the heighliner build [PR 2184](https://github.com/provenance-io/provenance/pull/2184).
 
 ### Full Commit History
 


### PR DESCRIPTION
## Description

This PR marks `v1.20.0-rc2` in the changelog and release changelog because `v1.20.0-rc1` had the release changelog named the wrong thing, so it didn't actually create the release.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
