### PR TITLE
Update the dependable changelog script to handle semantic flair on the PR title

### DIFF
--- a/.changelog/dependabot-changelog.sh
+++ b/.changelog/dependabot-changelog.sh
@@ -149,16 +149,17 @@ fi
 
 # Okay. There weren't any go.mod changes. It's a bump to something else (e.g. a
 # github action helper). Create an entry ourselves, based on the title, which
-# should look something like this: "Bump <library> from <old version> to <new version>".
-# First, though, standardize the spacing so the rest of the regex stuff is cleaner.
-title="$( sed -E 's/[[:space:]]+/ /; s/^ //; s/ $//;' <<< "$title" )"
+# should look something like this: "Bump <library> from <old version> to <new version>",
+# but might look like this: "chore(deps): bump <library> from <old version> to <new version>".
+# First, remove the semantic flair and standardize the spacing so the rest of the regex stuff is cleaner.
+title="$( sed -E 's/^[^[:space:]]+: //; s/[[:space:]]+/ /; s/^ //; s/ $//;' <<< "$title" )"
 [[ -n "$verbose" ]] && printf 'Clean Title: "%s"\n' "$title"
-if ! grep -Eqi '^Bump [^ ]+ from [^ ]+ to [^ ]+$' <<< "$title"; then
+if ! grep -Eqi '^[Bb]ump [^ ]+ from [^ ]+ to [^ ]+$' <<< "$title"; then
     printf 'Unknown title format: %s\n' "$title"
     exit 1
 fi
 
-lib="$( sed -E 's/^Bump //; s/ from.*$//;' <<< "$title" )"
+lib="$( sed -E 's/^[Bb]ump //; s/ from.*$//;' <<< "$title" )"
 [[ -n "$verbose" ]] && printf '    Library: "%s"\n' "$lib"
 if [[ -z "$lib" || "$lib" == "$title" || "$lib" =~ ' ' ]]; then
     printf 'Could not extract library from title: %s\n' "$title"


### PR DESCRIPTION
## Description

This PR fixes the dependabot changelog script to handle a semantic flair (e.g. "chore(deps): " prefix on the PR title for non-golang dependencies.


---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved handling of PR title formats for dependency updates, allowing for semantic prefixes and case-insensitive matching. This ensures more consistent processing of PR titles with varied formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->