### PR TITLE
Add the Edelweiss upgrades.

### DIFF
--- a/.changelog/unreleased/improvements/2735-add-edelweiss.md
+++ b/.changelog/unreleased/improvements/2735-add-edelweiss.md
@@ -1,0 +1,1 @@
+* Add the `edelweiss` upgrades [PR 2735](https://github.com/provenance-io/provenance/pull/2735).

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -105,6 +105,46 @@ var upgrades = map[string]appUpgrade{
 			return vm, nil
 		},
 	},
+	"edelweiss-rc1": {
+		Handler: func(ctx sdk.Context, app *App, vm module.VersionMap) (module.VersionMap, error) {
+			var err error
+			if vm, err = runModuleMigrations(ctx, app, vm); err != nil {
+				return nil, err
+			}
+
+			if err = pruneIBCExpiredConsensusStates(ctx, app); err != nil {
+				return nil, err
+			}
+
+			removeInactiveValidatorDelegations(ctx, app)
+
+			if err = convertFinishedVestingAccountsToBase(ctx, app); err != nil {
+				return nil, err
+			}
+
+			return vm, nil
+		},
+	},
+	"edelweiss": {
+		Handler: func(ctx sdk.Context, app *App, vm module.VersionMap) (module.VersionMap, error) {
+			var err error
+			if vm, err = runModuleMigrations(ctx, app, vm); err != nil {
+				return nil, err
+			}
+
+			if err = pruneIBCExpiredConsensusStates(ctx, app); err != nil {
+				return nil, err
+			}
+
+			removeInactiveValidatorDelegations(ctx, app)
+
+			if err = convertFinishedVestingAccountsToBase(ctx, app); err != nil {
+				return nil, err
+			}
+
+			return vm, nil
+		},
+	},
 }
 
 // InstallCustomUpgradeHandlers sets upgrade handlers for all entries in the upgrades map.

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -1062,6 +1062,26 @@ func (s *UpgradeTestSuite) TestDaisy() {
 	s.AssertUpgradeHandlerLogs("daisy", expInLog, nil)
 }
 
+func (s *UpgradeTestSuite) TestEdelweissRC1() {
+	expInLog := []string{
+		LogMsgRunModuleMigrations,
+		LogMsgPruneIBCExpiredConsensusStates,
+		LogMsgRemoveInactiveValidatorDelegations,
+		LogMsgConvertFinishedVestingAccountsToBase,
+	}
+	s.AssertUpgradeHandlerLogs("edelweiss-rc1", expInLog, nil)
+}
+
+func (s *UpgradeTestSuite) TestEdelweiss() {
+	expInLog := []string{
+		LogMsgRunModuleMigrations,
+		LogMsgPruneIBCExpiredConsensusStates,
+		LogMsgRemoveInactiveValidatorDelegations,
+		LogMsgConvertFinishedVestingAccountsToBase,
+	}
+	s.AssertUpgradeHandlerLogs("edelweiss", expInLog, nil)
+}
+
 // wrappedWasmMsgSrvr is a wasmtypes.MsgServer that lets us inject an error to return from StoreCode.
 type wrappedWasmMsgSrvr struct {
 	wasmMsgServer wasmtypes.MsgServer


### PR DESCRIPTION
## Description

This PR adds the `edelweiss` and `edelweiss-rc1` upgrades which run through the standard upgrade processes.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for `edelweiss-rc1` and `edelweiss` network upgrades with automated module migrations, IBC consensus state management, validator delegation processing, and vesting account conversions.

* **Tests**
  * Added test coverage for the new upgrade handlers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/provenance-io/provenance/pull/2735?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->