### PR TITLE
clean up settlement records when destroying a ledger.

### DIFF
--- a/.changelog/unreleased/bug-fixes/2698-ledger-clean-settlements.md
+++ b/.changelog/unreleased/bug-fixes/2698-ledger-clean-settlements.md
@@ -1,0 +1,1 @@
+* Ensure DestroyLedger removes settlement instructions to prevent orphaned records in FundTransfersWithSettlement [#2698](https://github.com/provenance-io/provenance/issues/2698).

--- a/x/ledger/keeper/ledger.go
+++ b/x/ledger/keeper/ledger.go
@@ -408,6 +408,23 @@ func (k Keeper) DestroyLedger(ctx context.Context, lk *types.LedgerKey) error {
 		}
 	}
 
+	// Collect all settlement instructions for this ledger using the keyStr prefix.
+	settlementKeysToRemove := make([]collections.Pair[string, string], 0)
+	if err := k.FundTransfersWithSettlement.Walk(ctx, prefix,
+		func(key collections.Pair[string, string], _ types.StoredSettlementInstructions) (stop bool, err error) {
+			settlementKeysToRemove = append(settlementKeysToRemove, key)
+			return false, nil
+		}); err != nil {
+		return err
+	}
+
+	// Remove all settlement instructions associated with this ledger.
+	for _, key := range settlementKeysToRemove {
+		if err := k.FundTransfersWithSettlement.Remove(ctx, key); err != nil {
+			return err
+		}
+	}
+
 	// Emit the ledger destroyed event to notify other modules.
 	if err := sdk.UnwrapSDKContext(ctx).EventManager().EmitTypedEvent(types.NewEventLedgerDestroyed(lk)); err != nil {
 		return err

--- a/x/ledger/keeper/ledger_test.go
+++ b/x/ledger/keeper/ledger_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"cosmossdk.io/collections"
 	"cosmossdk.io/math"
 	"cosmossdk.io/x/nft"
 
@@ -9,6 +10,7 @@ import (
 
 	"github.com/provenance-io/provenance/x/ledger/keeper"
 	"github.com/provenance-io/provenance/x/ledger/types"
+	ledger "github.com/provenance-io/provenance/x/ledger/types"
 )
 
 func (s *TestSuite) TestNonExistentDenom() {
@@ -1020,4 +1022,47 @@ func (s *TestSuite) TestLedgersQueryServer() {
 			}
 		})
 	}
+}
+
+func (s *MsgServerTestSuite) TestDestroyAlsoRemovesStoredSettlementInstructions() {
+	keyStr := s.existingLedger.Key.String()
+
+	// Seed two settlement rows different correlation IDs against the existing ledger.
+	seed := func(correlationID string) {
+		s.Require().NoError(
+			s.keeper.FundTransfersWithSettlement.Set(
+				s.ctx,
+				collections.Join(keyStr, correlationID),
+				ledger.StoredSettlementInstructions{},
+			),
+			"seeding settlement %q", correlationID,
+		)
+	}
+	seed("corr-1")
+	seed("corr-2")
+
+	for _, corr := range []string{"corr-1", "corr-2"} {
+		has, err := s.keeper.FundTransfersWithSettlement.Has(s.ctx, collections.Join(keyStr, corr))
+		s.Require().NoError(err, "Has(%q) before destroy", corr)
+		s.Require().True(has, "expected settlement %q to be seeded before destroy", corr)
+	}
+
+	msgServer := keeper.NewMsgServer(s.keeper)
+	resp, err := msgServer.Destroy(s.ctx, &ledger.MsgDestroyRequest{
+		Key:    s.existingLedger.Key,
+		Signer: s.validAddress1.String(),
+	})
+	s.Require().NoError(err, "Destroy should succeed")
+	s.Require().Equal(&ledger.MsgDestroyResponse{}, resp)
+
+	for _, corr := range []string{"corr-1", "corr-2"} {
+		has, err := s.keeper.FundTransfersWithSettlement.Has(s.ctx, collections.Join(keyStr, corr))
+		s.Require().NoError(err, "Has(%q) after destroy", corr)
+		s.Require().False(has, "expected settlement %q to be removed by Destroy", corr)
+	}
+
+	// No settlement row anywhere should still reference this ledger.
+	all, err := s.keeper.GetAllSettlements(s.ctx, &keyStr)
+	s.Require().NoError(err, "GetAllSettlements after destroy")
+	s.Require().Empty(all, "no settlements should remain for the destroyed ledger")
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
* clean up settlement records when destroying a ledger.
closes: #2698

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [x] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ledger destruction to fully remove all associated settlement instructions so no orphaned settlement records remain; destroying a ledger now consistently clears related settlement data to preserve data consistency and system integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->