### PR TITLE
CI: migrate workflows to checkout v6

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -25,7 +25,7 @@ jobs:
       PR_TARGET: ${{ github.event.pull_request.base.ref }}
     steps:
       - name: Checkout PR Branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           # Depending on your needs, you can use a token that will re-trigger workflows
           # See https://github.com/stefanzweifel/git-auto-commit-action#commits-made-by-this-action-do-not-trigger-new-workflow-runs

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,7 @@ jobs:
   heighliner-docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: docker/setup-buildx-action@v3
 
@@ -75,7 +75,7 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-go@v6
         with:
@@ -118,7 +118,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-go@v6
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: technote-space/get-diff-action@v6.1.2
         with:
           PATTERNS: |

--- a/.github/workflows/proto-registry.yml
+++ b/.github/workflows/proto-registry.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Buf setup action
         uses: bufbuild/buf-setup-action@v1.50.0
       - name: Buf push 'third_party/proto'

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -24,7 +24,7 @@ jobs:
     name: Protobuf Checks
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
     name: Build OSX
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Setup go
         uses: actions/setup-go@v6
         with:
@@ -91,7 +91,7 @@ jobs:
       GOTOOLCHAIN: local
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Setup go
         uses: actions/setup-go@v6
         with:
@@ -119,7 +119,7 @@ jobs:
     name: Protobuf Push
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Buf setup action
         uses: bufbuild/buf-setup-action@v1.50.0
       - name: Buf push 'proto/'
@@ -137,7 +137,7 @@ jobs:
     name: Create Release
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Create release ${{ needs.build_init.outputs.version }}
         uses: actions/create-release@v1
         id: create_release
@@ -161,7 +161,7 @@ jobs:
     name: Attach Release Artifacts
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Setup go
         uses: actions/setup-go@v6
         with:
@@ -224,7 +224,7 @@ jobs:
     name: Java/Kotlin Proto Publishing
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Java Setup
         uses: actions/setup-java@v5
@@ -264,7 +264,7 @@ jobs:
     name: NPM Proto Publishing
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Publish
         uses: provenance-io/npm-publish-action@v1.1
         with:

--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -24,7 +24,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip-sims')"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: technote-space/get-diff-action@v6.1.2
         with:
           PATTERNS: |
@@ -50,7 +50,7 @@ jobs:
     if: needs.setup.outputs.should-run
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Output setup
         run: |
           echo " should-run: [${{ needs.setup.outputs.should-run }}]"
@@ -83,7 +83,7 @@ jobs:
         os: ["ubuntu-latest"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Define test-logs
         id: test-logs
         run: |
@@ -135,7 +135,7 @@ jobs:
         os: ["ubuntu-latest"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Define test-logs
         id: test-logs
         run: |
@@ -172,7 +172,7 @@ jobs:
         os: ["ubuntu-latest"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Define test-logs
         id: test-logs
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
   setup-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: technote-space/get-diff-action@v6.1.2
         with:
           PATTERNS: |
@@ -96,7 +96,7 @@ jobs:
     env:
       LD_LIBRARY_PATH: /usr/local/lib:/usr/local/lib/x86_64-linux-gnu
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           # CodeCov requires fetch-depth > 1
           fetch-depth: 2
@@ -127,7 +127,7 @@ jobs:
     #       it's in the steps below (except the checkout step).
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           # CodeCov requires fetch-depth > 1
           fetch-depth: 2
@@ -186,7 +186,7 @@ jobs:
     env:
       LD_LIBRARY_PATH: /usr/local/lib:/usr/local/lib/x86_64-linux-gnu
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         if: needs.setup-tests.outputs.should-run
         with:


### PR DESCRIPTION
Updates CI to use `actions/checkout@v6` for improved performance and security.

https://github.com/actions/checkout/releases/tag/v6.0.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated all continuous integration and continuous deployment workflow configurations to use the latest version of the repository checkout action. This enhancement applies across all pipeline jobs, improving the reliability and consistency of the build and deployment processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->