### PR TITLE
Fix spelling of the rateLimitingKeeper.

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -525,8 +525,8 @@ func New(
 		app.IbcHooks,
 	)
 
-	rateLimtingKeeper := ibcratelimitkeeper.NewKeeper(appCodec, keys[ibcratelimit.StoreKey], nil)
-	app.RateLimitingKeeper = &rateLimtingKeeper
+	rateLimitingKeeper := ibcratelimitkeeper.NewKeeper(appCodec, keys[ibcratelimit.StoreKey], nil)
+	app.RateLimitingKeeper = &rateLimitingKeeper
 
 	// Create Transfer Keepers
 	rateLimitingTransferModule := ibcratelimitmodule.NewIBCMiddleware(nil, app.HooksICS4Wrapper, app.RateLimitingKeeper)


### PR DESCRIPTION
app/app.go
rateLimtingKeeper - rateLimitingKeeper `fix erros`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

This release contains behind‐the‐scenes improvements that enhance overall reliability and maintainability. While you may not notice visible changes, these updates help ensure a smoother, more consistent experience.

- **Bug Fixes**
  - Corrected an internal naming discrepancy to support reliable core functionality.
- **Refactor**
  - Standardized internal naming conventions for improved code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->