### PR TITLE
Replace interface{} with any in some lazy and testlog stuff.

### DIFF
--- a/internal/provutils/lazy.go
+++ b/internal/provutils/lazy.go
@@ -61,7 +61,7 @@ func (l *LazyStringer[T]) String() string {
 // See also: LazyStringer
 type LazySprintf struct {
 	format string
-	args   []interface{}
+	args   []any
 }
 
 // NewLazySprintf defers fmt.Sprintf until the Stringer interface is invoked.
@@ -71,7 +71,7 @@ type LazySprintf struct {
 // immediately even if the logger doesn't output anything, so it's best to just provide what you want directly.
 //
 // See also: NewLazyStringer.
-func NewLazySprintf(format string, args ...interface{}) *LazySprintf {
+func NewLazySprintf(format string, args ...any) *LazySprintf {
 	return &LazySprintf{format, args}
 }
 

--- a/testutil/testlog/logs.go
+++ b/testutil/testlog/logs.go
@@ -29,13 +29,13 @@ func WriteSlice[S ~[]E, E any](t testing.TB, name string, vals S) {
 // Then, there'll be one line for each variable, each with the format "<name> = <value>" (with the = lined up).
 //
 // See also: WriteSlice.
-func WriteVariables(t testing.TB, header string, namesAndValues ...interface{}) {
+func WriteVariables(t testing.TB, header string, namesAndValues ...any) {
 	t.Helper()
 	t.Log(newNamedValues(t, namesAndValues).GetLogString(header))
 }
 
 // WriteVariable writes the provided named variable to the test logs in the format "<name> = <value>".
-func WriteVariable(t testing.TB, name string, value interface{}) {
+func WriteVariable(t testing.TB, name string, value any) {
 	t.Helper()
 	t.Logf("%s = %s", name, valueString(value))
 }
@@ -48,11 +48,11 @@ func createSliceLogString[S ~[]E, E any](name string, vals S) string {
 // namedValue associates a name with a value.
 type namedValue struct {
 	Name  string
-	Value interface{}
+	Value any
 }
 
 // newNamedValue creates a new namedValue.
-func newNamedValue(name string, value interface{}) *namedValue {
+func newNamedValue(name string, value any) *namedValue {
 	return &namedValue{Name: name, Value: value}
 }
 
@@ -67,7 +67,7 @@ type namedValues []*namedValue
 // The test fails immediately if an odd number of namesAndValues are provided or if any name args are not a string.
 //
 // E.g. newNamedValues(t, "addr1", addr1, "addr2", addr2)
-func newNamedValues(t testing.TB, namesAndValues []interface{}) namedValues {
+func newNamedValues(t testing.TB, namesAndValues []any) namedValues {
 	t.Helper()
 	if len(namesAndValues) == 0 {
 		return nil
@@ -124,7 +124,7 @@ func (s namedValues) GetLogString(header string) string {
 }
 
 // valueString creates a string of the given value.
-func valueString(value interface{}) string {
+func valueString(value any) string {
 	if value == nil {
 		return "<nil>"
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.

As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.



closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized internal type usage across utility and test logging modules to align with current Go conventions, improving maintainability and type consistency.
  * No changes to runtime behavior or user-facing functionality; logging and formatting behavior remain the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->