### PR TITLE
Add duplication checks to CreateSecuritization.

### DIFF
--- a/.changelog/unreleased/improvements/2682-dup-check-securitization.md
+++ b/.changelog/unreleased/improvements/2682-dup-check-securitization.md
@@ -1,0 +1,1 @@
+* Add duplication checks to CreateSecuritization [#2682](https://github.com/provenance-io/provenance/issues/2682).

--- a/x/asset/types/msgs.go
+++ b/x/asset/types/msgs.go
@@ -111,9 +111,14 @@ func (msg MsgCreateSecuritization) ValidateBasic() error {
 		errs = append(errs, NewErrCodeInvalidField("pools", "cannot be empty"))
 	}
 
+	seenPools := make(map[string]int)
 	for i, pool := range msg.Pools {
 		if len(pool) == 0 {
 			errs = append(errs, NewErrCodeInvalidField(fmt.Sprintf("pools[%d]", i), "cannot be empty"))
+		} else if j, found := seenPools[pool]; found {
+			errs = append(errs, NewErrCodeInvalidField("pools", "duplicate pool at index %d and %d", j, i))
+		} else {
+			seenPools[pool] = i
 		}
 	}
 
@@ -121,12 +126,17 @@ func (msg MsgCreateSecuritization) ValidateBasic() error {
 		errs = append(errs, NewErrCodeInvalidField("tranches", "cannot be empty"))
 	}
 
+	seenDenoms := make(map[string]int)
 	for i, tranche := range msg.Tranches {
 		if tranche == nil {
 			errs = append(errs, NewErrCodeInvalidField(fmt.Sprintf("tranches[%d]", i), "cannot be nil"))
 		} else {
 			if err := tranche.Validate(); err != nil {
 				errs = append(errs, NewErrCodeInvalidField(fmt.Sprintf("tranches[%d]", i), "%s", err))
+			} else if j, found := seenDenoms[tranche.Denom]; found {
+				errs = append(errs, NewErrCodeInvalidField("tranches", "duplicate denom %q at index %d and %d", tranche.Denom, j, i))
+			} else {
+				seenDenoms[tranche.Denom] = i
 			}
 		}
 	}

--- a/x/asset/types/msgs_test.go
+++ b/x/asset/types/msgs_test.go
@@ -755,6 +755,50 @@ func TestMsgCreateSecuritization_ValidateBasic(t *testing.T) {
 			},
 			expErr: "invalid signer: decoding bech32 failed: invalid separator index -1: invalid field",
 		},
+		{
+			name: "duplicate pool",
+			msg: MsgCreateSecuritization{
+				Id: "test-sec",
+				Pools: []string{
+					"pool1",
+					"pool2",
+					"pool1",
+				},
+				Tranches: []*sdk.Coin{
+					{
+						Denom:  "tranche1",
+						Amount: sdkmath.NewInt(1000),
+					},
+				},
+				Signer: "cosmos1w6t0l7z0yerj49ehnqwqaayxqpe3u7e23edgma",
+			},
+			expErr: "invalid pools: duplicate pool at index 0 and 2: invalid field",
+		},
+		{
+			name: "duplicate tranche denom",
+			msg: MsgCreateSecuritization{
+				Id: "test-sec",
+				Pools: []string{
+					"pool1",
+				},
+				Tranches: []*sdk.Coin{
+					{
+						Denom:  "tranche1",
+						Amount: sdkmath.NewInt(1000),
+					},
+					{
+						Denom:  "tranche2",
+						Amount: sdkmath.NewInt(2000),
+					},
+					{
+						Denom:  "tranche1",
+						Amount: sdkmath.NewInt(3000),
+					},
+				},
+				Signer: "cosmos1w6t0l7z0yerj49ehnqwqaayxqpe3u7e23edgma",
+			},
+			expErr: `invalid tranches: duplicate denom "tranche1" at index 0 and 2: invalid field`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
* Add duplication checks to CreateSecuritization.
closes: #2682

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added duplication checks for securitization creation to prevent invalid configurations.
  * Validates that pool entries are unique within a securitization.
  * Validates that tranche denominations are unique.
  * Error messages now clearly report the indices of duplicate entries to help users identify and fix configuration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->