### PR TITLE
Store a backup flatfees gas meter in the context.

### DIFF
--- a/.changelog/unreleased/bug-fixes/2727-gas-limited-flat-fees.md
+++ b/.changelog/unreleased/bug-fixes/2727-gas-limited-flat-fees.md
@@ -1,0 +1,1 @@
+* Store a backup flatfees gas meter in the context [PR 2727](https://github.com/provenance-io/provenance/pull/2727).

--- a/internal/antewrapper/decorator_context_setup.go
+++ b/internal/antewrapper/decorator_context_setup.go
@@ -67,7 +67,10 @@ func (d ProvSetUpContextDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simula
 	// Note that SetGasMeter uses an infinite gas meter if simulating or at height 0 (init genesis).
 	newCtx = ante.SetGasMeter(simulate, ctx, gasLimit)
 	// Now wrap that gas meter in our flat-fee gas meter.
-	newCtx = ctx.WithGasMeter(NewFlatFeeGasMeter(newCtx.GasMeter(), newCtx.Logger(), d.ffk))
+	ffgm := NewFlatFeeGasMeter(newCtx.GasMeter(), newCtx.Logger(), d.ffk)
+	newCtx = ctx.WithGasMeter(ffgm)
+	// Add a second copy to the context as a backup in case the main gas meter is overwritten.
+	newCtx = SetFlatFeeGasMeterBackup(newCtx, ffgm)
 	// Note: We don't set the costs yet because we want to check a few more things before doing that work.
 
 	// Ensure that the requested gas does not exceed either the configured block maximum, or the tx maximum.

--- a/internal/antewrapper/flat_fee_gas_meter.go
+++ b/internal/antewrapper/flat_fee_gas_meter.go
@@ -352,13 +352,38 @@ func (g *FlatFeeGasMeter) getDefinitionDenom(ctx sdk.Context) string {
 	return g.feeConverter.GetDefinitionAmount().Denom
 }
 
+// flatFeeGasMeterContextKey is a private struct used as a context key to hold a FlatFeeGasMeter.
+type flatFeeGasMeterContextKey struct{}
+
+// SetFlatFeeGasMeterBackup stores the provided FlatFeeGasMeter in the context in a backup location.
+func SetFlatFeeGasMeterBackup(ctx sdk.Context, gm *FlatFeeGasMeter) sdk.Context {
+	return ctx.WithValue(flatFeeGasMeterContextKey{}, gm)
+}
+
+// getFlatFeeGasMeterBackup gets the backup FlatFeeGasMeter from the context.
+func getFlatFeeGasMeterBackup(ctx sdk.Context) *FlatFeeGasMeter {
+	rawValue := ctx.Value(flatFeeGasMeterContextKey{})
+	if rawValue == nil {
+		return nil
+	}
+	rv, ok := rawValue.(*FlatFeeGasMeter)
+	if !ok {
+		return nil
+	}
+	return rv
+}
+
 // GetFlatFeeGasMeter will extract the flat fee gas meter from the ctx.
 func GetFlatFeeGasMeter(ctx sdk.Context) (*FlatFeeGasMeter, error) {
-	rv, ok := ctx.GasMeter().(*FlatFeeGasMeter)
-	if !ok {
-		return nil, sdkerrors.ErrLogic.Wrapf("gas meter is not a FlatFeeGasMeter: %T", ctx.GasMeter())
+	if rv, ok := ctx.GasMeter().(*FlatFeeGasMeter); ok {
+		return rv, nil
 	}
-	return rv, nil
+	// In some cases, the SDK auto-replaces the gas meter in the context.
+	// For those situations, we grab the backup flatfees gas meter and return that.
+	if rv := getFlatFeeGasMeterBackup(ctx); rv != nil {
+		return rv, nil
+	}
+	return nil, sdkerrors.ErrLogic.Wrapf("gas meter is not a FlatFeeGasMeter: %T", ctx.GasMeter())
 }
 
 // ConsumeMsg will get the FlatFeeGasMeter from the context and call ConsumeMsg with the provided msg.

--- a/internal/antewrapper/flat_fee_gas_meter_test.go
+++ b/internal/antewrapper/flat_fee_gas_meter_test.go
@@ -1984,7 +1984,7 @@ func TestConsumeMsg(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := sdk.Context{}.WithGasMeter(tc.ctxGM)
+			ctx := sdk.Context{}.WithContext(context.Background()).WithGasMeter(tc.ctxGM)
 			testFunc := func() {
 				ConsumeMsg(ctx, tc.msgs...)
 			}
@@ -2048,7 +2048,7 @@ func TestConsumeAdditionalFee(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := sdk.Context{}.WithGasMeter(tc.ctxGM)
+			ctx := sdk.Context{}.WithContext(context.Background()).WithGasMeter(tc.ctxGM)
 			testFunc := func() {
 				ConsumeAdditionalFee(ctx, tc.fee)
 			}
@@ -2142,7 +2142,7 @@ func TestConsumeAdditionalFlatFee(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := sdk.Context{}.WithGasMeter(tc.ctxGM)
+			ctx := sdk.Context{}.WithContext(context.Background()).WithGasMeter(tc.ctxGM)
 			testFunc := func() {
 				ConsumeAdditionalFlatFee(ctx, tc.amt)
 			}

--- a/internal/antewrapper/flat_fee_gas_meter_test.go
+++ b/internal/antewrapper/flat_fee_gas_meter_test.go
@@ -2,6 +2,7 @@ package antewrapper
 
 import (
 	"bytes"
+	"context"
 	"strconv"
 	"strings"
 	"testing"
@@ -1796,25 +1797,32 @@ func TestGetFlatFeeGasMeter(t *testing.T) {
 		require.NoError(t, err, "ParseCoinNormalized(%q)", coins)
 		return rv
 	}
+	newCtx := func() sdk.Context {
+		return sdk.Context{}.WithContext(context.Background())
+	}
 
 	tests := []struct {
 		name   string
+		ctx    sdk.Context
 		ctxGM  storetypes.GasMeter
 		expGM  *FlatFeeGasMeter
 		expErr string
 	}{
 		{
 			name:   "nil gas meter",
+			ctx:    newCtx(),
 			ctxGM:  nil,
 			expErr: "gas meter is not a FlatFeeGasMeter: <nil>: internal logic error",
 		},
 		{
 			name:   "not a flat-fee gas meter",
+			ctx:    newCtx(),
 			ctxGM:  NewMockGasMeter(),
 			expErr: "gas meter is not a FlatFeeGasMeter: *antewrapper.MockGasMeter: internal logic error",
 		},
 		{
 			name: "flat-fee gas meter",
+			ctx:  newCtx(),
 			ctxGM: &FlatFeeGasMeter{
 				upFrontCost:   cz("12nhash"),
 				onSuccessCost: cz("48nhash"),
@@ -1828,11 +1836,29 @@ func TestGetFlatFeeGasMeter(t *testing.T) {
 				msgTypeURLs:   []string{"abc", "xyz"},
 			},
 		},
+		{
+			name: "not a flat-fee gas meter, but backup is set",
+			ctx: SetFlatFeeGasMeterBackup(newCtx(),
+				&FlatFeeGasMeter{
+					upFrontCost:   cz("13nhash"),
+					onSuccessCost: cz("49nhash"),
+					addedFees:     cz("13usdc"),
+					msgTypeURLs:   []string{"def", "uvw"},
+				},
+			),
+			ctxGM: NewMockGasMeter(),
+			expGM: &FlatFeeGasMeter{
+				upFrontCost:   cz("13nhash"),
+				onSuccessCost: cz("49nhash"),
+				addedFees:     cz("13usdc"),
+				msgTypeURLs:   []string{"def", "uvw"},
+			},
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := sdk.Context{}.WithGasMeter(tc.ctxGM)
+			ctx := tc.ctx.WithGasMeter(tc.ctxGM)
 
 			var actGM *FlatFeeGasMeter
 			var err error


### PR DESCRIPTION
## Description

Store a backup flatfees gas meter in the context so that fees can be recorded even if something else changes the gas meter.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where the flat-fee gas meter could be lost during transaction processing. Implemented a backup mechanism that preserves the flat-fee gas meter in the execution context and provides automatic fallback retrieval. This ensures reliable access to fee calculations throughout the entire transaction execution cycle, even when the primary gas meter is replaced.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/provenance-io/provenance/pull/2727?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->