### PR TITLE
Make the Wasm GRPC Querier return the correct response types.

### DIFF
--- a/.changelog/unreleased/bug-fixes/2728-better-whitelist-queries.md
+++ b/.changelog/unreleased/bug-fixes/2728-better-whitelist-queries.md
@@ -1,0 +1,1 @@
+* Make the Wasm GRPC Querier return the correct response types [PR 2728](https://github.com/provenance-io/provenance/pull/2728).

--- a/.changelog/unreleased/dependencies/2728-better-whitelist-queries.md
+++ b/.changelog/unreleased/dependencies/2728-better-whitelist-queries.md
@@ -1,0 +1,1 @@
+* `github.com/CosmWasm/wasmvm/v2` removed at v2.3.2 [PR 2728](https://github.com/provenance-io/provenance/pull/2728).

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	cosmossdk.io/x/tx v0.14.0
 	cosmossdk.io/x/upgrade v0.2.0
 	github.com/CosmWasm/wasmd v0.61.8
-	github.com/CosmWasm/wasmvm/v2 v2.3.2
 	github.com/CosmWasm/wasmvm/v3 v3.0.3
 	github.com/cometbft/cometbft v0.38.21
 	github.com/cometbft/cometbft-db v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,6 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c h1:pxW6RcqyfI9/kWtOwnv/G+AzdKuy2ZrqINhenH4HyNs=
 github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/CosmWasm/wasmvm/v2 v2.3.2 h1:LO6+G9iG3Hg6EezxfMWX5TMx6a5DbuKGwZv6BSdtXfA=
-github.com/CosmWasm/wasmvm/v2 v2.3.2/go.mod h1:RzLlMwFRLaTwPM0DdHFA0m/APT5muKjU6t3ZxCrpXJ0=
 github.com/CosmWasm/wasmvm/v3 v3.0.3 h1:rg8cZ2qXFj3HwUOqni53OZV/oTvmA2mTVabKA7L0sro=
 github.com/CosmWasm/wasmvm/v3 v3.0.3/go.mod h1:oknpb1bFERvvKcY7vHRp1F/Y/z66xVrsl7n9uWkOAlM=
 github.com/Crocmagnon/fatcontext v0.5.2 h1:vhSEg8Gqng8awhPju2w7MKHqMlg4/NI+gSDHtR3xgwA=

--- a/internal/provwasm/query_plugins.go
+++ b/internal/provwasm/query_plugins.go
@@ -52,7 +52,7 @@ func QueryPlugins(queryRouter baseapp.GRPCQueryRouter, cdc codec.Codec) *wasmkee
 
 	return &wasmkeeper.QueryPlugins{
 		Stargate: StargateQuerier(queryRouter, stargateCdc),
-		Grpc:     GrpcQuerier(queryRouter),
+		Grpc:     GrpcQuerier(queryRouter, stargateCdc),
 	}
 }
 
@@ -87,9 +87,9 @@ func StargateQuerier(queryRouter baseapp.GRPCQueryRouter, cdc codec.Codec) func(
 }
 
 // GrpcQuerier dispatches whitelisted queries and returns protobuf encoded responses
-func GrpcQuerier(queryRouter baseapp.GRPCQueryRouter) func(ctx sdk.Context, request *wasmvmtypes.GrpcQuery) (proto.Message, error) {
+func GrpcQuerier(queryRouter baseapp.GRPCQueryRouter, cdc codec.Codec) func(ctx sdk.Context, request *wasmvmtypes.GrpcQuery) (proto.Message, error) {
 	return func(ctx sdk.Context, request *wasmvmtypes.GrpcQuery) (proto.Message, error) {
-		_, err := GetWhitelistedQuery(request.Path)
+		protoRespType, err := GetWhitelistedQuery(request.Path)
 		if err != nil {
 			return nil, err
 		}
@@ -107,7 +107,14 @@ func GrpcQuerier(queryRouter baseapp.GRPCQueryRouter) func(ctx sdk.Context, requ
 			return nil, err
 		}
 
-		return res, nil
+		if err = cdc.Unmarshal(res.Value, protoRespType); err != nil {
+			return nil, wasmvmtypes.InvalidResponse{
+				Err:      fmt.Sprintf("error unmarshalling response into %T: %v", protoRespType, err),
+				Response: res.Value,
+			}
+		}
+
+		return protoRespType, nil
 	}
 }
 

--- a/internal/provwasm/stargate_whitelist.go
+++ b/internal/provwasm/stargate_whitelist.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
-	wasmvmtypes "github.com/CosmWasm/wasmvm/v2/types"
+	wasmvmtypes "github.com/CosmWasm/wasmvm/v3/types"
 	vaulttypes "github.com/provlabs/vault/types"
 
 	circuittypes "cosmossdk.io/x/circuit/types"


### PR DESCRIPTION
## Description

Make the Wasm GRPC Querier return the correct response types.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Wasm GRPC Querier to return correct response types for whitelisted queries.

* **Dependencies**
  * Upgraded wasmvm dependency from v2 to v3.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/provenance-io/provenance/pull/2728?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->