### PR TITLE
Create the wisteria upgrade that update validator commissions.

### DIFF
--- a/.changelog/unreleased/features/2260-validator-commission-bumps.md
+++ b/.changelog/unreleased/features/2260-validator-commission-bumps.md
@@ -1,0 +1,1 @@
+* Create the wisteria upgrade that will set validator commission rates [PR 2260](https://github.com/provenance-io/provenance/pull/2260).

--- a/app/app.go
+++ b/app/app.go
@@ -208,13 +208,6 @@ var (
 	_ servertypes.Application = (*App)(nil)
 )
 
-// These are some values defined in the params module that we still need so that
-// the params module can be deleted. But I don't want the imports, so they're copied here.
-// TODO[viridian]: Delete these params constants after the upgrade.
-const (
-	paramsName = "params" // = paramstypes.ModuleName
-)
-
 // WasmWrapper allows us to use namespacing in the config file
 // This is only used for parsing in the app, x/wasm expects WasmConfig
 type WasmWrapper struct {

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	sdkmath "cosmossdk.io/math"
 	storetypes "cosmossdk.io/store/types"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 
@@ -37,8 +38,7 @@ type appUpgrade struct {
 // Entries should be in chronological/alphabetical order, earliest first.
 // I.e. Brand-new colors should be added to the bottom with the rcs first, then the non-rc.
 var upgrades = map[string]appUpgrade{
-	"viridian-rc1": { // upgrade for v1.20.0-rc1
-		Deleted: []string{paramsName},
+	"wisteria-rc1": { // Upgrade for v1.21.0-rc1.
 		Handler: func(ctx sdk.Context, app *App, vm module.VersionMap) (module.VersionMap, error) {
 			var err error
 			if err = pruneIBCExpiredConsensusStates(ctx, app); err != nil {
@@ -48,11 +48,16 @@ var upgrades = map[string]appUpgrade{
 				return nil, err
 			}
 			removeInactiveValidatorDelegations(ctx, app)
+			if err = updateValidatorCommissions(ctx, app); err != nil {
+				return nil, err
+			}
+			if err = increaseMinCommission(ctx, app); err != nil {
+				return nil, err
+			}
 			return vm, nil
 		},
 	},
-	"viridian": { // upgrade for v1.20.0
-		Deleted: []string{paramsName},
+	"wisteria": { // Upgrade for v1.21.0.
 		Handler: func(ctx sdk.Context, app *App, vm module.VersionMap) (module.VersionMap, error) {
 			var err error
 			if err = pruneIBCExpiredConsensusStates(ctx, app); err != nil {
@@ -62,6 +67,12 @@ var upgrades = map[string]appUpgrade{
 				return nil, err
 			}
 			removeInactiveValidatorDelegations(ctx, app)
+			if err = updateValidatorCommissions(ctx, app); err != nil {
+				return nil, err
+			}
+			if err = increaseMinCommission(ctx, app); err != nil {
+				return nil, err
+			}
 			return vm, nil
 		},
 	},
@@ -225,3 +236,46 @@ var (
 	_ = removeInactiveValidatorDelegations
 	_ = pruneIBCExpiredConsensusStates
 )
+
+// updateValidatorCommissions updates all the validators to have 60% commission rate, with a max of 60% too.
+// Part of the wisteria upgrade.
+func updateValidatorCommissions(ctx sdk.Context, app *App) error {
+	ctx.Logger().Info("Updating the commissions for all validators to 60% with 60% max.")
+	sixtyPct := sdkmath.LegacyMustNewDecFromStr("0.60")
+
+	validators, err := app.StakingKeeper.GetAllValidators(ctx)
+	if err != nil {
+		return fmt.Errorf("could not get all validators: %w", err)
+	}
+
+	for _, validator := range validators {
+		validator.Commission.MaxRate = sixtyPct
+		validator.Commission.Rate = sixtyPct
+		err = app.StakingKeeper.SetValidator(ctx, validator)
+		if err != nil {
+			return fmt.Errorf("could not update validator %q: %w", validator.OperatorAddress, err)
+		}
+	}
+
+	ctx.Logger().Info("Done updating the commissions for all validators to 60% with 60% max.")
+	return nil
+}
+
+// increaseMinCommission increases the minimum commission (for any validator) to 60%.
+// Part of the wisteria upgrade.
+func increaseMinCommission(ctx sdk.Context, app *App) error {
+	ctx.Logger().Info("Setting minimum commission to 60%.")
+	params, err := app.StakingKeeper.GetParams(ctx)
+	if err != nil {
+		return fmt.Errorf("could not get staking module params: %w", err)
+	}
+
+	params.MinCommissionRate = sdkmath.LegacyMustNewDecFromStr("0.60")
+	err = app.StakingKeeper.SetParams(ctx, params)
+	if err != nil {
+		return fmt.Errorf("could not set staking module params: %w", err)
+	}
+
+	ctx.Logger().Info("Done setting minimum commission to 60%.")
+	return nil
+}


### PR DESCRIPTION
## Description

This PR creates the `wisteria-rc1` and `wisteria` upgrades and removes the `viridian` ones.

The wisteria upgrades will update the commission of all validators to be 60% with a max rate of 60%. It will also update the minimum rate (for any validator) to 60%.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
