### PR TITLE
Create the ConsumeAdditionalFlatFee helper.

### DIFF
--- a/.changelog/unreleased/improvements/2413-consume-usd-fees.md
+++ b/.changelog/unreleased/improvements/2413-consume-usd-fees.md
@@ -1,0 +1,1 @@
+* Create the `ConsumeAdditionalFlatFee` helper for the FlatFeeGasMeter [PR 2413](https://github.com/provenance-io/provenance/pull/2413).

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -30,10 +30,10 @@ import (
 	"github.com/cosmos/gogoproto/proto"
 
 	"github.com/provenance-io/provenance/internal/pioconfig"
+	v1beta1 "github.com/provenance-io/provenance/legacy_protos/cosmwasm/wasm/v1beta1"
 	"github.com/provenance-io/provenance/testutil/assertions"
 	markermodule "github.com/provenance-io/provenance/x/marker"
 	markertypes "github.com/provenance-io/provenance/x/marker/types"
-	v1beta1 "github.com/provenance-io/provenance/legacy_protos/cosmwasm/wasm/v1beta1"
 )
 
 func TestSimAppExportAndBlockedAddrs(t *testing.T) {

--- a/internal/antewrapper/flat_fee_gas_meter.go
+++ b/internal/antewrapper/flat_fee_gas_meter.go
@@ -9,6 +9,7 @@ import (
 	"cosmossdk.io/log"
 	sdkmath "cosmossdk.io/math"
 	storetypes "cosmossdk.io/store/types"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )

--- a/internal/antewrapper/utils.go
+++ b/internal/antewrapper/utils.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/provenance-io/provenance/internal/pioconfig"
 	"github.com/provenance-io/provenance/internal/provutils"
+	flatfees "github.com/provenance-io/provenance/x/flatfees/types"
 )
 
 const (
@@ -54,6 +55,13 @@ type (
 	FlatFeesKeeper interface {
 		CalculateMsgCost(ctx sdk.Context, msgs ...sdk.Msg) (upFront sdk.Coins, onSuccess sdk.Coins, err error)
 		ExpandMsgs(msgs []sdk.Msg) ([]sdk.Msg, error)
+		GetParams(ctx sdk.Context) flatfees.Params
+	}
+
+	// FeeConverter has the methods needed from the flatfees.ConversionFactor type that are needed in here.
+	FeeConverter interface {
+		GetDefinitionAmount() sdk.Coin
+		ConvertCoins(toConvert sdk.Coins) sdk.Coins
 	}
 
 	// FeegrantKeeper defines the expected feegrant keeper.

--- a/internal/handlers/msg_service_router_test.go
+++ b/internal/handlers/msg_service_router_test.go
@@ -616,6 +616,17 @@ func (k *MockFlatFeesKeeper) ExpandMsgs(msgs []sdk.Msg) ([]sdk.Msg, error) {
 	return msgs, nil
 }
 
+func (k *MockFlatFeesKeeper) GetParams(_ sdk.Context) flatfeestypes.Params {
+	return flatfeestypes.Params{
+		// These values were picked arbitrarily since nothing in here should use these values anyway.
+		DefaultCost: sdk.NewInt64Coin("stablecoin", 10),
+		ConversionFactor: flatfeestypes.ConversionFactor{
+			DefinitionAmount: sdk.NewInt64Coin("stablecoin", 100),
+			ConvertedAmount:  sdk.NewInt64Coin("feecoin", 15),
+		},
+	}
+}
+
 func TestHandlersConsumeMsgs(t *testing.T) {
 	pioconfig.SetProvConfig(sdk.DefaultBondDenom) // Set denom as stake.
 	priv, _, addr1 := testdata.KeyTestPubAddr()


### PR DESCRIPTION
## Description

Create the `ConsumeAdditionalFlatFee` helper. It's just like `ConsumeAdditionalFee`, but uses adds the fee in the chain's definition denom (flatfees params) to consume fees in the definition denom which are later converted to the fee denom to be checked and collected at the end of all the Msgs.

E.g. if the chain's definition denom is `musd`, and you had an endpoint that you want to charge an extra 10musd ($0.01) per entry in the endpoint's msg, you could use `ConsumeAdditionaFlatlFee(ctx, uint64(len(msg.Stuff) * 10))`. If there were 7 entries, the amount `70musd` would be added to the `addedFees` field. Then, during `Finalize()` (on the gas meter), the conversion factor is used to convert that into the fee denom. E.g. if the conversion factor is $0.025/hash = 25musd/1000000000hash, then 70musd = 2.8hash, so the `addedFees` would end up being `2800000000nhash` when it comes time to make sure that enough fee was provided, and to collect anything left over.

This will allow endpoints to charge variable amounts but still have them stay flat as the cost of nhash changes.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [x] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for consuming additional flat fees in the fee definition denomination, with automatic conversion to the appropriate denomination during fee calculation.

* **Bug Fixes**
  * Improved handling of added fees to ensure correct conversion and accounting in final fee calculations.

* **Tests**
  * Expanded and enhanced test coverage for fee conversion, added fees handling, and flat fee consumption.
  * Improved mock utilities for more accurate and robust test scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->