### PR TITLE
Prevent markers from using reserved prefixes.

### DIFF
--- a/.changelog/unreleased/bug-fixes/2747-fix-nft-denoms.md
+++ b/.changelog/unreleased/bug-fixes/2747-fix-nft-denoms.md
@@ -1,0 +1,1 @@
+* Prevent markers from using the nft/ prefix [PR 2747](https://github.com/provenance-io/provenance/pull/2747).

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -126,6 +126,26 @@ var upgrades = map[string]appUpgrade{
 		},
 	},
 	"edelweiss-rc2": {}, // Empty upgrade for v1.29.0-rc2
+	"edelweiss-rc3": { // Upgrade for v1.29.0-rc3
+		Handler: func(ctx sdk.Context, app *App, vm module.VersionMap) (module.VersionMap, error) {
+			var err error
+			if vm, err = runModuleMigrations(ctx, app, vm); err != nil {
+				return nil, err
+			}
+
+			if err = pruneIBCExpiredConsensusStates(ctx, app); err != nil {
+				return nil, err
+			}
+
+			removeInactiveValidatorDelegations(ctx, app)
+
+			if err = convertFinishedVestingAccountsToBase(ctx, app); err != nil {
+				return nil, err
+			}
+
+			return vm, nil
+		},
+	},
 	"edelweiss": { // v1.29.0
 		Handler: func(ctx sdk.Context, app *App, vm module.VersionMap) (module.VersionMap, error) {
 			var err error

--- a/x/marker/types/marker.go
+++ b/x/marker/types/marker.go
@@ -218,12 +218,12 @@ func (ma MarkerAccount) Validate() error {
 	if strings.TrimSpace(ma.Denom) == "" {
 		return fmt.Errorf("marker denom cannot be empty")
 	}
+	if err := ValidateNotReservedDenom(ma.Denom); err != nil {
+		return err
+	}
 	markerAddress, err := MarkerAddress(ma.Denom)
 	if err != nil {
 		return fmt.Errorf("marker denom is invalid: %w", err)
-	}
-	if err := ValidateNotReservedDenom(ma.Denom); err != nil {
-		return err
 	}
 	if err := ValidateIbcDenom(ma); err != nil {
 		return fmt.Errorf("invalid ibc denom configuration: %w", err)

--- a/x/marker/types/marker.go
+++ b/x/marker/types/marker.go
@@ -257,7 +257,7 @@ const metadataDenomPrefix = "nft/"
 // let marker-level minting/withdrawal clobber metadata-owned coins and can drive the marker
 // BeginBlocker into an uncorrectable supply mismatch (chain halt).
 func ValidateNotReservedDenom(denom string) error {
-	if strings.HasPrefix(strings.ToLower(denom), metadataDenomPrefix) {
+	if strings.HasPrefix(denom, metadataDenomPrefix) {
 		return fmt.Errorf("denom %q uses the reserved %q namespace and cannot be a marker", denom, metadataDenomPrefix)
 	}
 	return nil

--- a/x/marker/types/marker.go
+++ b/x/marker/types/marker.go
@@ -257,7 +257,7 @@ const metadataDenomPrefix = "nft/"
 // let marker-level minting/withdrawal clobber metadata-owned coins and can drive the marker
 // BeginBlocker into an uncorrectable supply mismatch (chain halt).
 func ValidateNotReservedDenom(denom string) error {
-	if strings.HasPrefix(denom, metadataDenomPrefix) {
+	if strings.HasPrefix(strings.ToLower(denom), metadataDenomPrefix) {
 		return fmt.Errorf("denom %q uses the reserved %q namespace and cannot be a marker", denom, metadataDenomPrefix)
 	}
 	return nil

--- a/x/marker/types/marker.go
+++ b/x/marker/types/marker.go
@@ -222,6 +222,9 @@ func (ma MarkerAccount) Validate() error {
 	if err != nil {
 		return fmt.Errorf("marker denom is invalid: %w", err)
 	}
+	if err := ValidateNotReservedDenom(ma.Denom); err != nil {
+		return err
+	}
 	if err := ValidateIbcDenom(ma); err != nil {
 		return fmt.Errorf("invalid ibc denom configuration: %w", err)
 	}
@@ -242,6 +245,22 @@ func (ma MarkerAccount) Validate() error {
 		return fmt.Errorf("forced transfers can only be allowed on restricted markers")
 	}
 	return ma.BaseAccount.Validate()
+}
+
+// metadataDenomPrefix is the denom prefix owned by the metadata module (scope value-owner coins).
+// It is duplicated here rather than imported from x/metadata/types to avoid a module dependency,
+// the same way ValidateIbcDenom hard-codes the "ibc/" prefix.
+const metadataDenomPrefix = "nft/"
+
+// ValidateNotReservedDenom returns an error if the denom belongs to another module's reserved
+// namespace and therefore must never back a marker. A marker over a metadata scope denom would
+// let marker-level minting/withdrawal clobber metadata-owned coins and can drive the marker
+// BeginBlocker into an uncorrectable supply mismatch (chain halt).
+func ValidateNotReservedDenom(denom string) error {
+	if strings.HasPrefix(denom, metadataDenomPrefix) {
+		return fmt.Errorf("denom %q uses the reserved %q namespace and cannot be a marker", denom, metadataDenomPrefix)
+	}
+	return nil
 }
 
 // ValidateIbcDenom if denom is ibc it that validates supply is not fixed and Mint/Burn is not allowed

--- a/x/marker/types/marker_test.go
+++ b/x/marker/types/marker_test.go
@@ -226,8 +226,11 @@ func TestValidateNotReservedDenom(t *testing.T) {
 		{name: "ibc denom is allowed", denom: "ibc/ABC123", expErr: ""},
 		{name: "nft prefix without slash is allowed", denom: "nftthing", expErr: ""},
 		{name: "metadata scope denom is reserved", denom: "nft/scope1qzge0zaztu65tx5x5llv5xc9zts96lrcj7", expErr: "denom \"nft/scope1qzge0zaztu65tx5x5llv5xc9zts96lrcj7\" uses the reserved \"nft/\" namespace and cannot be a marker"},
-		{name: "any nft-prefixed denom is reserved", denom: "nft/test", expErr: "denom \"nft/test\" uses the reserved \"nft/\" namespace and cannot be a marker"},
+		{name: "any lower-case nft-prefixed denom is reserved", denom: "nft/test", expErr: "denom \"nft/test\" uses the reserved \"nft/\" namespace and cannot be a marker"},
+		{name: "any upper-case nft-prefixed denom is reserved", denom: "NFT/test", expErr: "denom \"NFT/test\" uses the reserved \"nft/\" namespace and cannot be a marker"},
+		{name: "any mixed-case nft-prefixed denom is reserved", denom: "NfT/test", expErr: "denom \"NfT/test\" uses the reserved \"nft/\" namespace and cannot be a marker"},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ValidateNotReservedDenom(tt.denom)

--- a/x/marker/types/marker_test.go
+++ b/x/marker/types/marker_test.go
@@ -227,8 +227,8 @@ func TestValidateNotReservedDenom(t *testing.T) {
 		{name: "nft prefix without slash is allowed", denom: "nftthing", expErr: ""},
 		{name: "metadata scope denom is reserved", denom: "nft/scope1qzge0zaztu65tx5x5llv5xc9zts96lrcj7", expErr: "denom \"nft/scope1qzge0zaztu65tx5x5llv5xc9zts96lrcj7\" uses the reserved \"nft/\" namespace and cannot be a marker"},
 		{name: "any lower-case nft-prefixed denom is reserved", denom: "nft/test", expErr: "denom \"nft/test\" uses the reserved \"nft/\" namespace and cannot be a marker"},
-		{name: "any upper-case nft-prefixed denom is reserved", denom: "NFT/test", expErr: "denom \"NFT/test\" uses the reserved \"nft/\" namespace and cannot be a marker"},
-		{name: "any mixed-case nft-prefixed denom is reserved", denom: "NfT/test", expErr: "denom \"NfT/test\" uses the reserved \"nft/\" namespace and cannot be a marker"},
+		{name: "any upper-case nft-prefixed denom is allowed", denom: "NFT/test", expErr: ""},
+		{name: "any mixed-case nft-prefixed denom is allowed", denom: "Nft/test", expErr: ""},
 	}
 
 	for _, tt := range tests {

--- a/x/marker/types/marker_test.go
+++ b/x/marker/types/marker_test.go
@@ -167,6 +167,11 @@ func TestNewMarkerValidate(t *testing.T) {
 			fmt.Errorf("invalid ibc denom configuration: ACCESS_BURN is not supported for ibc marker"),
 		},
 		{
+			"reserved metadata namespace denom is invalid",
+			NewMarkerAccount(baseAcc, sdk.NewInt64Coin("nft/test", 1), manager, nil, StatusProposed, MarkerType_Coin, true, false, false, []string{}),
+			fmt.Errorf("denom \"nft/test\" uses the reserved \"nft/\" namespace and cannot be a marker"),
+		},
+		{
 			"valid marker account",
 			NewMarkerAccount(baseAcc, sdk.NewInt64Coin("test", 1), manager, nil, StatusProposed, MarkerType_Coin, true, false, false, []string{}),
 			nil,
@@ -206,6 +211,30 @@ func TestNewMarkerValidate(t *testing.T) {
 				errStr := fmt.Sprintf("%v", err)
 				chkStr := fmt.Sprintf("%v", tt.expErr)
 				require.Equal(t, chkStr, errStr)
+			}
+		})
+	}
+}
+
+func TestValidateNotReservedDenom(t *testing.T) {
+	tests := []struct {
+		name   string
+		denom  string
+		expErr string
+	}{
+		{name: "plain denom is allowed", denom: "test", expErr: ""},
+		{name: "ibc denom is allowed", denom: "ibc/ABC123", expErr: ""},
+		{name: "nft prefix without slash is allowed", denom: "nftthing", expErr: ""},
+		{name: "metadata scope denom is reserved", denom: "nft/scope1qzge0zaztu65tx5x5llv5xc9zts96lrcj7", expErr: "denom \"nft/scope1qzge0zaztu65tx5x5llv5xc9zts96lrcj7\" uses the reserved \"nft/\" namespace and cannot be a marker"},
+		{name: "any nft-prefixed denom is reserved", denom: "nft/test", expErr: "denom \"nft/test\" uses the reserved \"nft/\" namespace and cannot be a marker"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateNotReservedDenom(tt.denom)
+			if len(tt.expErr) > 0 {
+				require.EqualError(t, err, tt.expErr)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

This PR makes it so that markers cannot have the nft/ prefix.
This PR also adds the `edelweiss-rc3` upgrade with a handler because I know another fix will need it.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Markers can no longer use the `nft/` prefix in their denominations, preventing conflicts with the reserved metadata namespace.

* **New Features**
  * Added an upgrade plan "edelweiss-rc3" to run module migrations, prune expired IBC states, remove inactive delegations, and finalize vesting accounts during upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->