### PR TITLE
Vault v1.1.0 Release 

### DIFF
--- a/.changelog/unreleased/dependencies/2749-bump-vault.md
+++ b/.changelog/unreleased/dependencies/2749-bump-vault.md
@@ -1,0 +1,1 @@
+* `github.com/provlabs/vault` bumped to v1.1.0 (from v1.0.15) [PR 2750](https://github.com/provenance-io/provenance/pull/2749).

--- a/.changelog/unreleased/dependencies/2750-bump-vault.md
+++ b/.changelog/unreleased/dependencies/2750-bump-vault.md
@@ -1,0 +1,1 @@
+* `github.com/provlabs/vault` bumped to v1.1.0 (from v1.0.15) [PR 2750](https://github.com/provenance-io/provenance/pull/2750).

--- a/.changelog/unreleased/dependencies/2750-bump-vault.md
+++ b/.changelog/unreleased/dependencies/2750-bump-vault.md
@@ -1,1 +1,0 @@
-* `github.com/provlabs/vault` bumped to v1.1.0 (from v1.0.15) [PR 2750](https://github.com/provenance-io/provenance/pull/2750).

--- a/.changelog/unreleased/features/2749-setup-vault-params.md
+++ b/.changelog/unreleased/features/2749-setup-vault-params.md
@@ -1,0 +1,1 @@
+* Wire the vault module params and initialize them (`tech_fee_address`, `default_aum_fee_bips`) during the `edelweiss-rc3` and `edelweiss` upgrades [PR 2750](https://github.com/provenance-io/provenance/pull/2749).

--- a/.changelog/unreleased/features/2750-setup-vault-params.md
+++ b/.changelog/unreleased/features/2750-setup-vault-params.md
@@ -1,1 +1,0 @@
-* Wire the vault module params and initialize them (`tech_fee_address`, `default_aum_fee_bips`) during the `edelweiss-rc3` and `edelweiss` upgrades [PR 2750](https://github.com/provenance-io/provenance/pull/2750).

--- a/.changelog/unreleased/features/2750-setup-vault-params.md
+++ b/.changelog/unreleased/features/2750-setup-vault-params.md
@@ -1,0 +1,1 @@
+* Wire the vault module params and initialize them (`tech_fee_address`, `default_aum_fee_bips`) during the `edelweiss-rc3` and `edelweiss` upgrades [PR 2750](https://github.com/provenance-io/provenance/pull/2750).

--- a/app/app.go
+++ b/app/app.go
@@ -613,6 +613,8 @@ func New(
 		app.AccountKeeper,
 		*app.MarkerKeeper,
 		app.BankKeeper,
+		app.NameKeeper,
+		app.AttributeKeeper,
 	)
 
 	app.TriggerKeeper = triggerkeeper.NewKeeper(appCodec, keys[triggertypes.StoreKey], app.MsgServiceRouter())
@@ -784,7 +786,7 @@ func New(
 		quarantinemodule.NewAppModule(appCodec, app.QuarantineKeeper, app.AccountKeeper, app.BankKeeper, app.interfaceRegistry),
 		sanctionmodule.NewAppModule(appCodec, app.SanctionKeeper, app.AccountKeeper, app.BankKeeper, app.GovKeeper, app.interfaceRegistry),
 
-		vaultmodule.NewAppModule(app.VaultKeeper, app.MarkerKeeper, app.BankKeeper, address.Bech32Codec{Bech32Prefix: addrPrefix}),
+		vaultmodule.NewAppModule(app.VaultKeeper, app.MarkerKeeper, app.BankKeeper, app.NameKeeper, app.AttributeKeeper, address.Bech32Codec{Bech32Prefix: addrPrefix}),
 
 		ibc.NewAppModule(app.IBCKeeper),
 		ibcratelimitmodule.NewAppModule(appCodec, *app.RateLimitingKeeper),

--- a/app/app.go
+++ b/app/app.go
@@ -609,7 +609,7 @@ func New(
 		runtime.NewKVStoreService(keys[vaulttypes.StoreKey]),
 		runtime.EventService{},
 		address.Bech32Codec{Bech32Prefix: addrPrefix},
-		[]byte(govAuthority),
+		sdk.MustAccAddressFromBech32(govAuthority),
 		app.AccountKeeper,
 		*app.MarkerKeeper,
 		app.BankKeeper,

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -62,6 +62,7 @@ func TestSimAppExportAndBlockedAddrs(t *testing.T) {
 	// finalize block so we have CheckTx state set
 	_, err := app.FinalizeBlock(&abci.RequestFinalizeBlock{
 		Height: 1,
+		Time:   time.Now().UTC(),
 	})
 	require.NoError(t, err)
 
@@ -156,6 +157,7 @@ func TestExportAppStateAndValidators(t *testing.T) {
 	// finalize block so we have CheckTx state set
 	_, err := app.FinalizeBlock(&abci.RequestFinalizeBlock{
 		Height: 1,
+		Time:   time.Now().UTC(),
 	})
 	require.NoError(t, err)
 

--- a/app/snapshot_test.go
+++ b/app/snapshot_test.go
@@ -128,6 +128,7 @@ func newSnapshotApp(t *testing.T, initChain bool) (*App, sdk.AccAddress) {
 		Height:             app.LastBlockHeight() + 1,
 		Hash:               app.LastCommitID().Hash,
 		NextValidatorsHash: valSet.Hash(),
+		Time:               time.Now().UTC(),
 	})
 	require.NoError(t, err, "app.FinalizeBlock")
 	_, err = app.Commit()

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -301,7 +301,7 @@ func SetupWithGenesisValSet(t *testing.T, chainID string, valSet *cmttypes.Valid
 		Height:             app.LastBlockHeight() + 1,
 		Hash:               app.LastCommitID().Hash,
 		NextValidatorsHash: valSet.Hash(),
-		Time:               time.Now().UTC(),
+		Time:               time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 	})
 	require.NoError(t, err, "FinalizeBlock")
 

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -301,6 +301,7 @@ func SetupWithGenesisValSet(t *testing.T, chainID string, valSet *cmttypes.Valid
 		Height:             app.LastBlockHeight() + 1,
 		Hash:               app.LastCommitID().Hash,
 		NextValidatorsHash: valSet.Hash(),
+		Time:               time.Now().UTC(),
 	})
 	require.NoError(t, err, "FinalizeBlock")
 

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	vaulttypes "github.com/provlabs/vault/types"
+
 	storetypes "cosmossdk.io/store/types"
 	circuittypes "cosmossdk.io/x/circuit/types"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
@@ -15,7 +17,6 @@ import (
 	ibctmmigrations "github.com/cosmos/ibc-go/v10/modules/light-clients/07-tendermint/migrations"
 
 	flatfeestypes "github.com/provenance-io/provenance/x/flatfees/types"
-	vaulttypes "github.com/provlabs/vault/types"
 )
 
 // appUpgrade is an internal structure for defining all things for an upgrade.

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -15,6 +15,7 @@ import (
 	ibctmmigrations "github.com/cosmos/ibc-go/v10/modules/light-clients/07-tendermint/migrations"
 
 	flatfeestypes "github.com/provenance-io/provenance/x/flatfees/types"
+	vaulttypes "github.com/provlabs/vault/types"
 )
 
 // appUpgrade is an internal structure for defining all things for an upgrade.
@@ -143,6 +144,10 @@ var upgrades = map[string]appUpgrade{
 				return nil, err
 			}
 
+			if err = setupVaultParams(ctx, app); err != nil {
+				return nil, err
+			}
+
 			return vm, nil
 		},
 	},
@@ -160,6 +165,10 @@ var upgrades = map[string]appUpgrade{
 			removeInactiveValidatorDelegations(ctx, app)
 
 			if err = convertFinishedVestingAccountsToBase(ctx, app); err != nil {
+				return nil, err
+			}
+
+			if err = setupVaultParams(ctx, app); err != nil {
 				return nil, err
 			}
 
@@ -484,6 +493,34 @@ func updateMsgFees(ctx sdk.Context, app *App) error {
 	}
 
 	ctx.Logger().Info("All message fees updated successfully.", "total_updated", len(feeUpdates))
+	return nil
+}
+
+// setupVaultParams initializes the vault module parameters with chain-appropriate
+// default values. The vault Params (tech_fee_address and default_aum_fee_bips) were
+// added after the module was first wired into the chain, so existing chains won't
+// have them set. This establishes the defaults during the upgrade. It is idempotent:
+// re-running it simply re-writes the same default values.
+func setupVaultParams(ctx sdk.Context, app *App) error {
+	ctx.Logger().Info("Setting up vault module params.")
+
+	params := vaulttypes.Params{
+		TechFeeAddress:    vaulttypes.GetDefaultTechFeeAddress(ctx.ChainID()).String(),
+		DefaultAumFeeBips: vaulttypes.DefaultAumFeeBips,
+	}
+
+	if err := params.Validate(); err != nil {
+		return fmt.Errorf("invalid vault params: %w", err)
+	}
+
+	if err := app.VaultKeeper.Params.Set(ctx, params); err != nil {
+		return fmt.Errorf("failed to set vault params: %w", err)
+	}
+
+	ctx.Logger().Info("Vault module params set successfully.",
+		"tech_fee_address", params.TechFeeAddress,
+		"default_aum_fee_bips", params.DefaultAumFeeBips,
+	)
 	return nil
 }
 

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -1072,12 +1072,24 @@ func (s *UpgradeTestSuite) TestEdelweissRC1() {
 	s.AssertUpgradeHandlerLogs("edelweiss-rc1", expInLog, nil)
 }
 
+func (s *UpgradeTestSuite) TestEdelweissRC3() {
+	expInLog := []string{
+		LogMsgRunModuleMigrations,
+		LogMsgPruneIBCExpiredConsensusStates,
+		LogMsgRemoveInactiveValidatorDelegations,
+		LogMsgConvertFinishedVestingAccountsToBase,
+		"INF Setting up vault module params. module=baseapp",
+	}
+	s.AssertUpgradeHandlerLogs("edelweiss-rc3", expInLog, nil)
+}
+
 func (s *UpgradeTestSuite) TestEdelweiss() {
 	expInLog := []string{
 		LogMsgRunModuleMigrations,
 		LogMsgPruneIBCExpiredConsensusStates,
 		LogMsgRemoveInactiveValidatorDelegations,
 		LogMsgConvertFinishedVestingAccountsToBase,
+		"INF Setting up vault module params. module=baseapp",
 	}
 	s.AssertUpgradeHandlerLogs("edelweiss", expInLog, nil)
 }

--- a/go.mod
+++ b/go.mod
@@ -140,6 +140,8 @@ require (
 	github.com/cosmos/btcutil v1.0.5 // indirect
 	github.com/cosmos/gogogateway v1.2.0 // indirect
 	github.com/cosmos/iavl v1.2.6 // indirect
+	github.com/cosmos/ibc-go/modules/capability v1.0.1 // indirect
+	github.com/cosmos/ibc-go/v8 v8.8.0 // indirect
 	github.com/cosmos/ics23/go v0.11.0 // indirect
 	github.com/cosmos/ledger-cosmos-go v1.0.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
@@ -410,6 +412,8 @@ replace (
 	// Fix upstream GHSA-h395-qcrw-5vmq and GHSA-3vp4-m3rf-835h vulnerabilities.
 	// TODO Remove it: https://github.com/cosmos/cosmos-sdk/issues/10409
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.9.1
+
+	github.com/provlabs/vault => ../vault
 
 	// replace broken goleveldb
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/hashicorp/go-metrics v0.5.4
-	github.com/provlabs/vault v1.0.15
+	github.com/provlabs/vault v1.1.0
 	github.com/rs/zerolog v1.35.1
 	github.com/spf13/cast v1.10.0
 	github.com/spf13/cobra v1.10.2
@@ -412,8 +412,6 @@ replace (
 	// Fix upstream GHSA-h395-qcrw-5vmq and GHSA-3vp4-m3rf-835h vulnerabilities.
 	// TODO Remove it: https://github.com/cosmos/cosmos-sdk/issues/10409
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.9.1
-
-	github.com/provlabs/vault => ../vault
 
 	// replace broken goleveldb
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7

--- a/go.sum
+++ b/go.sum
@@ -976,6 +976,8 @@ github.com/provenance-io/cosmos-sdk v0.53.5-pio-2 h1:+xC5s+abO/BR9OHiJglok3oRC5o
 github.com/provenance-io/cosmos-sdk v0.53.5-pio-2/go.mod h1:AQJx0jpon70WAD4oOs/y+SlST4u7VIwEPR6F8S7JMdo=
 github.com/provenance-io/wasmd v0.61.10-pio-2 h1:uc0gDj31d2S4010dIy+rtI6RawUzsZ60i0BXcUT2gEk=
 github.com/provenance-io/wasmd v0.61.10-pio-2/go.mod h1:GMPqtsb1T8FvaKpQGJmGuj/JMPXBauk4ZhUErgmtEus=
+github.com/provlabs/vault v1.1.0 h1:Nk8ywgNbEJpxKFxmgS/NEIQN8fJFeK90AHYu75HlYtQ=
+github.com/provlabs/vault v1.1.0/go.mod h1:HdBgBP1qp4y3CgmM9RTmqDKqenBj1DuCZqinlpRgwBE=
 github.com/provlabs/vault/simapp v0.0.0-20250618191328-f45c4bfe12b9 h1:cu+rMHYCZIE9+StrjgwKn+cKta7wmDi9qBgVAb09e1g=
 github.com/provlabs/vault/simapp v0.0.0-20250618191328-f45c4bfe12b9/go.mod h1:Ha7fmwkYtr49a2VtWplC/lP/LKqJf3uLBH1CLIP5DFg=
 github.com/quasilyte/go-ruleguard v0.4.3-0.20240823090925-0fe6f58b47b1 h1:+Wl/0aFp0hpuHM3H//KMft64WQ1yX9LdJY64Qm/gFCo=

--- a/go.sum
+++ b/go.sum
@@ -320,8 +320,8 @@ github.com/cosmos/ibc-go/modules/capability v1.0.1 h1:ibwhrpJ3SftEEZRxCRkH0fQZ9s
 github.com/cosmos/ibc-go/modules/capability v1.0.1/go.mod h1:rquyOV262nGJplkumH+/LeYs04P3eV8oB7ZM4Ygqk4E=
 github.com/cosmos/ibc-go/v10 v10.7.0 h1:lE1nsilDP4SUiD7mhgdF9X3f1T4sa7Lt8CiH8Qy1jzg=
 github.com/cosmos/ibc-go/v10 v10.7.0/go.mod h1:a74pAPUSJ7NewvmvELU74hUClJhwnmm5MGbEaiTw/kE=
-github.com/cosmos/ibc-go/v8 v8.6.1 h1:35JQ9HttSDNLjy4J/ZxmmFbzw0cRVjoCRKkc3ngDZms=
-github.com/cosmos/ibc-go/v8 v8.6.1/go.mod h1:Hd3kDFNOhQ/EnYt8qb84/r78tA/lOYC3IkLMbpurs3I=
+github.com/cosmos/ibc-go/v8 v8.8.0 h1:Xn4/Xzt7JZihKRRSe8xJ65zG7PwrSnIWYRoQDK9hhME=
+github.com/cosmos/ibc-go/v8 v8.8.0/go.mod h1:G2z+Q6ZQSMcyHI2+BVcJdvfOupb09M2h/tgpXOEdY6k=
 github.com/cosmos/ics23/go v0.11.0 h1:jk5skjT0TqX5e5QJbEnwXIS2yI2vnmLOgpQPeM5RtnU=
 github.com/cosmos/ics23/go v0.11.0/go.mod h1:A8OjxPE67hHST4Icw94hOxxFEJMBG031xIGF/JHNIY0=
 github.com/cosmos/keyring v1.2.0 h1:8C1lBP9xhImmIabyXW4c3vFjjLiBdGCmfLUfeZlV1Yo=
@@ -976,8 +976,6 @@ github.com/provenance-io/cosmos-sdk v0.53.5-pio-2 h1:+xC5s+abO/BR9OHiJglok3oRC5o
 github.com/provenance-io/cosmos-sdk v0.53.5-pio-2/go.mod h1:AQJx0jpon70WAD4oOs/y+SlST4u7VIwEPR6F8S7JMdo=
 github.com/provenance-io/wasmd v0.61.10-pio-2 h1:uc0gDj31d2S4010dIy+rtI6RawUzsZ60i0BXcUT2gEk=
 github.com/provenance-io/wasmd v0.61.10-pio-2/go.mod h1:GMPqtsb1T8FvaKpQGJmGuj/JMPXBauk4ZhUErgmtEus=
-github.com/provlabs/vault v1.0.15 h1:nH8dBVwgNg3i9xoJUh3YS+44b858mA3gdyEEMb8VXag=
-github.com/provlabs/vault v1.0.15/go.mod h1:1vskm2+cCclAMVBbbjuRLHkHxlkKgOaLHGX1S82jLts=
 github.com/provlabs/vault/simapp v0.0.0-20250618191328-f45c4bfe12b9 h1:cu+rMHYCZIE9+StrjgwKn+cKta7wmDi9qBgVAb09e1g=
 github.com/provlabs/vault/simapp v0.0.0-20250618191328-f45c4bfe12b9/go.mod h1:Ha7fmwkYtr49a2VtWplC/lP/LKqJf3uLBH1CLIP5DFg=
 github.com/quasilyte/go-ruleguard v0.4.3-0.20240823090925-0fe6f58b47b1 h1:+Wl/0aFp0hpuHM3H//KMft64WQ1yX9LdJY64Qm/gFCo=

--- a/internal/handlers/msg_service_router_test.go
+++ b/internal/handlers/msg_service_router_test.go
@@ -190,6 +190,7 @@ func TestFailedTx(tt *testing.T) {
 			&abci.RequestFinalizeBlock{
 				Height: ctx.BlockHeight() + 1,
 				Txs:    [][]byte{txBytes},
+				Time:   time.Now().UTC(),
 			},
 		)
 		assert.NoError(t, err, "FinalizeBlock expected no error")
@@ -238,6 +239,7 @@ func TestFailedTx(tt *testing.T) {
 			&abci.RequestFinalizeBlock{
 				Height: ctx.BlockHeight() + 1,
 				Txs:    [][]byte{txBytes},
+				Time:   time.Now().UTC(),
 			},
 		)
 		assert.NoError(t, err, "FinalizeBlock")
@@ -313,6 +315,7 @@ func TestMsgService(tt *testing.T) {
 			&abci.RequestFinalizeBlock{
 				Height: ctx.BlockHeight() + 1,
 				Txs:    [][]byte{txBytes},
+				Time:   time.Now().UTC(),
 			},
 		)
 		t.Logf("Events:\n%s\n", eventsString(blockRes.TxResults[0].Events, true))
@@ -353,6 +356,7 @@ func TestMsgService(tt *testing.T) {
 			&abci.RequestFinalizeBlock{
 				Height: ctx.BlockHeight() + 1,
 				Txs:    [][]byte{txBytes},
+				Time:   time.Now().UTC(),
 			},
 		)
 		t.Logf("Events:\n%s\n", eventsString(blockRes.TxResults[0].Events, true))
@@ -398,6 +402,7 @@ func TestMsgService(tt *testing.T) {
 			&abci.RequestFinalizeBlock{
 				Height: ctx.BlockHeight() + 1,
 				Txs:    [][]byte{txBytes},
+				Time:   time.Now().UTC(),
 			},
 		)
 		t.Logf("Events:\n%s\n", eventsString(blockRes.TxResults[0].Events, true))
@@ -492,6 +497,7 @@ func TestMsgServiceAuthz(tt *testing.T) {
 			&abci.RequestFinalizeBlock{
 				Height: ctx.BlockHeight() + 1,
 				Txs:    [][]byte{txBytes},
+				Time:   time.Now().UTC(),
 			},
 		)
 		assert.NoError(t, err, "FinalizeBlock() error")
@@ -538,6 +544,7 @@ func TestMsgServiceAuthz(tt *testing.T) {
 			&abci.RequestFinalizeBlock{
 				Height: ctx.BlockHeight() + 1,
 				Txs:    [][]byte{txBytes},
+				Time:   time.Now().UTC(),
 			},
 		)
 		assert.NoError(t, err, "FinalizeBlock() error")
@@ -581,6 +588,7 @@ func TestMsgServiceAuthz(tt *testing.T) {
 			&abci.RequestFinalizeBlock{
 				Height: ctx.BlockHeight() + 1,
 				Txs:    [][]byte{txBytes},
+				Time:   time.Now().UTC(),
 			},
 		)
 		t.Logf("Events:\n%s\n", eventsString(blockRes.TxResults[0].Events, true))

--- a/internal/handlers/msg_service_router_test.go
+++ b/internal/handlers/msg_service_router_test.go
@@ -451,7 +451,7 @@ func TestMsgServiceAuthz(tt *testing.T) {
 		banktypes.Balance{Address: addr2.String(), Coins: initBalance},
 	)
 	encCfg := app.GetEncodingConfig()
-	ctx := app.BaseApp.NewContextLegacy(false, cmtproto.Header{ChainID: "flatfee-testing"})
+	ctx := app.BaseApp.NewContextLegacy(false, cmtproto.Header{ChainID: "flatfee-testing", Time: time.Now().UTC()})
 	require.NoError(tt, app.AccountKeeper.Params.Set(ctx, authtypes.DefaultParams()), "Setting default account params")
 	feeCollectorAccount := app.AccountKeeper.GetModuleAccount(ctx, authtypes.FeeCollectorName)
 	feeCollectorAddr := feeCollectorAccount.GetAddress().String()

--- a/third_party/proto/provlabs/vault/v1/events.proto
+++ b/third_party/proto/provlabs/vault/v1/events.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package provlabs.vault.v1;
 
 import "cosmos_proto/cosmos.proto";
+import "provlabs/vault/v1/params.proto";
 
 option go_package = "github.com/provlabs/vault/types";
 
@@ -343,4 +344,84 @@ message EventWithdrawalDelayUpdated {
   string authority = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // withdrawal_delay_seconds is the newly set withdrawal delay in seconds.
   uint64 withdrawal_delay_seconds = 3;
+}
+
+// EventVaultFeeCollected is an event emitted when a vault's AUM fee is collected.
+message EventVaultFeeCollected {
+  // vault_address is the bech32 address of the vault.
+  string vault_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  // collected_amount is the amount of the technology fee that was actually collected (e.g., "100nhash").
+  string collected_amount = 2;
+  // requested_amount is the amount of the technology fee that was calculated for the period (e.g., "120nhash").
+  string requested_amount = 3;
+  // aum_snapshot is the total vault value at the time of fee calculation (e.g., "1000000underlying").
+  string aum_snapshot = 4;
+  // duration_seconds is the duration for which the fee was calculated.
+  int64 duration_seconds = 5;
+  // outstanding_amount is the amount of AUM fee that remains unpaid after this collection (e.g., "20nhash").
+  string outstanding_amount = 6;
+}
+
+// EventParamsUpdated is an event emitted when the module parameters are updated.
+message EventParamsUpdated {
+  // params are the newly updated module parameters.
+  Params params = 1;
+}
+
+// EventVaultAUMFeeBipsUpdated is an event emitted when a vault's AUM fee bips are updated.
+message EventVaultAUMFeeBipsUpdated {
+  // vault_address is the bech32 address of the vault.
+  string vault_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  // authority is the address (tech fee address) that updated the fee bips.
+  string authority = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  // aum_fee_bips is the newly set AUM fee bips for the vault.
+  uint32 aum_fee_bips = 3;
+}
+
+// EventMinSwapInValueUpdated is an event emitted when a vault's minimum swap-in value is updated.
+message EventMinSwapInValueUpdated {
+  // vault_address is the bech32 address of the vault.
+  string vault_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  // authority is the address (admin or asset manager) that updated the limit.
+  string authority = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  // min_swap_in is the newly set minimum swap-in value, measured in the underlying_asset.
+  // - Values must be non-negative (>= 0).
+  // - An empty string "" or "0" indicates the minimum was cleared / no configured minimum.
+  string min_swap_in = 3;
+}
+
+// EventMinSwapOutValueUpdated is an event emitted when a vault's minimum swap-out value is updated.
+message EventMinSwapOutValueUpdated {
+  // vault_address is the bech32 address of the vault.
+  string vault_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  // authority is the address (admin or asset manager) that updated the limit.
+  string authority = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  // min_swap_out is the newly set minimum swap-out value, measured in the underlying_asset.
+  // - Values must be non-negative (>= 0).
+  // - An empty string "" or "0" indicates the minimum was cleared / no configured minimum.
+  string min_swap_out = 3;
+}
+
+// EventMaxSwapInValueUpdated is an event emitted when a vault's maximum swap-in value is updated.
+message EventMaxSwapInValueUpdated {
+  // vault_address is the bech32 address of the vault.
+  string vault_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  // authority is the address (admin or asset manager) that updated the limit.
+  string authority = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  // max_swap_in is the newly set maximum swap-in value, measured in the underlying_asset.
+  // - Values must be positive (> 0).
+  // - An empty string "" indicates no maximum limit.
+  string max_swap_in = 3;
+}
+
+// EventMaxSwapOutValueUpdated is an event emitted when a vault's maximum swap-out value is updated.
+message EventMaxSwapOutValueUpdated {
+  // vault_address is the bech32 address of the vault.
+  string vault_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  // authority is the address (admin or asset manager) that updated the limit.
+  string authority = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  // max_swap_out is the newly set maximum swap-out value, measured in the underlying_asset.
+  // - Values must be positive (> 0).
+  // - An empty string "" indicates no maximum limit.
+  string max_swap_out = 3;
 }

--- a/third_party/proto/provlabs/vault/v1/genesis.proto
+++ b/third_party/proto/provlabs/vault/v1/genesis.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package provlabs.vault.v1;
 
+import "cosmos_proto/cosmos.proto";
 import "gogoproto/gogo.proto";
 import "provlabs/vault/v1/params.proto";
 import "provlabs/vault/v1/vault.proto";

--- a/third_party/proto/provlabs/vault/v1/genesis.proto
+++ b/third_party/proto/provlabs/vault/v1/genesis.proto
@@ -2,11 +2,13 @@ syntax = "proto3";
 package provlabs.vault.v1;
 
 import "gogoproto/gogo.proto";
+import "provlabs/vault/v1/params.proto";
 import "provlabs/vault/v1/vault.proto";
 
 option go_package = "github.com/provlabs/vault/types";
 
-// QueueEntry is a (time, addr) pair used by the vault payout deferral queue.
+// QueueEntry is a (time, addr) pair used by various vault timeout queues
+// (e.g., payout deferral and fee collection).
 message QueueEntry {
   // time is the UNIX timestamp (in seconds) when the entry becomes eligible.
   uint64 time = 1;
@@ -45,4 +47,12 @@ message GenesisState {
 
   // pending_swap_out_queue contains entries for pending swap outs.
   PendingSwapOutQueue pending_swap_out_queue = 3 [(gogoproto.nullable) = false];
+
+  // fee_timeout_queue contains (time, addr) entries for vaults that are
+  // temporarily deferred from automatic AUM fee collection until the
+  // given UNIX timestamp (seconds). These entries are re-enqueued on InitGenesis.
+  repeated QueueEntry fee_timeout_queue = 4 [(gogoproto.nullable) = false];
+
+  // params defines the module parameters.
+  Params params = 5 [(gogoproto.nullable) = false];
 }

--- a/third_party/proto/provlabs/vault/v1/params.proto
+++ b/third_party/proto/provlabs/vault/v1/params.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+package provlabs.vault.v1;
+
+import "cosmos_proto/cosmos.proto";
+import "gogoproto/gogo.proto";
+
+option go_package = "github.com/provlabs/vault/types";
+
+// Params defines the set of module parameters.
+message Params {
+  option (gogoproto.equal) = true;
+
+  // tech_fee_address is the address where all AUM fees are collected and which holds
+  // the authority to update per-vault bips.
+  string tech_fee_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  // default_aum_fee_bips is the default fee rate (in basis points) applied to new vaults upon creation.
+  uint32 default_aum_fee_bips = 2;
+}

--- a/third_party/proto/provlabs/vault/v1/query.proto
+++ b/third_party/proto/provlabs/vault/v1/query.proto
@@ -6,6 +6,7 @@ import "cosmos/base/v1beta1/coin.proto";
 import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
 import "google/protobuf/timestamp.proto";
+import "provlabs/vault/v1/params.proto";
 import "provlabs/vault/v1/vault.proto";
 
 option go_package = "github.com/provlabs/vault/types";
@@ -40,6 +41,11 @@ service Query {
   // VaultPendingSwapOuts returns a paginated list of all pending swap outs for a specific vault.
   rpc VaultPendingSwapOuts(QueryVaultPendingSwapOutsRequest) returns (QueryVaultPendingSwapOutsResponse) {
     option (google.api.http).get = "/vault/v1/vaults/{id}/pending_swap_outs";
+  }
+
+  // Params returns the current module parameters.
+  rpc Params(QueryParamsRequest) returns (QueryParamsResponse) {
+    option (google.api.http).get = "/vault/v1/params";
   }
 }
 
@@ -163,4 +169,13 @@ message QueryEstimateSwapOutResponse {
     (gogoproto.stdtime) = true,
     (gogoproto.nullable) = false
   ];
+}
+
+// QueryParamsRequest is the request message for the Query/Params endpoint.
+message QueryParamsRequest {}
+
+// QueryParamsResponse is the response message for the Query/Params endpoint.
+message QueryParamsResponse {
+  // params defines the vault module parameters.
+  Params params = 1 [(gogoproto.nullable) = false];
 }

--- a/third_party/proto/provlabs/vault/v1/tx.proto
+++ b/third_party/proto/provlabs/vault/v1/tx.proto
@@ -6,6 +6,7 @@ import "cosmos/base/v1beta1/coin.proto";
 import "cosmos/msg/v1/msg.proto";
 import "cosmos_proto/cosmos.proto";
 import "gogoproto/gogo.proto";
+import "provlabs/vault/v1/params.proto";
 
 option go_package = "github.com/provlabs/vault/types";
 
@@ -37,6 +38,18 @@ service Msg {
 
   // UpdateWithdrawalDelay allows updating the withdrawal delay for a vault.
   rpc UpdateWithdrawalDelay(MsgUpdateWithdrawalDelayRequest) returns (MsgUpdateWithdrawalDelayResponse);
+
+  // UpdateMinSwapInValue sets the minimum allowed value for a swap-in operation.
+  rpc UpdateMinSwapInValue(MsgUpdateMinSwapInValueRequest) returns (MsgUpdateMinSwapInValueResponse);
+
+  // UpdateMinSwapOutValue sets the minimum allowed value for a swap-out operation.
+  rpc UpdateMinSwapOutValue(MsgUpdateMinSwapOutValueRequest) returns (MsgUpdateMinSwapOutValueResponse);
+
+  // UpdateMaxSwapInValue sets the maximum allowed value for a swap-in operation.
+  rpc UpdateMaxSwapInValue(MsgUpdateMaxSwapInValueRequest) returns (MsgUpdateMaxSwapInValueResponse);
+
+  // UpdateMaxSwapOutValue sets the maximum allowed value for a swap-out operation.
+  rpc UpdateMaxSwapOutValue(MsgUpdateMaxSwapOutValueRequest) returns (MsgUpdateMaxSwapOutValueResponse);
 
   // ToggleSwapIn allows enabling or disabling swap-in operations for a vault.
   rpc ToggleSwapIn(MsgToggleSwapInRequest) returns (MsgToggleSwapInResponse);
@@ -86,6 +99,12 @@ service Msg {
   // SetAssetManager sets or clears the optional asset manager address for a vault.
   // The vault admin must sign this transaction. Passing an empty address clears it.
   rpc SetAssetManager(MsgSetAssetManagerRequest) returns (MsgSetAssetManagerResponse);
+
+  // UpdateParams updates the module parameters.
+  rpc UpdateParams(MsgUpdateParamsRequest) returns (MsgUpdateParamsResponse);
+
+  // UpdateVaultAUMFeeBips updates the AUM fee bips for a specific vault.
+  rpc UpdateVaultAUMFeeBips(MsgUpdateVaultAUMFeeBipsRequest) returns (MsgUpdateVaultAUMFeeBipsResponse);
 }
 
 // MsgCreateVaultRequest is the request message for the CreateVault endpoint.
@@ -104,6 +123,22 @@ message MsgCreateVaultRequest {
   // withdrawal_delay_seconds is the time period (in seconds) that a withdrawal
   // must wait in the pending queue before being processed.
   uint64 withdrawal_delay_seconds = 5;
+  // min_swap_in_value is the minimum value required for a deposit, measured in the underlying_asset.
+  // - Values must be non-negative (>= 0).
+  // - An empty string "" or "0" indicates no minimum.
+  string min_swap_in_value = 6 [(cosmos_proto.scalar) = "cosmos.IntString"];
+  // min_swap_out_value is the minimum value required for a withdrawal, measured in the underlying_asset.
+  // - Values must be non-negative (>= 0).
+  // - An empty string "" or "0" indicates no minimum.
+  string min_swap_out_value = 7 [(cosmos_proto.scalar) = "cosmos.IntString"];
+  // max_swap_in_value is the maximum value allowed for a deposit, measured in the underlying_asset.
+  // - Values must be positive (> 0).
+  // - An empty string "" clears the maximum / represents no maximum.
+  string max_swap_in_value = 8 [(cosmos_proto.scalar) = "cosmos.IntString"];
+  // max_swap_out_value is the maximum value allowed for a withdrawal, measured in the underlying_asset.
+  // - Values must be positive (> 0).
+  // - An empty string "" indicates no maximum limit.
+  string max_swap_out_value = 9 [(cosmos_proto.scalar) = "cosmos.IntString"];
 }
 
 // MsgCreateVaultResponse is the response message for the CreateVault endpoint.
@@ -233,6 +268,74 @@ message MsgUpdateWithdrawalDelayRequest {
 
 // MsgUpdateWithdrawalDelayResponse is the response message for the UpdateWithdrawalDelay endpoint.
 message MsgUpdateWithdrawalDelayResponse {}
+
+// MsgUpdateMinSwapInValueRequest is the request message for updating the minimum swap-in value of a vault.
+message MsgUpdateMinSwapInValueRequest {
+  option (cosmos.msg.v1.signer) = "authority";
+
+  // authority is the bech32 address of the vault administrator or asset manager.
+  string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  // vault_address is the bech32 address of the vault.
+  string vault_address = 2;
+  // min_swap_in_value is the minimum value required for a deposit, measured in the underlying_asset.
+  // - Values must be non-negative (>= 0).
+  // - An empty string "" or "0" clears the minimum / represents no minimum.
+  string min_swap_in_value = 3 [(cosmos_proto.scalar) = "cosmos.IntString"];
+}
+
+// MsgUpdateMinSwapInValueResponse is the response message for the UpdateMinSwapInValue endpoint.
+message MsgUpdateMinSwapInValueResponse {}
+
+// MsgUpdateMinSwapOutValueRequest is the request message for updating the minimum swap-out value of a vault.
+message MsgUpdateMinSwapOutValueRequest {
+  option (cosmos.msg.v1.signer) = "authority";
+
+  // authority is the bech32 address of the vault administrator or asset manager.
+  string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  // vault_address is the bech32 address of the vault.
+  string vault_address = 2;
+  // min_swap_out_value is the minimum value required for a withdrawal, measured in the underlying_asset.
+  // - Values must be non-negative (>= 0).
+  // - An empty string "" or "0" clears the minimum / represents no minimum.
+  string min_swap_out_value = 3 [(cosmos_proto.scalar) = "cosmos.IntString"];
+}
+
+// MsgUpdateMinSwapOutValueResponse is the response message for the UpdateMinSwapOutValue endpoint.
+message MsgUpdateMinSwapOutValueResponse {}
+
+// MsgUpdateMaxSwapInValueRequest is the request message for updating the maximum swap-in value of a vault.
+message MsgUpdateMaxSwapInValueRequest {
+  option (cosmos.msg.v1.signer) = "authority";
+
+  // authority is the bech32 address of the vault administrator or asset manager.
+  string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  // vault_address is the bech32 address of the vault.
+  string vault_address = 2;
+  // max_swap_in_value is the maximum value allowed for a deposit, measured in the underlying_asset.
+  // - Values must be positive (> 0).
+  // - An empty string "" clears the maximum / represents no maximum.
+  string max_swap_in_value = 3 [(cosmos_proto.scalar) = "cosmos.IntString"];
+}
+
+// MsgUpdateMaxSwapInValueResponse is the response message for the UpdateMaxSwapInValue endpoint.
+message MsgUpdateMaxSwapInValueResponse {}
+
+// MsgUpdateMaxSwapOutValueRequest is the request message for updating the maximum swap-out value of a vault.
+message MsgUpdateMaxSwapOutValueRequest {
+  option (cosmos.msg.v1.signer) = "authority";
+
+  // authority is the bech32 address of the vault administrator or asset manager.
+  string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  // vault_address is the bech32 address of the vault.
+  string vault_address = 2;
+  // max_swap_out_value is the maximum value allowed for a withdrawal, measured in the underlying_asset.
+  // - Values must be positive (> 0).
+  // - An empty string "" clears the maximum / represents no maximum.
+  string max_swap_out_value = 3 [(cosmos_proto.scalar) = "cosmos.IntString"];
+}
+
+// MsgUpdateMaxSwapOutValueResponse is the response message for the UpdateMaxSwapOutValue endpoint.
+message MsgUpdateMaxSwapOutValueResponse {}
 
 // MsgToggleSwapInRequest is the request message for enabling or disabling swap-in operations for a vault.
 message MsgToggleSwapInRequest {
@@ -446,3 +549,32 @@ message MsgSetAssetManagerRequest {
 
 // MsgSetAssetManagerResponse is the response message for the SetAssetManager endpoint.
 message MsgSetAssetManagerResponse {}
+
+// MsgUpdateParamsRequest is the request message for updating the module parameters.
+message MsgUpdateParamsRequest {
+  option (cosmos.msg.v1.signer) = "authority";
+
+  // authority is the address of the governance module account.
+  string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  // params defines the vault module parameters to update.
+  Params params = 2 [(gogoproto.nullable) = false];
+}
+
+// MsgUpdateParamsResponse is the response message for the UpdateParams endpoint.
+message MsgUpdateParamsResponse {}
+
+// MsgUpdateVaultAUMFeeBipsRequest is the request message for updating the AUM fee bips for a specific vault.
+message MsgUpdateVaultAUMFeeBipsRequest {
+  option (cosmos.msg.v1.signer) = "authority";
+
+  // authority is the tech fee address authorized to update per-vault bips.
+  string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  // vault_address is the bech32 address of the vault to update.
+  string vault_address = 2;
+  // aum_fee_bips is the new fee rate (in basis points) for the vault.
+  // The value must be between 0 and 10,000 (inclusive), where 10,000 represents 100%.
+  uint32 aum_fee_bips = 3;
+}
+
+// MsgUpdateVaultAUMFeeBipsResponse is the response message for the UpdateVaultAUMFeeBips endpoint.
+message MsgUpdateVaultAUMFeeBipsResponse {}

--- a/third_party/proto/provlabs/vault/v1/vault.proto
+++ b/third_party/proto/provlabs/vault/v1/vault.proto
@@ -95,6 +95,54 @@ message VaultAccount {
   // collateral operations alongside the admin (e.g., pausing/unpausing, depositing/withdrawing
   // principal or interest funds). If unset (empty string), only the admin may perform those actions.
   string asset_manager = 20 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+
+  // fee_period_start is the start time (in Unix seconds) of the current AUM fee collection period.
+  // This is a module-managed timestamp kept in sync with the fee timeout queue machinery.
+  int64 fee_period_start = 21;
+
+  // fee_period_timeout is the end time (in Unix seconds) of the current AUM fee collection period.
+  // This is a module-managed timestamp kept in sync with the fee timeout queue machinery.
+  int64 fee_period_timeout = 22;
+
+  // outstanding_aum_fee is the amount of AUM fee that has been calculated but not yet collected
+  // due to insufficient liquidity in the principal marker. This amount is always denominated
+  // in the vault's payment_denom, must be preserved, and is carried into valuation computations.
+  cosmos.base.v1beta1.Coin outstanding_aum_fee = 23 [(gogoproto.nullable) = false];
+
+  // aum_fee_bips is the AUM fee rate (in basis points) for this specific vault.
+  // Units: Basis Points (1 bps = 0.01%).
+  // Valid Range: 0 to 10000 (0% to 100%).
+  // A value of 0 disables AUM fee collection for this vault.
+  // Negative values are not supported (uint32).
+  uint32 aum_fee_bips = 24;
+
+  // min_swap_in_value is a string representing the minimum value required for a deposit.
+  // - The value is measured in the underlying_asset.
+  // - Incoming payment_denom deposits are converted to this unit before checking.
+  // - Values must be non-negative (>= 0).
+  // - If empty ("") or "0", there is no minimum limit.
+  string min_swap_in_value = 25 [(cosmos_proto.scalar) = "cosmos.IntString"];
+
+  // min_swap_out_value is a string representing the minimum value required for a withdrawal.
+  // - The value is measured in the underlying_asset.
+  // - Outgoing redemptions are converted to this unit before checking.
+  // - Values must be non-negative (>= 0).
+  // - If empty ("") or "0", there is no minimum limit.
+  string min_swap_out_value = 26 [(cosmos_proto.scalar) = "cosmos.IntString"];
+
+  // max_swap_in_value is a string representing the maximum value allowed for a deposit.
+  // - The value is measured in the underlying_asset.
+  // - Incoming payment_denom deposits are converted to this unit before checking.
+  // - Values must be positive (> 0).
+  // - An empty string "" indicates no maximum limit.
+  string max_swap_in_value = 27 [(cosmos_proto.scalar) = "cosmos.IntString"];
+
+  // max_swap_out_value is a string representing the maximum value allowed for a withdrawal.
+  // - The value is measured in the underlying_asset.
+  // - Outgoing redemptions are converted to this unit before checking.
+  // - Values must be positive (> 0).
+  // - An empty string "" indicates no maximum limit.
+  string max_swap_out_value = 28 [(cosmos_proto.scalar) = "cosmos.IntString"];
 }
 
 // AccountBalance represents the coin balance of a single account.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

## [v1.1.0](https://github.com/provlabs/vault/releases/tag/v1.1.0) 2026-06-04

This release introduces the 15 bps annual AUM technology fee with governance-managed
fee parameters and per-vault rate control, configurable minimum and maximum limits for
swap-in and swap-out operations, and broad numeric hardening across the NAV, AUM, and
interest calculations so that oversized values return errors instead of panicking the
block hook. The `provenance` dependency is repointed from the `provlabs` fork to upstream
`main`, with accompanying Cosmos SDK and Go toolchain bumps.

**Client API breaking:** the `AutoCLI` positional argument order for `CreateVault` and
`SetShareDenomMetadata` was aligned with the proto definitions. Scripts and tooling that
rely on the previous positional order must be updated. See
[#135](https://github.com/provlabs/vault/issues/135) for details.

### Features

* Implemented configurable minimum and maximum limits for swap-in and swap-out operations [#39](https://github.com/provlabs/vault/issues/39).
* Add gemini file agent persona file with update test [PR 176](https://github.com/provlabs/vault/pull/176).
* Implement 15 bps annual AUM technology fee collected from vault principal [PR 178](https://github.com/provlabs/vault/pull/178).
* Add Claude Code agent personas and skills for code review, testing, and Cosmos SDK / Provenance workflows [PR 196](https://github.com/provlabs/vault/pull/196).

### Improvements

* Ensure atomicity in withdrawal processing via CacheContext to prevent inconsistent states during failures [#131](https://github.com/provlabs/vault/issues/131).
* Aligned `AutoCLI` positional argument order with proto definitions for `CreateVault` (`[#135](https://github.com/provlabs/vault/issues/135).
* Replaced all `ctx.Logger()` calls in the keeper package with the module-scoped `k.getLogger(ctx)` for consistent, structured logging attributed to `x/vault`, and documented the convention in `GEMINI.md` [#179](https://github.com/provlabs/vault/issues/179).
* Implemented global governance parameters for AUM fees and granular per-vault fee rate (bips) management, migrating hardcoded fee logic to a formal Params structure with authorized update capabilities [#180](https://github.com/provlabs/vault/issues/180).
* Convert the `.claude/skills/*/scripts/` helpers (pr-review, branch-diff-analysis, vault-lint-test) from Bash + `jq` to Python 3 stdlib equivalents [PR 200](https://github.com/provlabs/vault/pull/200).
* Add an absolute interest-rate ceiling and overflow-safe interest calculations [PR 205](https://github.com/provlabs/vault/pull/205).
* Document and add test coverage for the bridge mint/burn supply-of-record model, where bridge operations never mutate the vault's `TotalShares` [#207](https://github.com/provlabs/vault/issues/207).
* Add safe-math operations to AUM calculations so overflows return an error instead of panicking [PR 210](https://github.com/provlabs/vault/pull/210).

### Bug Fixes

* Guard NAV valuation multiplications with `SafeMul` so an oversized net asset value returns an error instead of panicking the block hook [#206](https://github.com/provlabs/vault/issues/206).

### Dependencies

* Go bumped to 1.25.8 (from 1.24.1) to match the Go version required by upstream Provenance [#188](https://github.com/provlabs/vault/issues/188).
* `github.com/cosmos/cosmos-sdk` bumped to v0.53.6 (from v0.53.5) [#188](https://github.com/provlabs/vault/issues/188).
* `github.com/provenance-io/provenance` repointed from the `github.com/provlabs/provenance` fork to upstream `main` at `v1.3.2-0.20260519172448-9b0fb12c99b3` (commit `9b0fb12c`) [#188](https://github.com/provlabs/vault/issues/188).

### Full Commit History

* https://github.com/provlabs/vault/compare/v1.0.15...v1.1.0


closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added vault parameters query endpoint for retrieving governance settings
  * Enabled configuration of swap deposit and withdrawal limits per vault
  * Enhanced AUM fee tracking with outstanding fee monitoring and fee period management

* **Chores**
  * Updated vault module dependency to v1.1.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->