### PR TITLE
Attributes: Truncate the expiration date to the second and include the current second in the entries deleted.

### DIFF
--- a/.changelog/unreleased/bug-fixes/2729-attr-exp-edge-case.md
+++ b/.changelog/unreleased/bug-fixes/2729-attr-exp-edge-case.md
@@ -1,0 +1,2 @@
+* Attributes: Truncate the expirate date to the second [PR 2729](https://github.com/provenance-io/provenance/pull/2729).
+* Attributes: Include the current block second when finding expired attributes to delete [PR 2729](https://github.com/provenance-io/provenance/pull/2729).

--- a/x/attribute/keeper/keeper.go
+++ b/x/attribute/keeper/keeper.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"strings"
+	"time"
 
 	"cosmossdk.io/log"
 	storetypes "cosmossdk.io/store/types"
@@ -544,7 +545,10 @@ func (k Keeper) DeleteExpiredAttributes(ctx sdk.Context, limit int) int {
 	expirationKeys := [][]byte{}
 	store := ctx.KVStore(k.storeKey)
 
-	iterator := store.Iterator(types.AttributeExpirationKeyPrefix, types.GetAttributeExpireTimePrefix(ctx.BlockTime()))
+	// The ending for iterators is exclusive. So we need to add a second to the blocktime to include entries that
+	// expire exactly on the block time.
+	endDateTime := ctx.BlockTime().Truncate(time.Second).Add(time.Second)
+	iterator := store.Iterator(types.AttributeExpirationKeyPrefix, types.GetAttributeExpireTimePrefix(endDateTime))
 	for ; iterator.Valid(); iterator.Next() {
 		expirationKeys = append(expirationKeys, iterator.Key())
 	}
@@ -599,8 +603,8 @@ func (k Keeper) deleteAttributeExpireLookup(store storetypes.KVStore, attr types
 
 // ValidateExpirationDate returns error if attribute has an expiration date that is in the past of current block time
 func (k Keeper) ValidateExpirationDate(ctx sdk.Context, attr types.Attribute) error {
-	if attr.ExpirationDate != nil && attr.ExpirationDate.Unix() < ctx.BlockTime().Unix() {
-		return fmt.Errorf("attribute expiration date %v is before block time of %v", attr.ExpirationDate.UTC(), ctx.BlockTime().UTC())
+	if attr.ExpirationDate != nil && !attr.ExpirationDate.After(ctx.BlockTime()) {
+		return fmt.Errorf("attribute expiration date %v is not after block time of %v", attr.ExpirationDate.UTC(), ctx.BlockTime().UTC())
 	}
 	return nil
 }

--- a/x/attribute/keeper/keeper_test.go
+++ b/x/attribute/keeper/keeper_test.go
@@ -139,7 +139,7 @@ func (s *KeeperTestSuite) TestSetAttribute() {
 				ExpirationDate: &past,
 			},
 			ownerAddr: s.user1Addr,
-			errorMsg:  fmt.Sprintf("attribute expiration date %v is before block time of %v", past.UTC(), s.ctx.BlockTime().UTC()),
+			errorMsg:  fmt.Sprintf("attribute expiration date %v is not after block time of %v", past.UTC(), s.ctx.BlockTime().UTC()),
 		},
 		{
 			name: "should fail due to attribute length too long",
@@ -486,7 +486,7 @@ func (s *KeeperTestSuite) TestUpdateAttributeExpiration() {
 				AttributeType:  types.AttributeType_String,
 				ExpirationDate: &past,
 			},
-			errorMsg:  fmt.Sprintf("attribute expiration date %v is before block time of %v", past.UTC(), s.ctx.BlockTime().UTC()),
+			errorMsg:  fmt.Sprintf("attribute expiration date %v is not after block time of %v", past.UTC(), s.ctx.BlockTime().UTC()),
 			ownerAddr: s.user1Addr,
 		},
 		{
@@ -1042,10 +1042,11 @@ func (s *KeeperTestSuite) TestDeleteExpiredAttributes() {
 	past := s.startBlockTime.Add(-2 * time.Hour)
 	future := s.startBlockTime.Add(time.Hour)
 
-	s.ctx = s.ctx.WithBlockTime(past)
+	s.ctx = s.ctx.WithBlockTime(past.Add(-1 * time.Second))
 	s.Require().NoError(s.app.NameKeeper.SetNameRecord(s.ctx, "one.expire.testing", s.user1Addr, false), "SetNameRecord one.expire.testing")
 	s.Require().NoError(s.app.NameKeeper.SetNameRecord(s.ctx, "two.expire.testing", s.user1Addr, false), "SetNameRecord two.expire.testing")
 	s.Require().NoError(s.app.NameKeeper.SetNameRecord(s.ctx, "three.expire.testing", s.user1Addr, false), "SetNameRecord three.expire.testing")
+	s.Require().NoError(s.app.NameKeeper.SetNameRecord(s.ctx, "threev2.expire.testing", s.user1Addr, false), "SetNameRecord threev2.expire.testing")
 	s.Require().NoError(s.app.NameKeeper.SetNameRecord(s.ctx, "four.expire.testing", s.user1Addr, false), "SetNameRecord four.expire.testing")
 	s.Require().NoError(s.app.NameKeeper.SetNameRecord(s.ctx, "five.expire.testing", s.user1Addr, false), "SetNameRecord five.expire.testing")
 
@@ -1066,6 +1067,13 @@ func (s *KeeperTestSuite) TestDeleteExpiredAttributes() {
 	s.Require().NoError(s.app.AttributeKeeper.SetAttribute(s.ctx, attr3, s.user1Addr), "SetAttribute attr3")
 	s.Require().NotNil(store.Get(types.AttributeExpireKey(attr3)), "store.Get attr3 AttributeExpireKey")
 	s.Require().NotNil(store.Get(types.AttributeNameAddrKeyPrefix(attr3.Name, attr3.GetAddressBytes())), "store.Get attr3 AttributeNameAddrKeyPrefix")
+
+	attr3v2 := types.NewAttribute("threev2.expire.testing", s.user1, types.AttributeType_String, []byte("test3v2"), nil, "")
+	startBlockTimeP1 := s.startBlockTime.Add(time.Second)
+	attr3v2.ExpirationDate = &startBlockTimeP1
+	s.Require().NoError(s.app.AttributeKeeper.SetAttribute(s.ctx, attr3v2, s.user1Addr), "SetAttribute attr3v2")
+	s.Require().NotNil(store.Get(types.AttributeExpireKey(attr3v2)), "store.Get attr3v2 AttributeExpireKey")
+	s.Require().NotNil(store.Get(types.AttributeNameAddrKeyPrefix(attr3v2.Name, attr3v2.GetAddressBytes())), "store.Get attr3v2 AttributeNameAddrKeyPrefix")
 
 	attr4 := types.NewAttribute("four.expire.testing", s.user1, types.AttributeType_String, []byte("test4"), nil, "")
 	attr4.ExpirationDate = &future
@@ -1092,8 +1100,11 @@ func (s *KeeperTestSuite) TestDeleteExpiredAttributes() {
 	s.Assert().Nil(store.Get(types.AttributeExpireKey(attr2)), "store.Get attr2 AttributeExpireKey")
 	s.Assert().Nil(store.Get(types.AttributeNameAddrKeyPrefix(attr2.Name, attr2.GetAddressBytes())), "store.Get attr2 AttributeNameAddrKeyPrefix")
 
-	s.Assert().NotNil(store.Get(types.AttributeExpireKey(attr3)), "store.Get attr3 AttributeExpireKey")
-	s.Assert().NotNil(store.Get(types.AttributeNameAddrKeyPrefix(attr3.Name, attr3.GetAddressBytes())), "store.Get attr3 AttributeNameAddrKeyPrefix")
+	s.Assert().Nil(store.Get(types.AttributeExpireKey(attr3)), "store.Get attr3 AttributeExpireKey")
+	s.Assert().Nil(store.Get(types.AttributeNameAddrKeyPrefix(attr3.Name, attr3.GetAddressBytes())), "store.Get attr3 AttributeNameAddrKeyPrefix")
+
+	s.Assert().NotNil(store.Get(types.AttributeExpireKey(attr3v2)), "store.Get attr3v2 AttributeExpireKey")
+	s.Assert().NotNil(store.Get(types.AttributeNameAddrKeyPrefix(attr3v2.Name, attr3v2.GetAddressBytes())), "store.Get attr3v2 AttributeNameAddrKeyPrefix")
 
 	s.Assert().NotNil(store.Get(types.AttributeExpireKey(attr4)), "store.Get attr4 AttributeExpireKey")
 	s.Assert().NotNil(store.Get(types.AttributeNameAddrKeyPrefix(attr4.Name, attr4.GetAddressBytes())), "store.Get attr4 AttributeNameAddrKeyPrefix")

--- a/x/attribute/keeper/msg_server_test.go
+++ b/x/attribute/keeper/msg_server_test.go
@@ -6,9 +6,10 @@ import (
 	"time"
 
 	abci "github.com/cometbft/cometbft/abci/types"
-	"github.com/cosmos/gogoproto/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/cosmos/gogoproto/proto"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
@@ -114,7 +115,7 @@ func (s *MsgServerTestSuite) TestUpdateAttributeExpiration() {
 		{
 			name:     "Should fail, block time is ahead of expiration time",
 			msg:      *types.NewMsgUpdateAttributeExpirationRequest("", "", "", &twoHoursInPast, s.owner1Addr),
-			errorMsg: fmt.Sprintf("attribute expiration date %v is before block time of %v", twoHoursInPast.UTC(), s.ctx.BlockTime().UTC()),
+			errorMsg: fmt.Sprintf("attribute expiration date %v is not after block time of %v", twoHoursInPast.UTC(), s.ctx.BlockTime().UTC()),
 		},
 		{
 			name: "Should succeed",

--- a/x/attribute/types/attribute.go
+++ b/x/attribute/types/attribute.go
@@ -25,6 +25,10 @@ func NewAttribute(name string, address string, attrType AttributeType, value []b
 		trimmed := strings.TrimSpace(string(value))
 		value = []byte(trimmed)
 	}
+	if expirationDate != nil {
+		ed := expirationDate.Truncate(time.Second)
+		expirationDate = &ed
+	}
 	return Attribute{
 		Name:           name,
 		Address:        address,


### PR DESCRIPTION
## Description

This PR does two things related to attributes:
1) Truncate the expiration date to the second.
2) When finding attributes that are expired, include entries that expired exactly at the blocktime (truncated to seconds).

This addresses an edge case where it was possible (for a single block) for expired attributes to be sometimes treated as not-expired.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
