### PR TITLE
Change the costs of some msgs.

### DIFF
--- a/.changelog/unreleased/features/2604-upgrade-msg-fees.md
+++ b/.changelog/unreleased/features/2604-upgrade-msg-fees.md
@@ -1,0 +1,1 @@
+* Update costs of msgs `MsgWriteRecordRequest`, `MsgWriteSessionRequest` & `MsgUpdateClient` [#2604](https://github.com/provenance-io/provenance/issues/2604).

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -422,6 +422,9 @@ func setupMsgStoreCodeFee(ctx sdk.Context, app *App) error {
 
 	ctx.Logger().Info("MsgStoreCode flat fee set successfully", "msg_type", msgFee.MsgTypeUrl, "fee_musd", "100000", "fee_usd", "$100")
 
+	return nil
+}
+
 // updateMsgFees updates the flat fees for multiple message types.
 // Metadata operations (record/session writes): Lower fees to encourage usage
 // IBC client updates: Minimal fee for relayer operations

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -1066,6 +1066,7 @@ func (s *UpgradeTestSuite) TestDaisyRC1() {
 		LogMsgPruneIBCExpiredConsensusStates,
 		LogMsgRemoveInactiveValidatorDelegations,
 		LogMsgConvertFinishedVestingAccountsToBase,
+		"INF Updating message fees",
 	}
 	s.AssertUpgradeHandlerLogs("daisy-rc1", expInLog, nil)
 }
@@ -1076,6 +1077,7 @@ func (s *UpgradeTestSuite) TestDaisy() {
 		LogMsgPruneIBCExpiredConsensusStates,
 		LogMsgRemoveInactiveValidatorDelegations,
 		LogMsgConvertFinishedVestingAccountsToBase,
+		"INF Updating message fees",
 	}
 	s.AssertUpgradeHandlerLogs("daisy", expInLog, nil)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
* Change the costs of some msgs
closes: #2604

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [x] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated message fees for provenance and IBC-related message types; these fee adjustments will be applied during the daisy system upgrade.
* **Documentation**
  * Added a changelog entry describing the updated message fees and their impact.
* **Tests**
  * Upgrade tests updated to reflect a new log entry indicating message-fee updates during the upgrade process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->