### PR TITLE
Dwedul/no params key

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -211,9 +211,7 @@ var (
 // the params module can be deleted. But I don't want the imports, so they're copied here.
 // TODO[viridian]: Delete these params constants after the upgrade.
 const (
-	paramsName = "params"           // = paramstypes.ModuleName
-	paramsKey  = paramsName         // = paramstypes.StoreKey
-	paramsTKey = "transient_params" // paramstypes.TStoreKey
+	paramsName = "params" // = paramstypes.ModuleName
 )
 
 // WasmWrapper allows us to use namespacing in the config file
@@ -362,7 +360,7 @@ func New(
 	keys := storetypes.NewKVStoreKeys(
 		authtypes.StoreKey, banktypes.StoreKey, stakingtypes.StoreKey,
 		minttypes.StoreKey, distrtypes.StoreKey, slashingtypes.StoreKey,
-		govtypes.StoreKey, consensusparamtypes.StoreKey, paramsKey, upgradetypes.StoreKey, feegrant.StoreKey,
+		govtypes.StoreKey, consensusparamtypes.StoreKey, upgradetypes.StoreKey, feegrant.StoreKey,
 		evidencetypes.StoreKey, capabilitytypes.StoreKey, circuittypes.StoreKey,
 		authzkeeper.StoreKey, group.StoreKey, crisistypes.StoreKey,
 
@@ -386,7 +384,7 @@ func New(
 		hold.StoreKey,
 		exchange.StoreKey,
 	)
-	tkeys := storetypes.NewTransientStoreKeys(paramsTKey)
+	tkeys := storetypes.NewTransientStoreKeys()
 	memKeys := storetypes.NewMemoryStoreKeys(capabilitytypes.MemStoreKey)
 
 	govAuthority := authtypes.NewModuleAddress(govtypes.ModuleName).String()


### PR DESCRIPTION
## Description

Remove the params store key and transient store key from the app.

This is in draft because I need to test the upgrade again.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
