### PR TITLE
Change cost of AddAttribute to 2 cents.

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -64,6 +64,8 @@ var upgrades = map[string]appUpgrade{
 		},
 	},
 	"bouvardia": { // Upgrade for v1.26.0.
+		Added:   []string{flatfeestypes.StoreKey},
+		Deleted: []string{msgfeestypes.StoreKey},
 		Handler: func(ctx sdk.Context, app *App, vm module.VersionMap) (module.VersionMap, error) {
 			var err error
 			if vm, err = runModuleMigrations(ctx, app, vm); err != nil {
@@ -430,6 +432,9 @@ func MakeFlatFeesCosts() []*flatfeestypes.MsgFee {
 		// Msgs that cost $0.005
 		flatfeestypes.NewMsgFee("/provenance.metadata.v1.MsgAddNetAssetValuesRequest", feeDefCoin(5)),
 
+		// Msgs that cost $0.02.
+		flatfeestypes.NewMsgFee("/provenance.attribute.v1.MsgAddAttributeRequest", feeDefCoin(20)),
+
 		// Msgs that cost $0.05.
 		flatfeestypes.NewMsgFee("/cosmos.authz.v1beta1.MsgExec", feeDefCoin(50)),
 		flatfeestypes.NewMsgFee("/cosmos.authz.v1beta1.MsgRevoke", feeDefCoin(50)),
@@ -479,7 +484,6 @@ func MakeFlatFeesCosts() []*flatfeestypes.MsgFee {
 		// The default cost is $0.15. All Msg types not in this list will use the default.
 
 		// Msgs that cost $0.25.
-		flatfeestypes.NewMsgFee("/provenance.attribute.v1.MsgAddAttributeRequest", feeDefCoin(250)),
 		flatfeestypes.NewMsgFee("/provenance.marker.v1.MsgIbcTransferRequest", feeDefCoin(250)),
 		flatfeestypes.NewMsgFee("/provenance.name.v1.MsgBindNameRequest", feeDefCoin(250)),
 		flatfeestypes.NewMsgFee("/provenance.oracle.v1.MsgSendQueryOracleRequest", feeDefCoin(250)),


### PR DESCRIPTION
## Description

It was determined that the extra cost for adding an attribute wasn't helping anything, so we're dropping it back down to normal.

This PR also adds the missing `Added` and `Deleted` fields to the upgrade.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Transaction fee for Add Attribute requests reduced to $0.02, replacing the previous $0.25 tier.
  - Fee table now includes an explicit entry for Add Attribute at the new tier.

- Chores
  - Updated the upcoming “bouvardia” network upgrade metadata to reflect fee module changes, migrating fee storage to the new system and removing the legacy one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->