### PR TITLE
Bump github.com/CosmWasm/wasmd to v0.61.10-pio-2 (from v0.61.10-pio-1).

### DIFF
--- a/.changelog/unreleased/dependencies/2731-bump-wasmd.md
+++ b/.changelog/unreleased/dependencies/2731-bump-wasmd.md
@@ -1,0 +1,1 @@
+* `github.com/CosmWasm/wasmd` bumped to v0.61.10-pio-2 of `github.com/provenance-io/wasmd` (from v0.61.10-pio-1 of `github.com/provenance-io/wasmd`) [PR 2731](https://github.com/provenance-io/provenance/pull/2731).

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	cosmossdk.io/x/nft v0.2.0
 	cosmossdk.io/x/tx v0.14.0
 	cosmossdk.io/x/upgrade v0.2.0
-	github.com/CosmWasm/wasmd v0.61.8
+	github.com/CosmWasm/wasmd v0.61.10
 	github.com/CosmWasm/wasmvm/v2 v2.3.2
 	github.com/CosmWasm/wasmvm/v3 v3.0.3
 	github.com/cometbft/cometbft v0.38.21
@@ -398,7 +398,7 @@ replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
 
 	// This is required for https://github.com/provenance-io/provenance/issues/1414
-	github.com/CosmWasm/wasmd => github.com/provenance-io/wasmd v0.61.10-pio-1
+	github.com/CosmWasm/wasmd => github.com/provenance-io/wasmd v0.61.10-pio-2
 
 	github.com/cosmos/cosmos-sdk => github.com/provenance-io/cosmos-sdk v0.53.5-pio-2
 

--- a/go.sum
+++ b/go.sum
@@ -976,8 +976,8 @@ github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
 github.com/provenance-io/cosmos-sdk v0.53.5-pio-2 h1:+xC5s+abO/BR9OHiJglok3oRC5oBGVjJQ+opv5+ikgQ=
 github.com/provenance-io/cosmos-sdk v0.53.5-pio-2/go.mod h1:AQJx0jpon70WAD4oOs/y+SlST4u7VIwEPR6F8S7JMdo=
-github.com/provenance-io/wasmd v0.61.10-pio-1 h1:V/wUE7qCCPiaM38anjmwxaYbvrR4fmgqpH0alrOnpCA=
-github.com/provenance-io/wasmd v0.61.10-pio-1/go.mod h1:GMPqtsb1T8FvaKpQGJmGuj/JMPXBauk4ZhUErgmtEus=
+github.com/provenance-io/wasmd v0.61.10-pio-2 h1:uc0gDj31d2S4010dIy+rtI6RawUzsZ60i0BXcUT2gEk=
+github.com/provenance-io/wasmd v0.61.10-pio-2/go.mod h1:GMPqtsb1T8FvaKpQGJmGuj/JMPXBauk4ZhUErgmtEus=
 github.com/provlabs/vault v1.0.15 h1:nH8dBVwgNg3i9xoJUh3YS+44b858mA3gdyEEMb8VXag=
 github.com/provlabs/vault v1.0.15/go.mod h1:1vskm2+cCclAMVBbbjuRLHkHxlkKgOaLHGX1S82jLts=
 github.com/provlabs/vault/simapp v0.0.0-20250618191328-f45c4bfe12b9 h1:cu+rMHYCZIE9+StrjgwKn+cKta7wmDi9qBgVAb09e1g=


### PR DESCRIPTION
## Description

This PR bumps the wasmd library to `v0.61.10-pio-2` (from `v0.61.10-pio-1`).

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CosmWasm wasmd dependency to v0.61.10-pio-2.
  * Bumped Go module requirement for wasmd from v0.61.8 to v0.61.10 to align with the replace mapping update.



<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/provenance-io/provenance/pull/2731?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->