### PR TITLE
Limit the msgs in a trigger by gas.

### DIFF
--- a/.changelog/unreleased/improvements/2572-cap-trigger-msgs-by-gas.md
+++ b/.changelog/unreleased/improvements/2572-cap-trigger-msgs-by-gas.md
@@ -1,0 +1,1 @@
+* Limit a trigger's total gas to the same 4,000,000 gas that a tx gets [PR 2572](https://github.com/provenance-io/provenance/pull/2572).

--- a/x/trigger/keeper/trigger_dispatcher.go
+++ b/x/trigger/keeper/trigger_dispatcher.go
@@ -10,6 +10,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
 
+	"github.com/provenance-io/provenance/internal/antewrapper"
 	"github.com/provenance-io/provenance/x/trigger/types"
 )
 
@@ -69,6 +70,10 @@ func (k Keeper) runActions(ctx sdk.Context, actions []*codectypes.Any) error {
 // handleMsgs Handles each message and verifies gas limit has not been exceeded.
 func (k Keeper) handleMsgs(ctx sdk.Context, msgs []sdk.Msg) ([]sdk.Result, error) {
 	results := make([]sdk.Result, len(msgs))
+	// Each set of Msgs gets the same amount of gas as if they were supplied in a tx.
+	// Because we're in a BeginBlock, the existing gas meter is either a no-op or infinite, and doesn't matter.
+	// We don't use a flat-fee gas meter here because the fees were already paid, and we don't need to track them again.
+	ctx = ctx.WithGasMeter(storetypes.NewGasMeter(antewrapper.TxGasLimit))
 
 	for i, msg := range msgs {
 		handler := k.router.Handler(msg)


### PR DESCRIPTION
In the x/trigger module's `BeginBlocker`, while processing triggers, use a limited gas meter for each trigger's set of Msgs. The gas meter will be limited to the same amount of gas that we limit a tx to: 4,000,000. In other words, the combined gas used by all the Msgs of a single trigger must be at most 4,000,000. Each trigger gets its own gas meter.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gas metering consistency for message processing during BeginBlock operations.
* **Improvements**
  * Capped a trigger’s total gas limit to 4,000,000 gas to match transaction gas limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->