### PR TITLE
Fix: PurgeAttribute leaves orphaned expiration lookup entries.

### DIFF
--- a/.changelog/unreleased/bug-fixes/2684-attribute-expiry-lookup.md
+++ b/.changelog/unreleased/bug-fixes/2684-attribute-expiry-lookup.md
@@ -1,0 +1,1 @@
+* PurgeAttribute leaves orphaned expiration lookup entries [#2684](https://github.com/provenance-io/provenance/issues/2684).

--- a/.changelog/unreleased/bug-fixes/2684-attribute-expiry-lookup.md
+++ b/.changelog/unreleased/bug-fixes/2684-attribute-expiry-lookup.md
@@ -1,1 +1,1 @@
-* PurgeAttribute leaves orphaned expiration lookup entries [#2684](https://github.com/provenance-io/provenance/issues/2684).
+* PurgeAttribute no longer leaves orphaned expiration lookup entries [#2684](https://github.com/provenance-io/provenance/issues/2684).

--- a/x/attribute/keeper/keeper.go
+++ b/x/attribute/keeper/keeper.go
@@ -466,23 +466,20 @@ func (k Keeper) PurgeAttribute(ctx sdk.Context, name string, owner sdk.AccAddres
 	}
 	store := ctx.KVStore(k.storeKey)
 	for _, acct := range accts {
-		attrToDelete := k.getAddrAttributesKeysByName(store, acct, name)
-		for _, key := range attrToDelete {
-			store.Delete(key)
-			k.DecAttrNameAddressLookup(ctx, name, acct)
+		attrToDelete := k.getAddrAttributesByName(store, acct, name)
+		for _, attr := range attrToDelete {
+			addrBz := attr.GetAddressBytes()
+			store.Delete(types.AddrAttributeKey(addrBz, attr))
+			k.DecAttrNameAddressLookup(ctx, name, addrBz)
+			k.deleteAttributeExpireLookup(store, attr)
+
+			deleteEvent := types.NewEventAttributeDelete(name, attr.Address, owner.String())
+			if err := ctx.EventManager().EmitTypedEvent(deleteEvent); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
-}
-
-// getAddrAttributesKeysByName returns an list of attribute keys for the an account and attribute name
-func (k Keeper) getAddrAttributesKeysByName(store storetypes.KVStore, acctAddr sdk.AccAddress, attributeName string) (attributeKeys [][]byte) {
-	it := storetypes.KVStorePrefixIterator(store, types.AddrAttributesNameKeyPrefix(acctAddr, attributeName))
-	defer it.Close() //nolint:errcheck // close error safe to ignore in this context.
-	for ; it.Valid(); it.Next() {
-		attributeKeys = append(attributeKeys, it.Key())
-	}
-	return
 }
 
 // A predicate function for matching names
@@ -648,4 +645,18 @@ func (k Keeper) SetAccountData(ctx sdk.Context, addr string, value string) error
 	}
 
 	return ctx.EventManager().EmitTypedEvent(&types.EventAccountDataUpdated{Account: addr})
+}
+
+// getAddrAttributesByName returns a list of attributes for an account and attribute name.
+func (k Keeper) getAddrAttributesByName(store storetypes.KVStore, acctAddr sdk.AccAddress, attributeName string) (attrs []types.Attribute) {
+	it := storetypes.KVStorePrefixIterator(store, types.AddrAttributesNameKeyPrefix(acctAddr, attributeName))
+	defer it.Close() //nolint:errcheck // close error safe to ignore in this context.
+	for ; it.Valid(); it.Next() {
+		attr := types.Attribute{}
+		if err := k.cdc.Unmarshal(it.Value(), &attr); err != nil {
+			continue
+		}
+		attrs = append(attrs, attr)
+	}
+	return
 }

--- a/x/attribute/keeper/keeper.go
+++ b/x/attribute/keeper/keeper.go
@@ -466,7 +466,10 @@ func (k Keeper) PurgeAttribute(ctx sdk.Context, name string, owner sdk.AccAddres
 	}
 	store := ctx.KVStore(k.storeKey)
 	for _, acct := range accts {
-		attrToDelete := k.getAddrAttributesByName(store, acct, name)
+		attrToDelete, err := k.getAddrAttributesByName(store, acct, name)
+		if err != nil {
+			return err
+		}
 		for _, attr := range attrToDelete {
 			addrBz := attr.GetAddressBytes()
 			store.Delete(types.AddrAttributeKey(addrBz, attr))
@@ -648,15 +651,16 @@ func (k Keeper) SetAccountData(ctx sdk.Context, addr string, value string) error
 }
 
 // getAddrAttributesByName returns a list of attributes for an account and attribute name.
-func (k Keeper) getAddrAttributesByName(store storetypes.KVStore, acctAddr sdk.AccAddress, attributeName string) (attrs []types.Attribute) {
+func (k Keeper) getAddrAttributesByName(store storetypes.KVStore, acctAddr sdk.AccAddress, attributeName string) (attrs []types.Attribute, err error) {
 	it := storetypes.KVStorePrefixIterator(store, types.AddrAttributesNameKeyPrefix(acctAddr, attributeName))
 	defer it.Close() //nolint:errcheck // close error safe to ignore in this context.
+	var attributes []types.Attribute
 	for ; it.Valid(); it.Next() {
 		attr := types.Attribute{}
 		if err := k.cdc.Unmarshal(it.Value(), &attr); err != nil {
-			continue
+			return nil, err
 		}
-		attrs = append(attrs, attr)
+		attributes = append(attributes, attr)
 	}
-	return
+	return attributes, nil
 }

--- a/x/attribute/keeper/keeper_test.go
+++ b/x/attribute/keeper/keeper_test.go
@@ -1526,3 +1526,51 @@ func (s *KeeperTestSuite) TestUpdateAttributeNoExpirationStaysNil() {
 	s.Require().Len(attrs, 1, "should have exactly one attribute")
 	s.Assert().Nil(attrs[0].ExpirationDate, "expiration should remain nil for attribute that never had one")
 }
+
+func (s *KeeperTestSuite) TestPurgeAttributeExpirationCleanup() {
+	now := s.ctx.BlockTime()
+	future := now.Add(time.Hour * 24 * 365) // 1 year from now
+
+	attrWithExpiry := types.NewAttribute("example.attribute", s.user1, types.AttributeType_String, []byte("exp1"), &future, "")
+	s.Require().NoError(s.app.AttributeKeeper.SetAttribute(s.ctx, attrWithExpiry, s.user1Addr), "should save attribute with expiration")
+
+	attrNoExpiry := types.NewAttribute("example.attribute", s.user1, types.AttributeType_String, []byte("noexp"), nil, "")
+	s.Require().NoError(s.app.AttributeKeeper.SetAttribute(s.ctx, attrNoExpiry, s.user1Addr), "should save attribute without expiration")
+
+	store := s.ctx.KVStore(s.app.GetKey(types.StoreKey))
+	expireKey := types.AttributeExpireKey(attrWithExpiry)
+	s.Require().NotNil(expireKey, "expiration key should not be nil for attribute with expiration")
+	s.Assert().True(store.Has(expireKey), "expiration entry should exist before purge")
+
+	err := s.app.AttributeKeeper.PurgeAttribute(s.ctx, "example.attribute", s.user1Addr)
+	s.Require().NoError(err, "PurgeAttribute should not error")
+
+	s.Assert().False(store.Has(expireKey), "expiration entry should be removed after purge")
+
+	attrs, err := s.app.AttributeKeeper.GetAllAttributesAddr(s.ctx, s.user1Addr)
+	s.Require().NoError(err, "GetAllAttributesAddr should not error")
+	for _, attr := range attrs {
+		s.Assert().NotEqual("example.attribute", attr.Name, "no attributes with purged name should remain")
+	}
+}
+
+func (s *KeeperTestSuite) TestPurgeAttributeEmitsEvents() {
+	attr1 := types.NewAttribute("example.attribute", s.user1, types.AttributeType_String, []byte("val1"), nil, "")
+	attr2 := types.NewAttribute("example.attribute", s.user1, types.AttributeType_String, []byte("val2"), nil, "")
+	s.Require().NoError(s.app.AttributeKeeper.SetAttribute(s.ctx, attr1, s.user1Addr), "should save attr1")
+	s.Require().NoError(s.app.AttributeKeeper.SetAttribute(s.ctx, attr2, s.user1Addr), "should save attr2")
+
+	s.ctx = s.ctx.WithEventManager(sdk.NewEventManager())
+
+	err := s.app.AttributeKeeper.PurgeAttribute(s.ctx, "example.attribute", s.user1Addr)
+	s.Require().NoError(err, "PurgeAttribute should not error")
+
+	events := s.ctx.EventManager().Events()
+	deleteEventCount := 0
+	for _, event := range events {
+		if event.Type == "provenance.attribute.v1.EventAttributeDelete" {
+			deleteEventCount++
+		}
+	}
+	s.Assert().Equal(2, deleteEventCount, "should emit one EventAttributeDelete per purged attribute")
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
* PurgeAttribute leaves orphaned expiration lookup entries.
closes: #2684

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Purging attributes now removes all associated expiration lookup entries and related lookup data, preventing orphaned expiration records and ensuring proper cleanup.
  * Purge failures are surfaced if attribute deletion events cannot be emitted.

* **Tests**
  * Added tests verifying expiration lookup cleanup when attributes are purged.
  * Added tests confirming deletion events are emitted for purged attributes.

* **Documentation**
  * Added an unreleased changelog entry documenting the bug fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->