### PR TITLE
Add missing ledger_class_id to CLI ledger response

### DIFF
--- a/.changelog/unreleased/bug-fixes/2692-query-ledger.md
+++ b/.changelog/unreleased/bug-fixes/2692-query-ledger.md
@@ -1,0 +1,1 @@
+* Add missing ledger_class_id to CLI ledger response [#2692](https://github.com/provenance-io/provenance/issues/2692).

--- a/x/ledger/client/cli/query.go
+++ b/x/ledger/client/cli/query.go
@@ -89,6 +89,7 @@ func GetCmd() *cobra.Command {
 			// Convert to PlainText
 			plainText := LedgerPlainText{
 				Key:                        req.Key,
+				LedgerClassId:              l.Ledger.LedgerClassId,
 				Status:                     strconv.Itoa(int(l.Ledger.StatusTypeId)),
 				NextPmtDate:                helper.EpochDaysToYMD(l.Ledger.NextPmtDate),
 				NextPmtAmt:                 nextPmtAmt,

--- a/x/ledger/client/cli/query_format.go
+++ b/x/ledger/client/cli/query_format.go
@@ -11,6 +11,8 @@ import (
 type LedgerPlainText struct {
 	// Ledger key
 	Key *ledger.LedgerKey `json:"key,omitempty"`
+	// Ledger Class Id
+	LedgerClassId string `json:"ledger_class_id,omitempty"`
 	// Status of the ledger
 	Status string `json:"status,omitempty"`
 	// Next payment date

--- a/x/ledger/keeper/query_server_test.go
+++ b/x/ledger/keeper/query_server_test.go
@@ -54,6 +54,7 @@ func (s *TestSuite) TestLedgerQueryServer_LedgerAndEntries() {
 	s.Require().NoError(err)
 	s.Require().NotNil(lresp)
 	s.Require().NotNil(lresp.Ledger)
+	s.Require().Equal(s.validLedgerClass.LedgerClassId, lresp.Ledger.LedgerClassId, "Ledger.LedgerClassId")
 
 	// Query Ledgers
 	lsresp, err := qs.Ledgers(s.ctx, &ledger.QueryLedgersRequest{Pagination: &query.PageRequest{CountTotal: true}})


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
* Add missing ledger_class_id to CLI ledger response
closes: #2692 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where the ledger class ID was missing from the ledger query command-line response. The identifier is now properly included when querying ledger information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->