### PR TITLE
Backport 2741: Make the wasm GRPC Querier return a ResponseQuery again.

### DIFF
--- a/.changelog/unreleased/bug-fixes/2741-undo-wasm-query.md
+++ b/.changelog/unreleased/bug-fixes/2741-undo-wasm-query.md
@@ -1,0 +1,1 @@
+* Revert PR 2728 and make the wasm grpc querier return a ResponseQuery again [PR 2741](https://github.com/provenance-io/provenance/pull/2741).

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -105,7 +105,7 @@ var upgrades = map[string]appUpgrade{
 			return vm, nil
 		},
 	},
-	"edelweiss-rc1": {
+	"edelweiss-rc1": { // v1.29.0-rc1
 		Handler: func(ctx sdk.Context, app *App, vm module.VersionMap) (module.VersionMap, error) {
 			var err error
 			if vm, err = runModuleMigrations(ctx, app, vm); err != nil {
@@ -125,7 +125,8 @@ var upgrades = map[string]appUpgrade{
 			return vm, nil
 		},
 	},
-	"edelweiss": {
+	"edelweiss-rc2": {}, // Empty upgrade for v1.29.0-rc2
+	"edelweiss": { // v1.29.0
 		Handler: func(ctx sdk.Context, app *App, vm module.VersionMap) (module.VersionMap, error) {
 			var err error
 			if vm, err = runModuleMigrations(ctx, app, vm); err != nil {

--- a/internal/provwasm/query_plugins.go
+++ b/internal/provwasm/query_plugins.go
@@ -89,7 +89,8 @@ func StargateQuerier(queryRouter baseapp.GRPCQueryRouter, cdc codec.Codec) func(
 // GrpcQuerier dispatches whitelisted queries and returns protobuf encoded responses
 func GrpcQuerier(queryRouter baseapp.GRPCQueryRouter, cdc codec.Codec) func(ctx sdk.Context, request *wasmvmtypes.GrpcQuery) (proto.Message, error) {
 	return func(ctx sdk.Context, request *wasmvmtypes.GrpcQuery) (proto.Message, error) {
-		protoRespType, err := GetWhitelistedQuery(request.Path)
+		// Make sure the request is white-listed.
+		_, err := GetWhitelistedQuery(request.Path)
 		if err != nil {
 			return nil, err
 		}
@@ -107,14 +108,9 @@ func GrpcQuerier(queryRouter baseapp.GRPCQueryRouter, cdc codec.Codec) func(ctx 
 			return nil, err
 		}
 
-		if err = cdc.Unmarshal(res.Value, protoRespType); err != nil {
-			return nil, wasmvmtypes.InvalidResponse{
-				Err:      fmt.Sprintf("error unmarshalling response into %T: %v", protoRespType, err),
-				Response: res.Value,
-			}
-		}
-
-		return protoRespType, nil
+		// We're returning an *abci.ResponseQuery here instead of the actual query result type because
+		// we started out doing it this way, and now all the smart contracts expect it this way.
+		return res, nil
 	}
 }
 


### PR DESCRIPTION
## Description

This PR makes the wasm GRPC Querier return a ResponseQuery again (instead of the query response type).
This is a backport of the following PR to the `release/v1.29.x` branch:
* #2741 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.
