### PR TITLE
Fix: Add node flag to WASM queries (build-address)

### DIFF
--- a/.changelog/unreleased/bug-fixes/2199-fix-wasm-build-addr.md
+++ b/.changelog/unreleased/bug-fixes/2199-fix-wasm-build-addr.md
@@ -1,0 +1,1 @@
+* Add the query flags to the query wasm build-addr command [PR 2199](https://github.com/provenance-io/provenance/pull/2199).

--- a/cmd/provenanced/cmd/root.go
+++ b/cmd/provenanced/cmd/root.go
@@ -132,6 +132,7 @@ func NewRootCmd(sealConfig bool) (*cobra.Command, params.EncodingConfig) {
 	}
 
 	fixTxWasmInstantiate2Aliases(rootCmd)
+	fixQueryWasmBuildAddressFlags(rootCmd)
 
 	return rootCmd, encodingConfig
 }
@@ -534,4 +535,17 @@ func getTelemetryGlobalLabels(logger log.Logger, appOpts servertypes.AppOptions)
 
 	logger.Debug("Extracted telemetry setup from app options.", telEnabledKey, enabled, telGlobalLabelsKey, globalLabels)
 	return globalLabels, enabled
+}
+
+// fixQueryWasmBuildAddressFlags resolves an issue where the Wasm build-address query failed to recognize the node flag.
+func fixQueryWasmBuildAddressFlags(rootCmd *cobra.Command) {
+	// Find the "build-address" command.
+	cmd, _, err := rootCmd.Find([]string{"query", "wasm", "build-address"})
+	if err != nil || cmd == nil {
+		// If the command doesn't exist, there's nothing to do.
+		return
+	}
+
+	// Apply query flags to the command.
+	flags.AddQueryFlagsToCmd(cmd)
 }


### PR DESCRIPTION
This is a recreation of #2194 by [GunanshuJoshi](https://github.com/GunanshuJoshi), but with signed commits.

## Description

This PR adds a new `--node` flag to support custom endpoints for node connections while making Wasm queries specifically `build-address`. This update ensures that the `provenanced q wasm build-address` command works correctly with custom node configurations.  

## Issue:
While creating the predictable contract address I encountered the following error:
```bash
unknown flag: --node
````
This occurred when running the following command:

```bash
provenanced query wasm build-address <code-hash> <creator-address> <salt> --node https://rpc.test.provenance.io:443
```
It seems the flag is not being recognized properly. I suspect there might be an issue with either the flag registration in the command definition (root.go) or how the CLI parser processes the command.

The main file updated is:  
- `cmd/provenanced/cmd/root.go`  

closes: `n/a`  
I haven't created any particular issue for this change. However, this was discussed on Discord, where it was agreed that the node flag should function correctly.  
Reference: [Discord conversation](https://discord.com/channels/897185242182484029/933506958873464944/1295915569329078323).  

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced query flags for the `query wasm build-addr` command, enhancing its functionality and output customization.
	- Added persistent flags for custom denomination and message fee floor price, improving command configurability.

- **Bug Fixes**
	- Resolved issues with the "build-address" command under the "query wasm" subcommand, ensuring correct flag recognition and improved error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->