### PR TITLE
Update the cost of a market commitment settlement.

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -393,6 +393,10 @@ func updateMsgFees(ctx sdk.Context, app *App) error {
 			MsgTypeUrl: "/provenance.flatfees.v1.MsgRemoveOracleAddressRequest",
 			Cost:       sdk.NewCoins(sdk.NewInt64Coin("musd", 0)), // free (gov prop msg)
 		},
+		{
+			MsgTypeUrl: "/provenance.exchange.v1.MsgMarketCommitmentSettleRequest",
+			Cost:       sdk.NewCoins(sdk.NewInt64Coin("musd", 50)), // $0.05
+		},
 	}
 
 	for _, msgFee := range feeUpdates {


### PR DESCRIPTION
## Description

In the `daisy` upgrades, set the cost of a `MarketCommitmentSettle` to $0.05 (from the default $0.15).

Figure is planning on issuing more and smaller such msgs. Overall amount spent should end up going up even with this price reduction.

This will put that msg a little on the cheap side. According to gas data from before flatfees, such a msg was costing about $0.12.

Since `testnet` has already had the `daisy-rc1` upgrade applied to it, it won't get this change. On testnet, a gov prop will be used to change the cost of that msg.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
