### PR TITLE
Fix casing of 'as' in the dockerfiles.

### DIFF
--- a/.changelog/unreleased/improvements/2452-fix-dockerfile-casing.md
+++ b/.changelog/unreleased/improvements/2452-fix-dockerfile-casing.md
@@ -1,0 +1,1 @@
+* Fix the casing of 'as' in our dockerfiles [#2452](https://github.com/provenance-io/provenance/issues/2452).

--- a/docker/blockchain/Dockerfile
+++ b/docker/blockchain/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-bullseye as build
+FROM golang:1.23-bullseye AS build
 ARG VERSION
 
 WORKDIR /go/src/github.com/provenance-io/provenance
@@ -31,7 +31,7 @@ RUN ARCH=$(uname -m) && \
     make VERSION=${VERSION} install
 
 ###
-FROM debian:bullseye-slim as run
+FROM debian:bullseye-slim AS run
 ENV LD_LIBRARY_PATH="/usr/local/lib"
 RUN apt-get update && \
     apt-get upgrade -y && \

--- a/networks/dev/blockchain-dev/Dockerfile
+++ b/networks/dev/blockchain-dev/Dockerfile
@@ -2,7 +2,7 @@
 # Use `make docker-build-dev` to build or `make devnet-start` to
 # start the test network and `make devnet-stop` to stop it.
 
-FROM golang:1.23-bullseye as build-x86_64
+FROM golang:1.23-bullseye AS build-x86_64
 WORKDIR /go/src/github.com/provenance-io/provenance
 ENV GOPRIVATE=github.com/provenance-io
 RUN apt-get update && apt-get upgrade -y
@@ -19,7 +19,7 @@ COPY vendor/ ./vendor/
 RUN go build -mod vendor -ldflags '-w -s -X github.com/cosmos/cosmos-sdk/version.Name=Provenance-Blockchain' -o /go/bin/ ./cmd/...
 
 ## Run provenance for x86_64
-FROM debian:bullseye-slim as provenance-x86_64
+FROM debian:bullseye-slim AS provenance-x86_64
 ENV LOCALNET=1
 ENV LD_LIBRARY_PATH="/usr/local/lib"
 
@@ -48,7 +48,7 @@ CMD ["start"]
 
 
 ## Build provenance for ARM
-FROM golang:1.23-bullseye as build-arm64
+FROM golang:1.23-bullseye AS build-arm64
 WORKDIR /go/src/github.com/provenance-io/provenance
 ENV GOPRIVATE=github.com/provenance-io
 RUN apt-get update && apt-get upgrade -y
@@ -65,7 +65,7 @@ COPY vendor/ ./vendor/
 RUN go build -mod vendor -ldflags '-w -s -X github.com/cosmos/cosmos-sdk/version.Name=Provenance-Blockchain' -o /go/bin/ ./cmd/...
 
 ## Run provenance for ARM
-FROM debian:bullseye-slim as provenance-arm64
+FROM debian:bullseye-slim AS provenance-arm64
 ENV LOCALNET=1
 ENV LD_LIBRARY_PATH="/usr/local/lib"
 

--- a/networks/ibc/blockchain-ibc/Dockerfile
+++ b/networks/ibc/blockchain-ibc/Dockerfile
@@ -3,7 +3,7 @@
 # start the test network and `make localnet-stop` to stop it.
 
 ## Build provenance for x86_64
-FROM golang:1.23-bullseye as build-x86_64
+FROM golang:1.23-bullseye AS build-x86_64
 WORKDIR /go/src/github.com/provenance-io/provenance
 ENV GOPRIVATE=github.com/provenance-io
 RUN apt-get update && apt-get upgrade -y
@@ -20,7 +20,7 @@ COPY vendor/ ./vendor/
 RUN go build -mod vendor -ldflags '-w -s -X github.com/cosmos/cosmos-sdk/version.Name=Provenance-Blockchain' -o /go/bin/ ./cmd/...
 
 ## Run provenance for x86_64
-FROM debian:bullseye-slim as provenance-x86_64
+FROM debian:bullseye-slim AS provenance-x86_64
 ENV LOCALNET=1
 ENV LD_LIBRARY_PATH="/usr/local/lib"
 
@@ -52,7 +52,7 @@ CMD ["start"]
 
 
 ## Build provenance for ARM
-FROM golang:1.23-bullseye as build-arm64
+FROM golang:1.23-bullseye AS build-arm64
 WORKDIR /go/src/github.com/provenance-io/provenance
 ENV GOPRIVATE=github.com/provenance-io
 RUN apt-get update && apt-get upgrade -y
@@ -69,7 +69,7 @@ COPY vendor/ ./vendor/
 RUN go build -mod vendor -ldflags '-w -s -X github.com/cosmos/cosmos-sdk/version.Name=Provenance-Blockchain' -o /go/bin/ ./cmd/...
 
 ## Run provenance for ARM
-FROM debian:bullseye-slim as provenance-arm64
+FROM debian:bullseye-slim AS provenance-arm64
 ENV LOCALNET=1
 ENV LD_LIBRARY_PATH="/usr/local/lib"
 

--- a/networks/ibc/blockchain-relayer/Dockerfile
+++ b/networks/ibc/blockchain-relayer/Dockerfile
@@ -1,12 +1,12 @@
 ## Build provenance for ARM
-FROM golang:1.23-bullseye as build
+FROM golang:1.23-bullseye AS build
 WORKDIR /
 ARG VERSION
 RUN apt-get update && apt-get upgrade -y && apt-get install -y git
 RUN git clone https://github.com/cosmos/relayer.git /relayer && cd /relayer && git checkout "$VERSION" && make install && cd / && rm -rf /relayer
 
 ## Run provenance for ARM
-FROM build as relayer
+FROM build AS relayer
 ARG MNEMONIC
 ENV LD_LIBRARY_PATH="/usr/local/lib"
 

--- a/networks/local/blockchain-local/Dockerfile
+++ b/networks/local/blockchain-local/Dockerfile
@@ -3,7 +3,7 @@
 # start the test network and `make localnet-stop` to stop it.
 
 ## Build provenance for x86_64
-FROM golang:1.23-bullseye as build-x86_64
+FROM golang:1.23-bullseye AS build-x86_64
 WORKDIR /go/src/github.com/provenance-io/provenance
 ENV GOPRIVATE=github.com/provenance-io
 RUN apt-get update && apt-get upgrade -y
@@ -20,7 +20,7 @@ COPY vendor/ ./vendor/
 RUN go build -mod vendor -ldflags '-w -s -X github.com/cosmos/cosmos-sdk/version.Name=Provenance-Blockchain' -o /go/bin/ ./cmd/...
 
 ## Run provenance for x86_64
-FROM debian:bullseye-slim as provenance-x86_64
+FROM debian:bullseye-slim AS provenance-x86_64
 ENV LOCALNET=1
 ENV LD_LIBRARY_PATH="/usr/local/lib"
 
@@ -52,7 +52,7 @@ CMD ["start"]
 
 
 ## Build provenance for ARM
-FROM golang:1.23-bullseye as build-arm64
+FROM golang:1.23-bullseye AS build-arm64
 WORKDIR /go/src/github.com/provenance-io/provenance
 ENV GOPRIVATE=github.com/provenance-io
 RUN apt-get update && apt-get upgrade -y
@@ -69,7 +69,7 @@ COPY vendor/ ./vendor/
 RUN go build -mod vendor -ldflags '-w -s -X github.com/cosmos/cosmos-sdk/version.Name=Provenance-Blockchain' -o /go/bin/ ./cmd/...
 
 ## Run provenance for ARM
-FROM debian:bullseye-slim as provenance-arm64
+FROM debian:bullseye-slim AS provenance-arm64
 ENV LOCALNET=1
 ENV LD_LIBRARY_PATH="/usr/local/lib"
 


### PR DESCRIPTION
## Description

closes: #2452 

Fix the casing of "as" in our dockerfiles. The docker github actions have been complaining about the mismatch between "FROM" and "as" in our dockerfile(s).


---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized Docker multi-stage syntax by capitalizing AS across all Dockerfiles for consistency and build reliability.
  * Enhanced blockchain runtime image: added curl, jq, and libleveldb-dev; cleaned apt caches for slimmer images; bundled provenanced binary; installed architecture-specific libwasmvm libraries; and set PIO_HOME. Existing ports and commands remain unchanged.

* **Chores**
  * Added changelog entry documenting the Dockerfile casing correction (issue #2452).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->