### PR TITLE
ci: bump golangci-lint-action to v8

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,7 @@ jobs:
         if: env.GIT_DIFF
         with:
           go-version-file: 'go.mod'
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v8
         if: env.GIT_DIFF
         with:
           # If you change this version, be sure to also change it in contrib/devtools/Makefile.


### PR DESCRIPTION
Updated golangci-lint-action to v8 for better compatibility with the latest runner environments. Workflows only updated—no functional changes. Release notes: https://github.com/golangci/golangci-lint-action/releases/tag/v8.0.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the GitHub Actions workflow to use a newer version of the linting tool for Go code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->