### PR TITLE
Fix decoding of gov props with a ParameterChangeProposal in them.

### DIFF
--- a/.changelog/unreleased/bug-fixes/2198-fix-gov-props.md
+++ b/.changelog/unreleased/bug-fixes/2198-fix-gov-props.md
@@ -1,0 +1,1 @@
+* Register the params types with the codecs so old gov props can be read [PR 2198](https://github.com/provenance-io/provenance/pull/2198).

--- a/app/app.go
+++ b/app/app.go
@@ -98,6 +98,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/mint"
 	mintkeeper "github.com/cosmos/cosmos-sdk/x/mint/keeper"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+	paramprops "github.com/cosmos/cosmos-sdk/x/params/types/proposal" //nolint:depguard // Need this here to register old types.
 	"github.com/cosmos/cosmos-sdk/x/slashing"
 	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
@@ -785,6 +786,10 @@ func New(
 		})
 	app.BasicModuleManager.RegisterLegacyAminoCodec(legacyAmino)
 	app.BasicModuleManager.RegisterInterfaces(interfaceRegistry)
+
+	// We removed the params module, but have several gov props with a ParameterChangeProposal in them.
+	paramprops.RegisterLegacyAminoCodec(legacyAmino)
+	paramprops.RegisterInterfaces(interfaceRegistry)
 
 	// NOTE: upgrade module is required to be prioritized
 	app.mm.SetOrderPreBlockers(


### PR DESCRIPTION
## Description

Currently on testnet (running `v1.20.0-rc2` or `-rc3`):

* If you do a `provenanced query gov proposals` you'll get `Error: rpc error: code = Unknown desc = runtime error: invalid memory address or nil pointer dereference: panic`.
* If you do `provenanced query gov proposal 133`, you get `Error: rpc error: code = Unknown desc = rpc error: code = Internal desc = collections: encoding error: value decode: no concrete type registered for type URL /cosmos.params.v1beta1.ParameterChangeProposal against interface *v1beta1.Content: unknown request`.

This is because several gov props (`4`, `14`, `18`, `23`, `47`, `49`, `50`, `86`, `94`, `103`, `104`, `133`) have a `ParameterChangeProposal` in them. In `v1.20`, we completely removed the params module. With that, we stopped registering its types with the various codecs. But those gov props are stored in state, so we still need to be able to do stuff with them.

This PR registers the params module stuff with the codecs again, so that those old gov props can be read again.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a registration mechanism for legacy governance properties, enhancing compatibility with older data formats.
	- Added functionality for managing parameter change proposals within the governance module.

- **Bug Fixes**
	- Improved the system's ability to interpret and process older governance properties.

- **Tests**
	- Added a new test case to validate the creation and serialization of parameter change proposals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->