### PR TITLE
Fix metadata lint error

### DIFF
--- a/x/metadata/client/cli/helpers_test.go
+++ b/x/metadata/client/cli/helpers_test.go
@@ -339,7 +339,7 @@ func TestParsePartyType(t *testing.T) {
 		{input: "validator", exp: validator, expErr: ""},
 		{input: "VALIDATOR", exp: validator, expErr: ""},
 		{input: "Validator", exp: validator, expErr: ""},
-		
+
 		{input: "generic_1", exp: generic1, expErr: ""},
 		{input: "GENERIC_1", exp: generic1, expErr: ""},
 		{input: "Generic_1", exp: generic1, expErr: ""},


### PR DESCRIPTION
## Description

Fix a linter error in the metadata module. There's some extra whitespace on one line in a CLI unit test.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Cleaned up whitespace in unit test definitions to improve readability and maintain consistency across the test suite. This change is purely cosmetic and does not modify application behavior, performance, or outputs. No user-facing impact, configuration changes, or migration steps are required. Build and runtime behavior remain unchanged. Release contents are otherwise unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->