### PR TITLE
Specific transfer during alyssum upgrade.

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -567,11 +567,11 @@ func Test_v1beta1_MsgExecuteContract_DecodeFromGovProposal(t *testing.T) {
 	}
 	app.GovKeeper.SetProposal(ctx, *&prop)
 	stored, _ := app.GovKeeper.Proposals.Get(ctx, 1)
-	require.NotNil(t, stored,"app.GovKeeper.Proposals.Get()")
+	require.NotNil(t, stored, "app.GovKeeper.Proposals.Get()")
 	for _, msg := range stored.Messages {
 		var unpacked sdk.Msg
 		err := cdc.UnpackAny(msg, &unpacked)
-		require.NoError(t, err,"UnpackAny")
+		require.NoError(t, err, "UnpackAny")
 
 		_, ok := unpacked.(*v1beta1.MsgExecuteContract)
 		require.True(t, ok, "expected v1beta1.MsgExecuteContract")

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -907,6 +907,7 @@ func (s *UpgradeTestSuite) TestAlyssum() {
 		LogMsgPruneIBCExpiredConsensusStates,
 		LogMsgConvertFinishedVestingAccountsToBase,
 		"INF Unlocking select vesting accounts.",
+		"INF Transferring some locked funds.",
 	}
 	s.AssertUpgradeHandlerLogs("alyssum", expInLog, nil)
 }

--- a/x/attribute/keeper/keeper_test.go
+++ b/x/attribute/keeper/keeper_test.go
@@ -1418,7 +1418,7 @@ func (s *KeeperTestSuite) TestValidateAttributeConcreteType() {
 	testCases := []struct {
 		name         string
 		concreteType string
-		expErr       string 
+		expErr       string
 	}{
 		{
 			name:         "Valid type URL",

--- a/x/attribute/simulation/operations_test.go
+++ b/x/attribute/simulation/operations_test.go
@@ -162,7 +162,7 @@ func (s *SimTestSuite) TestSimulateMsgUpdateAttribute() {
 	name := "example.provenance"
 	s.LogIfError(s.app.NameKeeper.SetNameRecord(s.ctx, name, accounts[0].Address, false), "SetNameRecord(%q) error", name)
 	expireTime := GenerateRandomTime(1)
-	attr := types.NewAttribute(name, accounts[1].Address.String(), types.AttributeType_String, []byte("test"), &expireTime,"")
+	attr := types.NewAttribute(name, accounts[1].Address.String(), types.AttributeType_String, []byte("test"), &expireTime, "")
 	s.LogIfError(s.app.AttributeKeeper.SetAttribute(s.ctx, attr, accounts[0].Address), "SetAttribute(%q) error", name)
 
 	// execute operation
@@ -192,7 +192,7 @@ func (s *SimTestSuite) TestSimulateMsgDeleteAttribute() {
 
 	name := "example.provenance"
 	s.LogIfError(s.app.NameKeeper.SetNameRecord(s.ctx, name, accounts[0].Address, false), "SetNameRecord(%q) error", name)
-	attr := types.NewAttribute(name, accounts[1].Address.String(), types.AttributeType_String, []byte("test"), &expireTime,"")
+	attr := types.NewAttribute(name, accounts[1].Address.String(), types.AttributeType_String, []byte("test"), &expireTime, "")
 	s.LogIfError(s.app.AttributeKeeper.SetAttribute(s.ctx, attr, accounts[0].Address), "SetAttribute(%q) error", name)
 
 	// execute operation
@@ -222,7 +222,7 @@ func (s *SimTestSuite) TestSimulateMsgDeleteDistinctAttribute() {
 	name := "example.provenance"
 	expireTime := GenerateRandomTime(1)
 	s.LogIfError(s.app.NameKeeper.SetNameRecord(s.ctx, name, accounts[0].Address, false), "SetNameRecord(%q) error", name)
-	attr := types.NewAttribute(name, accounts[1].Address.String(), types.AttributeType_String, []byte("test"), &expireTime,"")
+	attr := types.NewAttribute(name, accounts[1].Address.String(), types.AttributeType_String, []byte("test"), &expireTime, "")
 	s.LogIfError(s.app.AttributeKeeper.SetAttribute(s.ctx, attr, accounts[0].Address), "SetAttribute(%q) error", name)
 
 	// execute operation


### PR DESCRIPTION
## Description

This transfers some locked funds from one specific account to another, locking them the funds in the destination.
It also fixes a few issues reported by `make lint` (in test files).

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * During the "alyssum" upgrade, a specific amount of locked funds is now transferred between two accounts while preserving the vesting state.

* **Bug Fixes**
  * Improved logging to reflect the transfer of locked funds during the upgrade process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->