### PR TITLE
Make GetWhitelistedQuery return a copy of the query response

### DIFF
--- a/.changelog/unreleased/bug-fixes/2701-stargate-query-data-race.md
+++ b/.changelog/unreleased/bug-fixes/2701-stargate-query-data-race.md
@@ -1,0 +1,1 @@
+* Make GetWhitelistedQuery return a copy of the query response [#2701](https://github.com/provenance-io/provenance/issues/2701).

--- a/internal/provwasm/stargate_whitelist.go
+++ b/internal/provwasm/stargate_whitelist.go
@@ -2,6 +2,7 @@ package provwasm
 
 import (
 	"fmt"
+	"reflect"
 	"sync"
 
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
@@ -358,7 +359,17 @@ func GetWhitelistedQuery(queryPath string) (proto.Message, error) {
 	if !ok {
 		return nil, wasmvmtypes.Unknown{}
 	}
-	return protoResponseType, nil
+	// Build a fresh zero-value instance of the same concrete type.
+	rt := reflect.TypeOf(protoResponseType)
+	if rt.Kind() != reflect.Ptr {
+		return nil, wasmvmtypes.Unknown{}
+	}
+	freshAny := reflect.New(rt.Elem()).Interface()
+	fresh, ok := freshAny.(proto.Message)
+	if !ok {
+		return nil, wasmvmtypes.Unknown{}
+	}
+	return fresh, nil
 }
 
 func setWhitelistedQuery(queryPath string, protoType proto.Message) {

--- a/internal/provwasm/stargate_whitelist.go
+++ b/internal/provwasm/stargate_whitelist.go
@@ -198,7 +198,7 @@ func init() {
 	setWhitelistedQuery("/cosmos.upgrade.v1beta1.Query/Authority", &upgradetypes.QueryAuthorityResponse{})
 
 	// wasm
-	setWhitelistedQuery("/cosmwasm.wasm.v1.Query/ContractHistory", &wasmtypes.QueryContractInfoResponse{})
+	setWhitelistedQuery("/cosmwasm.wasm.v1.Query/ContractHistory", &wasmtypes.QueryContractHistoryResponse{})
 	setWhitelistedQuery("/cosmwasm.wasm.v1.Query/ContractsByCode", &wasmtypes.QueryContractsByCodeResponse{})
 	setWhitelistedQuery("/cosmwasm.wasm.v1.Query/SmartContractState", &wasmtypes.QuerySmartContractStateResponse{})
 	setWhitelistedQuery("/cosmwasm.wasm.v1.Query/Code", &wasmtypes.QueryCodeResponse{})

--- a/internal/provwasm/stargate_whitelist_test.go
+++ b/internal/provwasm/stargate_whitelist_test.go
@@ -1,10 +1,14 @@
 package provwasm_test
 
 import (
+	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/cosmos/gogoproto/proto"
 	provapp "github.com/provenance-io/provenance/app"
 	"github.com/provenance-io/provenance/internal/provwasm"
 	"github.com/stretchr/testify/require"
@@ -33,4 +37,55 @@ func Test_StargateWhitelistedURLs(t *testing.T) {
 			require.NotNilf(t, route, "expected router to have a route for path %q", p)
 		})
 	}
+}
+func Test_GetWhitelistedQueryReturnsFreshInstance(t *testing.T) {
+	const path = "/cosmos.auth.v1beta1.Query/Account"
+
+	first, err := provwasm.GetWhitelistedQuery(path)
+	require.NoError(t, err, "first GetWhitelistedQuery call")
+	require.NotNil(t, first)
+
+	second, err := provwasm.GetWhitelistedQuery(path)
+	require.NoError(t, err, "second GetWhitelistedQuery call")
+	require.NotNil(t, second)
+
+	require.NotSamef(t, first, second,
+		"GetWhitelistedQuery must return a fresh instance per call; got the same pointer twice")
+
+	require.Equal(t,
+		reflect.TypeOf(first),
+		reflect.TypeOf(second),
+		"both calls should return the same concrete type")
+
+	if acct, ok := first.(*authtypes.QueryAccountResponse); ok {
+		acct.Reset()
+	}
+	require.NotSamef(t, first, second, "still distinct instances after mutation")
+}
+
+func Test_GetWhitelistedQueryConcurrentSafe(t *testing.T) {
+	const path = "/cosmos.bank.v1beta1.Query/Balance"
+	const goroutines = 64
+
+	results := make(chan proto.Message, goroutines)
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			m, err := provwasm.GetWhitelistedQuery(path)
+			require.NoError(t, err)
+			results <- m
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	seen := make(map[proto.Message]struct{}, goroutines)
+	for m := range results {
+		_, dup := seen[m]
+		require.Falsef(t, dup, "GetWhitelistedQuery returned a duplicate pointer under concurrency")
+		seen[m] = struct{}{}
+	}
+	require.Lenf(t, seen, goroutines, "expected %d distinct pointers", goroutines)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
* Make GetWhitelistedQuery return a copy of the query response
closes: #2701 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a data-race by ensuring query responses are returned as independent copies rather than shared instances.
* **Tests**
  * Added unit and concurrency tests confirming each query call yields a fresh, distinct response instance under sequential and concurrent use.
* **Documentation**
  * Added an unreleased changelog entry documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->