### PR TITLE
Remove the params store key and transient store key from the app.

### DIFF
--- a/.changelog/unreleased/bug-fixes/2189-remove-params-storekey.md
+++ b/.changelog/unreleased/bug-fixes/2189-remove-params-storekey.md
@@ -1,0 +1,1 @@
+* Remove the params store key and transient store key from the app [PR 2189](https://github.com/provenance-io/provenance/pull/2189).

--- a/.changelog/unreleased/bug-fixes/2189-remove-params-storekey.md
+++ b/.changelog/unreleased/bug-fixes/2189-remove-params-storekey.md
@@ -1,1 +1,2 @@
 * Remove the params store key and transient store key from the app [PR 2189](https://github.com/provenance-io/provenance/pull/2189).
+  This fixes a problem in `v1.20.0-rc2` that prevented nodes from restarting if stopped after the upgrade.

--- a/app/app.go
+++ b/app/app.go
@@ -211,9 +211,7 @@ var (
 // the params module can be deleted. But I don't want the imports, so they're copied here.
 // TODO[viridian]: Delete these params constants after the upgrade.
 const (
-	paramsName = "params"           // = paramstypes.ModuleName
-	paramsKey  = paramsName         // = paramstypes.StoreKey
-	paramsTKey = "transient_params" // paramstypes.TStoreKey
+	paramsName = "params" // = paramstypes.ModuleName
 )
 
 // WasmWrapper allows us to use namespacing in the config file
@@ -362,7 +360,7 @@ func New(
 	keys := storetypes.NewKVStoreKeys(
 		authtypes.StoreKey, banktypes.StoreKey, stakingtypes.StoreKey,
 		minttypes.StoreKey, distrtypes.StoreKey, slashingtypes.StoreKey,
-		govtypes.StoreKey, consensusparamtypes.StoreKey, paramsKey, upgradetypes.StoreKey, feegrant.StoreKey,
+		govtypes.StoreKey, consensusparamtypes.StoreKey, upgradetypes.StoreKey, feegrant.StoreKey,
 		evidencetypes.StoreKey, capabilitytypes.StoreKey, circuittypes.StoreKey,
 		authzkeeper.StoreKey, group.StoreKey, crisistypes.StoreKey,
 
@@ -386,7 +384,7 @@ func New(
 		hold.StoreKey,
 		exchange.StoreKey,
 	)
-	tkeys := storetypes.NewTransientStoreKeys(paramsTKey)
+	tkeys := storetypes.NewTransientStoreKeys()
 	memKeys := storetypes.NewMemoryStoreKeys(capabilitytypes.MemStoreKey)
 
 	govAuthority := authtypes.NewModuleAddress(govtypes.ModuleName).String()


### PR DESCRIPTION
## Description

Remove the params store key and transient store key from the app.

Turns out this should have been done in #2176. I didn't do it there because I was thinking that the app needed the store key in it in order to delete it. Now that I reflect on that, it should have obviously not been the right thing to do. Sorry.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed parameters related to store management, addressing restart issues after the recent upgrade.
	- Simplified application configuration by eliminating unnecessary key references, enhancing clarity in the app's initialization process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->