### PR TITLE
Fix Typos in Documentation and Code Comments

### DIFF
--- a/docs/proto-docs.md
+++ b/docs/proto-docs.md
@@ -5978,7 +5978,7 @@ It is replaced by providing a MsgAddMsgFeeProposalRequest in a governance propos
 | `description` | [string](#string) |  | propsal description |
 | `msg_type_url` | [string](#string) |  | type url of msg to add fee |
 | `additional_fee` | [cosmos.base.v1beta1.Coin](#cosmos-base-v1beta1-Coin) |  | additional fee for msg type |
-| `recipient` | [string](#string) |  | optional recipient to recieve basis points |
+| `recipient` | [string](#string) |  | optional recipient to receive basis points |
 | `recipient_basis_points` | [string](#string) |  | basis points to use when recipient is present (1 - 10,000) |
 
 
@@ -6041,7 +6041,7 @@ It is replaced by providing a MsgUpdateMsgFeeProposalRequest in a governance pro
 | `description` | [string](#string) |  | propsal description |
 | `msg_type_url` | [string](#string) |  | type url of msg to update fee |
 | `additional_fee` | [cosmos.base.v1beta1.Coin](#cosmos-base-v1beta1-Coin) |  | additional fee for msg type |
-| `recipient` | [string](#string) |  | optional recipient to recieve basis points |
+| `recipient` | [string](#string) |  | optional recipient to receive basis points |
 | `recipient_basis_points` | [string](#string) |  | basis points to use when recipient is present (1 - 10,000) |
 
 
@@ -7499,7 +7499,7 @@ MsgUpdateParamsResponse is a response message for the UpdateParams endpoint.
 <a name="provenance-marker-v1-MsgUpdateRequiredAttributesRequest"></a>
 
 ### MsgUpdateRequiredAttributesRequest
-MsgUpdateRequiredAttributesRequest defines a msg to update/add/remove required attributes from a resticted marker
+MsgUpdateRequiredAttributesRequest defines a msg to update/add/remove required attributes from a restricted marker
 signer must have transfer authority to change attributes, to update attribute add current to remove list and new to
 add list
 
@@ -7529,7 +7529,7 @@ MsgUpdateRequiredAttributesResponse defines the Msg/UpdateRequiredAttributes res
 <a name="provenance-marker-v1-MsgUpdateSendDenyListRequest"></a>
 
 ### MsgUpdateSendDenyListRequest
-MsgUpdateSendDenyListRequest defines a msg to add/remove addresses to send deny list for a resticted marker
+MsgUpdateSendDenyListRequest defines a msg to add/remove addresses to send deny list for a restricted marker
 signer must have transfer authority
 
 
@@ -7937,7 +7937,7 @@ EventMarkerSetDenomMetadata event emitted when metadata is set on marker with de
 <a name="provenance-marker-v1-EventMarkerTransfer"></a>
 
 ### EventMarkerTransfer
-EventMarkerTransfer event emitted when coins are transfered to from account to another
+EventMarkerTransfer event emitted when coins are transferred to from account to another
 
 
 | Field | Type | Label | Description |

--- a/third_party/proto/cosmos/authz/v1beta1/event.proto
+++ b/third_party/proto/cosmos/authz/v1beta1/event.proto
@@ -8,7 +8,7 @@ option go_package = "github.com/cosmos/cosmos-sdk/x/authz";
 
 // EventGrant is emitted on Msg/Grant
 message EventGrant {
-  // Msg type URL for which an autorization is granted
+  // Msg type URL for which an authorization is granted
   string msg_type_url = 2;
   // Granter account address
   string granter = 3 [(cosmos_proto.scalar) = "cosmos.AddressString"];
@@ -18,7 +18,7 @@ message EventGrant {
 
 // EventRevoke is emitted on Msg/Revoke
 message EventRevoke {
-  // Msg type URL for which an autorization is revoked
+  // Msg type URL for which an authorization is revoked
   string msg_type_url = 2;
   // Granter account address
   string granter = 3 [(cosmos_proto.scalar) = "cosmos.AddressString"];

--- a/x/metadata/client/cli/tx.go
+++ b/x/metadata/client/cli/tx.go
@@ -485,7 +485,7 @@ func ModifyOsLocatorCmd() *cobra.Command {
 	return cmd
 }
 
-// WriteScopeSpecificationCmd creates a command for adding scope specificiation
+// WriteScopeSpecificationCmd creates a command for adding scope specification
 func WriteScopeSpecificationCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "write-scope-specification [specification-id] [owner-addresses] [responsible-parties] [contract-specification-ids] [description-name, optional] [description, optional] [website-url, optional] [icon-url, optional]",


### PR DESCRIPTION


### Description
This pull request addresses several typographical errors in the documentation and code comments. The changes include:

1. **Documentation Updates:**
   - Corrected "recieve" to "receive" in `docs/proto-docs.md`.
   - Fixed "resticted" to "restricted" in `docs/proto-docs.md`.
   - Corrected "transfered" to "transferred" in `docs/proto-docs.md`.

2. **Code Comments Updates:**
   - Fixed "authorization" spelling in `third_party/proto/cosmos/authz/v1beta1/event.proto`.
   - Corrected "specification" spelling in `x/metadata/client/cli/tx.go`.

These changes improve the readability and accuracy of the documentation and code comments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected several typographical errors in user-facing documentation and comments, improving clarity and accuracy. No functional changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->