### PR TITLE
Suppress scope value owner migration events.

### DIFF
--- a/.changelog/unreleased/improvements/2195-hide-md-mig-events.md
+++ b/.changelog/unreleased/improvements/2195-hide-md-mig-events.md
@@ -1,0 +1,1 @@
+* Suppress the events emitted during the metadata migration that changes how scope value owners are recorded [PR 2195](https://github.com/provenance-io/provenance/pull/2195).

--- a/internal/sdk/events.go
+++ b/internal/sdk/events.go
@@ -1,0 +1,46 @@
+package sdk
+
+import (
+	abci "github.com/cometbft/cometbft/abci/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/gogoproto/proto"
+)
+
+// NoOpEventManager is an event manager that satisfies the sdk.EventManagerI interface, but does nothing.
+type NoOpEventManager struct{}
+
+var _ sdk.EventManagerI = (*NoOpEventManager)(nil)
+
+// NewNoOpEventManager returns a new event manager that does nothing.
+func NewNoOpEventManager() *NoOpEventManager {
+	return &NoOpEventManager{}
+}
+
+// Events returns sdk.EmptyEvents().
+func (x NoOpEventManager) Events() sdk.Events {
+	// Returning sdk.EmptyEvents() here (instead of nil) to match sdk.EventManager behavior.
+	return sdk.EmptyEvents()
+}
+
+// ABCIEvents returns sdk.EmptyABCIEvents().
+func (x NoOpEventManager) ABCIEvents() []abci.Event {
+	// Returning sdk.EmptyABCIEvents() here (instead of nil) to match sdk.EventManager behavior.
+	return sdk.EmptyABCIEvents()
+}
+
+// EmitTypedEvent ignores the provided argument, does nothing, and always returns nil.
+func (x NoOpEventManager) EmitTypedEvent(_ proto.Message) error {
+	return nil
+}
+
+// EmitTypedEvents ignores the provided arguments, does nothing, and always returns nil.
+func (x NoOpEventManager) EmitTypedEvents(_ ...proto.Message) error {
+	return nil
+}
+
+// EmitEvent ignores the provided event and does nothing.
+func (x NoOpEventManager) EmitEvent(_ sdk.Event) {}
+
+// EmitEvents ignores the provided events and does nothing.
+func (x NoOpEventManager) EmitEvents(_ sdk.Events) {}

--- a/x/metadata/keeper/migrations_v4.go
+++ b/x/metadata/keeper/migrations_v4.go
@@ -19,7 +19,11 @@ import (
 func (m Migrator) Migrate3To4(ctx sdk.Context) error {
 	// This migration emits too many events and can cause problems with nodes due to its size.
 	// So we'll just throw all of them away by swapping in a different event manager here.
-	ctx = ctx.WithEventManager(internalsdk.NewNoOpEventManager())
+	// But the testnet migration already ran using v1.20.0-rc2 which included all of the events in the block result.
+	// So, to keep v1.20.0-rc2 and v1.20.0 state compatible, we only throw out the events when not on a testnet.
+	if sdk.GetConfig().GetBech32AccountAddrPrefix() != "tp" {
+		ctx = ctx.WithEventManager(internalsdk.NewNoOpEventManager())
+	}
 	logger := m.keeper.Logger(ctx)
 	logger.Info("Starting migration of x/metadata from 3 to 4.")
 	if err := migrateValueOwners(ctx, newKeeper3To4(m.keeper)); err != nil {

--- a/x/metadata/keeper/migrations_v4.go
+++ b/x/metadata/keeper/migrations_v4.go
@@ -10,12 +10,16 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/address"
 	"github.com/cosmos/gogoproto/proto"
 
+	internalsdk "github.com/provenance-io/provenance/internal/sdk"
 	markertypes "github.com/provenance-io/provenance/x/marker/types"
 	"github.com/provenance-io/provenance/x/metadata/types"
 )
 
 // Migrate3To4 will update the metadata store from version 3 to version 4. This should be part of the viridian upgrade.
 func (m Migrator) Migrate3To4(ctx sdk.Context) error {
+	// This migration emits too many events and can cause problems with nodes due to its size.
+	// So we'll just throw all of them away by swapping in a different event manager here.
+	ctx = ctx.WithEventManager(internalsdk.NewNoOpEventManager())
 	logger := m.keeper.Logger(ctx)
 	logger.Info("Starting migration of x/metadata from 3 to 4.")
 	if err := migrateValueOwners(ctx, newKeeper3To4(m.keeper)); err != nil {


### PR DESCRIPTION
## Description

This PR updates the metadata module migration from v3 to v4 (to move value-owner records into the bank module). It will no longer emit any events when run on a mainnet node. Any events for other parts of the upgrade will still be included, though, just not the events from the metadata module migration.

For each scope value owner, there is at least 6 events (more if they've opted into quarantine). Both mainnet and testnet have around 300,000 scopes and most (if not all) have a value owner. That's around 1.8M events that would be emitted.

On testnet, when we ran the `viridian-rc1` upgrade, it included all of those events in the block-results for the upgrade height. I had to write a custom executable to extract it, and as JSON, it was almost 400MB. We could not find a way to allow a node to actually return that info via the block-results query.

In some unit tests I wrote and played with, reading the block result from state and unmarshalling it always took less than half a second. But that's a small fraction of the amount of time between request and timeout. My theory is that some limit is being hit, causing a panic in a sub-process that isn't being properly handled. When the panic happens, the request processing is halted and the node never sends any sort of response, leading ultimately to a timeout from something. Further, I believe that when that panic happens, there's memory that has been allocated, but not released, leading to a memory leak. This might explain why some modes had memory problems (some causing system crashes) after the upgrade.

So, to be on the safe side, we'll omit the events from the metadata module migration.

Also, so that `v1.20.0-rc2` and `v1.20.0` can be state compatible, this change only affects non-testnet nodes. That way, if you're recreating a node, playing through all the blocks, then, on the `viridian-rc1` upgrade height, you can switch to `v1.20.0` and get the correct result. I.e. for a testnet node, all the events will still be emitted during the metadata v3 to v4 module migration.


---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a no-operation event manager to suppress event emissions during metadata migration, enhancing performance.
	- Conditional event suppression based on the environment (testnet vs. others) during metadata migration.

- **Bug Fixes**
	- Improved error handling and logging during the migration of metadata from version 3 to 4.

- **Documentation**
	- Updated migration logic documentation to reflect changes in event management and value owner handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->