### PR TITLE
Mark v1.20.0-rc4

### DIFF
--- a/.changelog/unreleased/bug-fixes/2148-fix-recordspec-cli.md
+++ b/.changelog/unreleased/bug-fixes/2148-fix-recordspec-cli.md
@@ -1,1 +1,0 @@
-* Fix the query metadata recordspec command to use the RecordSpecification query when provided a recspec id [#2148](https://github.com/provenance-io/provenance/issues/2148).

--- a/.changelog/unreleased/bug-fixes/2198-fix-gov-props.md
+++ b/.changelog/unreleased/bug-fixes/2198-fix-gov-props.md
@@ -1,1 +1,0 @@
-* Register the params types with the codecs so old gov props can be read [PR 2198](https://github.com/provenance-io/provenance/pull/2198).

--- a/.changelog/unreleased/bug-fixes/2199-fix-wasm-build-addr.md
+++ b/.changelog/unreleased/bug-fixes/2199-fix-wasm-build-addr.md
@@ -1,1 +1,0 @@
-* Add the query flags to the query wasm build-addr command [PR 2199](https://github.com/provenance-io/provenance/pull/2199).

--- a/.changelog/unreleased/improvements/2121-commit-timeout.md
+++ b/.changelog/unreleased/improvements/2121-commit-timeout.md
@@ -1,1 +1,0 @@
-* Hard code the mainnet `consensus.timeout_commit` config value to 3.5s [#2121](https://github.com/provenance-io/provenance/issues/2121).

--- a/.changelog/unreleased/improvements/2181-combine-changelog-dep-lines.md
+++ b/.changelog/unreleased/improvements/2181-combine-changelog-dep-lines.md
@@ -1,1 +1,0 @@
-* Update the prep-release script to combine dependency changelog entries [PR 2181](https://github.com/provenance-io/provenance/pull/2181).

--- a/.changelog/unreleased/improvements/2192-use-v1-20-0-in-spec-links.md
+++ b/.changelog/unreleased/improvements/2192-use-v1-20-0-in-spec-links.md
@@ -1,1 +1,0 @@
-* Update the proto file links in the spec docs to point to `v1.20.0` (instead of `v1.19.0`) [PR 2192](https://github.com/provenance-io/provenance/pull/2192).

--- a/.changelog/unreleased/improvements/2195-hide-md-mig-events.md
+++ b/.changelog/unreleased/improvements/2195-hide-md-mig-events.md
@@ -1,1 +1,0 @@
-* Suppress the events emitted during the metadata migration that changes how scope value owners are recorded [PR 2195](https://github.com/provenance-io/provenance/pull/2195).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,28 @@ See: [.changelog/unreleased](.changelog/unreleased)
 
 ---
 
+## [v1.20.0-rc4](https://github.com/provenance-io/provenance/releases/tag/v1.20.0-rc4) 2024-10-25
+
+### Improvements
+
+* Hard code the mainnet `consensus.timeout_commit` config value to 3.5s [#2121](https://github.com/provenance-io/provenance/issues/2121).
+* Update the prep-release script to combine dependency changelog entries [PR 2181](https://github.com/provenance-io/provenance/pull/2181).
+* Update the proto file links in the spec docs to point to `v1.20.0` (instead of `v1.19.0`) [PR 2192](https://github.com/provenance-io/provenance/pull/2192).
+* Suppress the events emitted during the metadata migration that changes how scope value owners are recorded [PR 2195](https://github.com/provenance-io/provenance/pull/2195).
+
+### Bug Fixes
+
+* Fix the query metadata recordspec command to use the RecordSpecification query when provided a recspec id [#2148](https://github.com/provenance-io/provenance/issues/2148).
+* Register the params types with the codecs so old gov props can be read [PR 2198](https://github.com/provenance-io/provenance/pull/2198).
+* Add the query flags to the query wasm build-addr command [PR 2199](https://github.com/provenance-io/provenance/pull/2199).
+
+### Full Commit History
+
+* https://github.com/provenance-io/provenance/compare/v1.20.0-rc3...v1.20.0-rc4
+* https://github.com/provenance-io/provenance/compare/v1.19.1...v1.20.0-rc4
+
+---
+
 ## [v1.20.0-rc3](https://github.com/provenance-io/provenance/releases/tag/v1.20.0-rc3) 2024-10-16
 
 ### Bug Fixes


### PR DESCRIPTION
## Description

This PR marks `v1.20.0-rc4` in `main`.

It's basically a frontport of this PR:
* #2201 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes for Version v1.20.0-rc4

- **New Features**
	- Enhanced querying for metadata records with improved command functionality.
	- Added query flags to the `query wasm build-addr` command for better usability.

- **Improvements**
	- Configuration for consensus timeout has been set to 3.5 seconds for the mainnet.
	- Updated prep-release script to streamline dependency changelog entries.
	- Specification documentation links have been updated to reference version `v1.20.0`.
	- Suppressed events during the metadata migration for a cleaner process.

- **Bug Fixes**
	- Registered parameter types to ensure compatibility with older governance properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->