### PR TITLE
Switch to collections in the metadata module.

### DIFF
--- a/.changelog/unreleased/features/2495-collections-metadata.md
+++ b/.changelog/unreleased/features/2495-collections-metadata.md
@@ -1,0 +1,1 @@
+* Switch to collections in the metadata module [#2495](https://github.com/provenance-io/provenance/issues/2495).

--- a/app/app.go
+++ b/app/app.go
@@ -575,7 +575,7 @@ func New(
 	app.MarkerKeeper = &markerKeeper
 
 	app.MetadataKeeper = metadatakeeper.NewKeeper(
-		appCodec, keys[metadatatypes.StoreKey], app.AccountKeeper, app.AuthzKeeper, app.AttributeKeeper, app.MarkerKeeper, app.BankKeeper,
+		appCodec, runtime.NewKVStoreService(keys[metadatatypes.StoreKey]), app.AccountKeeper, app.AuthzKeeper, app.AttributeKeeper, app.MarkerKeeper, app.BankKeeper,
 	)
 
 	app.NFTKeeper = nftkeeper.NewKeeper(

--- a/x/metadata/keeper/export_test.go
+++ b/x/metadata/keeper/export_test.go
@@ -1,7 +1,7 @@
 package keeper
 
 import (
-	storetypes "cosmossdk.io/store/types"
+	corestore "cosmossdk.io/core/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/provenance-io/provenance/x/metadata/types"
@@ -10,9 +10,10 @@ import (
 // This file is available only to unit tests and exposes private things
 // so that they can be used in unit tests.
 
-// GetStoreKey is a TEST ONLY getter for the keeper's storekey.
-func (k *Keeper) GetStoreKey() storetypes.StoreKey {
-	return k.storeKey
+// GetStoreService is a TEST ONLY getter for the keeper's store service.
+// Used by tests that need to write raw bytes directly into the store (e.g. to simulate corrupt state).
+func (k *Keeper) GetStoreService() corestore.KVStoreService {
+	return k.storeService
 }
 
 // SetAuthKeeper is a TEST ONLY setter for the keeper's authKeeper.

--- a/x/metadata/keeper/keeper.go
+++ b/x/metadata/keeper/keeper.go
@@ -4,8 +4,9 @@ import (
 	"net/url"
 	"slices"
 
+	"cosmossdk.io/collections"
+	corestore "cosmossdk.io/core/store"
 	"cosmossdk.io/log"
-	storetypes "cosmossdk.io/store/types"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -16,13 +17,16 @@ import (
 	"github.com/provenance-io/provenance/x/metadata/types"
 )
 
+// indexPresent is the sentinel value stored in all secondary index collections,
+var indexPresent = []byte{0x01}
+
 // Keeper is the concrete state-based API for the metadata module.
 type Keeper struct {
 	// Key to access the key-value store from sdk.Context
-	storeKey storetypes.StoreKey
-	cdc      codec.BinaryCodec
-
-	moduleAddr sdk.AccAddress
+	storeService corestore.KVStoreService
+	cdc          codec.BinaryCodec
+	moduleAddr   sdk.AccAddress
+	schema       collections.Schema
 
 	// To check if accounts exist and set public keys.
 	authKeeper AuthKeeper
@@ -38,16 +42,46 @@ type Keeper struct {
 
 	// For managing value owners
 	bankKeeper BankKeeper
+	// Primary data collections.
+	// Key = MetadataAddress[1:] to preserve legacy storage layout
+	scopeCollections       collections.Map[[]byte, types.Scope]
+	sessionCollections     collections.Map[[]byte, types.Session]
+	recordCollections      collections.Map[[]byte, types.Record]
+	contractSpecCollection collections.Map[[]byte, types.ContractSpecification]
+	scopeSpecs             collections.Map[[]byte, types.ScopeSpecification]
+	recordSpecs            collections.Map[[]byte, types.RecordSpecification]
+	// OS Locator collection.
+	// Key = address.MustLengthPrefix(ownerAddr) — matches existing GetOSLocatorKey layout.
+	osLocators collections.Map[[]byte, types.ObjectStoreLocator]
+	// OS Locator params — single item stored at the prefix bytes.
+	osLocatorParamsCollection collections.Item[types.OSLocatorParams]
+	// Net Asset Values.
+	// Key = address.MustLengthPrefix(scopeAddr) + []byte(denom) — matches NetAssetValueKey layout.
+	netAssetValues collections.Map[[]byte, types.NetAssetValue]
+
+	// Secondary index caches (value = []byte{0x01} matching existing layout).
+	// prefix 0x17: key = length_prefix(addr) + scopeID_17bytes
+	addressScopeIndex collections.Map[[]byte, []byte]
+	// prefix 0x11: key = scopeSpecID_17bytes + scopeID_17bytes
+	scopeSpecScopeIndex collections.Map[[]byte, []byte]
+	// prefix 0x19: key = length_prefix(addr) + scopeSpecID_17bytes
+	addressScopeSpecIndex collections.Map[[]byte, []byte]
+	// prefix 0x14: key = contractSpecID_17bytes + scopeSpecID_17bytes
+	contractSpecScopeSpecIndex collections.Map[[]byte, []byte]
+	// prefix 0x20: key = length_prefix(addr) + contractSpecID_17bytes
+	addressContractSpecIndex collections.Map[[]byte, []byte]
 }
 
 // NewKeeper creates new instances of the metadata Keeper.
 func NewKeeper(
-	cdc codec.BinaryCodec, key storetypes.StoreKey, authKeeper AuthKeeper,
+	cdc codec.BinaryCodec, key corestore.KVStoreService, authKeeper AuthKeeper,
 	authzKeeper AuthzKeeper, attrKeeper AttrKeeper, markerKeeper MarkerKeeper,
 	bankKeeper bankkeeper.BaseKeeper,
 ) Keeper {
-	return Keeper{
-		storeKey:     key,
+	sb := collections.NewSchemaBuilder(key)
+
+	k := Keeper{
+		storeService: key,
 		cdc:          cdc,
 		moduleAddr:   authtypes.NewModuleAddress(types.ModuleName),
 		authKeeper:   authKeeper,
@@ -55,7 +89,105 @@ func NewKeeper(
 		attrKeeper:   attrKeeper,
 		markerKeeper: markerKeeper,
 		bankKeeper:   NewMDBankKeeper(bankKeeper),
+
+		scopeCollections: collections.NewMap(sb,
+			collections.NewPrefix(types.ScopeKeyPrefix),
+			"scopes",
+			collections.BytesKey,
+			codec.CollValue[types.Scope](cdc)),
+
+		sessionCollections: collections.NewMap(sb,
+			collections.NewPrefix(types.SessionKeyPrefix),
+			"sessions",
+			collections.BytesKey,
+			codec.CollValue[types.Session](cdc)),
+
+		recordCollections: collections.NewMap(sb,
+			collections.NewPrefix(types.RecordKeyPrefix),
+			"records",
+			collections.BytesKey,
+			codec.CollValue[types.Record](cdc)),
+
+		contractSpecCollection: collections.NewMap(sb,
+			collections.NewPrefix(types.ContractSpecificationKeyPrefix),
+			"contract_specs",
+			collections.BytesKey,
+			codec.CollValue[types.ContractSpecification](cdc)),
+
+		scopeSpecs: collections.NewMap(sb,
+			collections.NewPrefix(types.ScopeSpecificationKeyPrefix),
+			"scope_specs",
+			collections.BytesKey,
+			codec.CollValue[types.ScopeSpecification](cdc)),
+
+		recordSpecs: collections.NewMap(sb,
+			collections.NewPrefix(types.RecordSpecificationKeyPrefix),
+			"record_specs",
+			collections.BytesKey,
+			codec.CollValue[types.RecordSpecification](cdc)),
+
+		osLocators: collections.NewMap(sb,
+			collections.NewPrefix(types.OSLocatorAddressKeyPrefix),
+			"os_locators",
+			collections.BytesKey,
+			codec.CollValue[types.ObjectStoreLocator](cdc)),
+
+		osLocatorParamsCollection: collections.NewItem(sb,
+			collections.NewPrefix(types.OSLocatorParamPrefix),
+			"os_locator_params",
+			codec.CollValue[types.OSLocatorParams](cdc)),
+
+		netAssetValues: collections.NewMap(sb,
+			collections.NewPrefix(types.NetAssetValuePrefix),
+			"net_asset_values",
+			collections.BytesKey,
+			codec.CollValue[types.NetAssetValue](cdc)),
+
+		addressScopeIndex: collections.NewMap(sb,
+			collections.NewPrefix(types.AddressScopeCacheKeyPrefix),
+			"addr_scope_idx",
+			collections.BytesKey,
+			collections.BytesValue),
+
+		scopeSpecScopeIndex: collections.NewMap(sb,
+			collections.NewPrefix(types.ScopeSpecScopeCacheKeyPrefix),
+			"scope_spec_scope_idx",
+			collections.BytesKey,
+			collections.BytesValue),
+
+		addressScopeSpecIndex: collections.NewMap(sb,
+			collections.NewPrefix(types.AddressScopeSpecCacheKeyPrefix),
+			"addr_scope_spec_idx",
+			collections.BytesKey,
+			collections.BytesValue),
+
+		contractSpecScopeSpecIndex: collections.NewMap(sb,
+			collections.NewPrefix(types.ContractSpecScopeSpecCacheKeyPrefix),
+			"contract_spec_scope_spec_idx",
+			collections.BytesKey,
+			collections.BytesValue),
+
+		addressContractSpecIndex: collections.NewMap(sb,
+			collections.NewPrefix(types.AddressContractSpecCacheKeyPrefix),
+			"addr_contract_spec_idx",
+			collections.BytesKey,
+			collections.BytesValue),
 	}
+
+	schema, err := sb.Build()
+	if err != nil {
+		panic(err)
+	}
+	k.schema = schema
+	return k
+}
+
+// mdKey returns the collection key for a MetadataAddress.
+func mdKey(addr types.MetadataAddress) []byte {
+	if len(addr) == 0 {
+		return nil
+	}
+	return addr[1:]
 }
 
 // Logger returns a module-specific logger.

--- a/x/metadata/keeper/objectstore.go
+++ b/x/metadata/keeper/objectstore.go
@@ -3,34 +3,31 @@ package keeper
 import (
 	"fmt"
 
-	storetypes "cosmossdk.io/store/types"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/address"
 
 	"github.com/provenance-io/provenance/x/metadata/types"
 )
 
+// osLocatorKey returns the collection key for an OS Locator entry.
+// Matches address.MustLengthPrefix(ownerAddr) — without the 0x21 collection prefix.
+func osLocatorKey(ownerAddr sdk.AccAddress) []byte {
+	return address.MustLengthPrefix(ownerAddr)
+}
+
 // GetOsLocatorRecord Gets the object store locator entry from the kvstore for the given owner address.
 func (k Keeper) GetOsLocatorRecord(ctx sdk.Context, ownerAddr sdk.AccAddress) (osLocator types.ObjectStoreLocator, found bool) {
-	key := types.GetOSLocatorKey(ownerAddr)
-	store := ctx.KVStore(k.storeKey)
-	b := store.Get(key)
-	if b == nil {
-		return types.ObjectStoreLocator{}, false
-	}
-	err := k.cdc.Unmarshal(b, &osLocator)
+	val, err := k.osLocators.Get(ctx, osLocatorKey(ownerAddr))
 	if err != nil {
-		ctx.Logger().Error("failed to unmarshal locator", "err", err)
 		return types.ObjectStoreLocator{}, false
 	}
-	return osLocator, true
+	return val, true
 }
 
 // OSLocatorExists checks if the provided bech32 owner address has a OSL entry in the kvstore.
 func (k Keeper) OSLocatorExists(ctx sdk.Context, ownerAddr sdk.AccAddress) bool {
-	key := types.GetOSLocatorKey(ownerAddr)
-	store := ctx.KVStore(k.storeKey)
-	return store.Has(key)
+	has, err := k.osLocators.Has(ctx, osLocatorKey(ownerAddr))
+	return err == nil && has
 }
 
 // SetOSLocator binds an OS Locator to an address in the kvstore.
@@ -44,40 +41,22 @@ func (k Keeper) SetOSLocator(ctx sdk.Context, ownerAddr, encryptionKey sdk.AccAd
 	if account := k.authKeeper.GetAccount(ctx, ownerAddr); account == nil {
 		return types.ErrInvalidAddress
 	}
-	key := types.GetOSLocatorKey(ownerAddr)
-	store := ctx.KVStore(k.storeKey)
-	if store.Has(key) {
+	if k.OSLocatorExists(ctx, ownerAddr) {
 		return types.ErrOSLocatorAlreadyBound
 	}
-
 	record := types.NewOSLocatorRecord(ownerAddr, encryptionKey, urlToPersist.String())
-	bz, err := k.cdc.Marshal(&record)
-	if err != nil {
+	if err := k.osLocators.Set(ctx, osLocatorKey(ownerAddr), record); err != nil {
 		return err
 	}
-	store.Set(key, bz)
-
 	k.EmitEvent(ctx, types.NewEventOSLocatorCreated(record.Owner))
 	return nil
 }
 
 // IterateOSLocators runs a function for every ObjectStoreLocator entry in the kvstore.
 func (k Keeper) IterateOSLocators(ctx sdk.Context, cb func(account types.ObjectStoreLocator) (stop bool)) error {
-	store := ctx.KVStore(k.storeKey)
-	prefix := types.OSLocatorAddressKeyPrefix
-	it := storetypes.KVStorePrefixIterator(store, prefix)
-	defer it.Close() //nolint:errcheck // close error safe to ignore in this context.
-
-	for ; it.Valid(); it.Next() {
-		record := types.ObjectStoreLocator{}
-		if err := k.cdc.Unmarshal(it.Value(), &record); err != nil {
-			return err
-		}
-		if cb(record) {
-			break
-		}
-	}
-	return nil
+	return k.osLocators.Walk(ctx, nil, func(_ []byte, record types.ObjectStoreLocator) (stop bool, err error) {
+		return cb(record), nil
+	})
 }
 
 // GetOSLocatorByScope gets all Object Store Locators associated with a scope.
@@ -117,12 +96,12 @@ func (k Keeper) GetOSLocatorByScope(ctx sdk.Context, scopeID string) ([]types.Ob
 
 // RemoveOSLocator removes an os locator record from the kvstore.
 func (k Keeper) RemoveOSLocator(ctx sdk.Context, ownerAddr sdk.AccAddress) error {
-	key := types.GetOSLocatorKey(ownerAddr)
-	store := ctx.KVStore(k.storeKey)
-	if !store.Has(key) {
+	if !k.OSLocatorExists(ctx, ownerAddr) {
 		return types.ErrAddressNotBound
 	}
-	store.Delete(key)
+	if err := k.osLocators.Remove(ctx, osLocatorKey(ownerAddr)); err != nil {
+		return err
+	}
 	k.EmitEvent(ctx, types.NewEventOSLocatorDeleted(ownerAddr.String()))
 	return nil
 }
@@ -133,18 +112,14 @@ func (k Keeper) ModifyOSLocator(ctx sdk.Context, ownerAddr, encryptionKey sdk.Ac
 	if err != nil {
 		return err
 	}
-	key := types.GetOSLocatorKey(ownerAddr)
-	store := ctx.KVStore(k.storeKey)
-	if !store.Has(key) {
+
+	if !k.OSLocatorExists(ctx, ownerAddr) {
 		return types.ErrAddressNotBound
 	}
-
 	record := types.NewOSLocatorRecord(ownerAddr, encryptionKey, urlToPersist.String())
-	bz, err := k.cdc.Marshal(&record)
-	if err != nil {
+	if err := k.osLocators.Set(ctx, osLocatorKey(ownerAddr), record); err != nil {
 		return err
 	}
-	store.Set(key, bz)
 	k.EmitEvent(ctx, types.NewEventOSLocatorUpdated(record.Owner))
 	return nil
 }
@@ -154,17 +129,9 @@ func (k Keeper) ModifyOSLocator(ctx sdk.Context, ownerAddr, encryptionKey sdk.Ac
 // The uri format is not checked, and the owner address account is not looked up.
 // This also does not emit any events.
 func (k Keeper) ImportOSLocatorRecord(ctx sdk.Context, ownerAddr, encryptionKey sdk.AccAddress, uri string) error {
-	key := types.GetOSLocatorKey(ownerAddr)
-	store := ctx.KVStore(k.storeKey)
-	if store.Has(key) {
+	if k.OSLocatorExists(ctx, ownerAddr) {
 		return types.ErrOSLocatorAlreadyBound
 	}
-
 	record := types.NewOSLocatorRecord(ownerAddr, encryptionKey, uri)
-	bz, err := k.cdc.Marshal(&record)
-	if err != nil {
-		return err
-	}
-	store.Set(key, bz)
-	return nil
+	return k.osLocators.Set(ctx, osLocatorKey(ownerAddr), record)
 }

--- a/x/metadata/keeper/oslocatorparams.go
+++ b/x/metadata/keeper/oslocatorparams.go
@@ -1,6 +1,10 @@
 package keeper
 
 import (
+	"errors"
+
+	"cosmossdk.io/collections"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/provenance-io/provenance/x/metadata/types"
@@ -8,29 +12,21 @@ import (
 
 // GetOSLocatorParams returns the metadata OSLocatorParams.
 func (k Keeper) GetOSLocatorParams(ctx sdk.Context) (osLocatorParams types.OSLocatorParams) {
-	store := ctx.KVStore(k.storeKey)
-	bz := store.Get(types.OSLocatorParamPrefix)
-	if bz == nil {
-		return types.OSLocatorParams{
-			MaxUriLength: types.DefaultMaxURILength,
-		}
-	}
-	err := k.cdc.Unmarshal(bz, &osLocatorParams)
+	params, err := k.osLocatorParamsCollection.Get(ctx)
 	if err != nil {
+		if errors.Is(err, collections.ErrNotFound) {
+			return types.OSLocatorParams{MaxUriLength: types.DefaultMaxURILength}
+		}
 		panic(err)
 	}
-	return osLocatorParams
+	return params
 }
 
 // SetOSLocatorParams sets the metadata OSLocator parameters to the store.
 func (k Keeper) SetOSLocatorParams(ctx sdk.Context, params types.OSLocatorParams) {
-	bz, err := k.cdc.Marshal(&params)
-	if err != nil {
+	if err := k.osLocatorParamsCollection.Set(ctx, params); err != nil {
 		panic(err)
 	}
-
-	store := ctx.KVStore(k.storeKey)
-	store.Set(types.OSLocatorParamPrefix, bz)
 }
 
 // GetMaxURILength returns the configured parameter for max URI length on a locator record

--- a/x/metadata/keeper/query_server.go
+++ b/x/metadata/keeper/query_server.go
@@ -8,10 +8,9 @@ import (
 
 	"github.com/google/uuid"
 
-	"cosmossdk.io/store/prefix"
-
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/address"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/query"
 
@@ -151,36 +150,17 @@ func (k Keeper) ScopesAll(c context.Context, req *types.ScopesAllRequest) (*type
 		incInfo = !req.ExcludeIdInfo
 	}
 
-	pageRequest := getPageRequest(req)
-
 	ctx := sdk.UnwrapSDKContext(c)
-	kvStore := ctx.KVStore(k.storeKey)
-	prefixStore := prefix.NewStore(kvStore, types.ScopeKeyPrefix)
-
-	pageRes, err := query.Paginate(prefixStore, pageRequest, func(key, value []byte) error {
-		scope, vErr := k.readScopeBz(value)
-		if vErr == nil {
+	scopes, pageRes, err := query.CollectionPaginate(ctx, k.scopeCollections, getPageRequest(req),
+		func(_ []byte, scope types.Scope) (*types.ScopeWrapper, error) {
+			scope.ValueOwnerAddress = "" // clear — not trusted from state
 			k.PopulateScopeValueOwner(ctx, &scope)
-			retval.Scopes = append(retval.Scopes, types.WrapScope(&scope, incInfo))
-			return nil
-		}
-		// Something's wrong. Let's do what we can to give indications of it.
-		var addr types.MetadataAddress
-		kErr := addr.Unmarshal(key)
-		if kErr == nil {
-			k.Logger(ctx).Error("failed to unmarshal scope", "address", addr, "error", vErr)
-			retval.Scopes = append(retval.Scopes, types.WrapScopeNotFound(addr))
-		} else {
-			k64 := b64.StdEncoding.EncodeToString(key)
-			k.Logger(ctx).Error("failed to unmarshal scope key and value",
-				"key error", kErr, "value error", vErr, "key (base64)", k64)
-			retval.Scopes = append(retval.Scopes, &types.ScopeWrapper{})
-		}
-		return nil // Still want to move on to the next.
-	})
+			return types.WrapScope(&scope, incInfo), nil
+		})
 	if err != nil {
 		return &retval, sdkerrors.ErrInvalidRequest.Wrap(err.Error())
 	}
+	retval.Scopes = scopes
 	retval.Pagination = pageRes
 	return &retval, nil
 }
@@ -349,36 +329,15 @@ func (k Keeper) SessionsAll(c context.Context, req *types.SessionsAllRequest) (*
 		incInfo = !req.ExcludeIdInfo
 	}
 
-	pageRequest := getPageRequest(req)
-
 	ctx := sdk.UnwrapSDKContext(c)
-	kvStore := ctx.KVStore(k.storeKey)
-	prefixStore := prefix.NewStore(kvStore, types.SessionKeyPrefix)
-
-	pageRes, err := query.Paginate(prefixStore, pageRequest, func(key, value []byte) error {
-		var session types.Session
-		vErr := session.Unmarshal(value)
-		if vErr == nil {
-			retval.Sessions = append(retval.Sessions, types.WrapSession(&session, incInfo))
-			return nil
-		}
-		// Something's wrong. Let's do what we can to give indications of it.
-		var addr types.MetadataAddress
-		kErr := addr.Unmarshal(key)
-		if kErr == nil {
-			k.Logger(ctx).Error("failed to unmarshal session", "address", addr, "error", vErr)
-			retval.Sessions = append(retval.Sessions, types.WrapSessionNotFound(addr))
-		} else {
-			k64 := b64.StdEncoding.EncodeToString(key)
-			k.Logger(ctx).Error("failed to unmarshal session key and value",
-				"key error", kErr, "value error", vErr, "key (base64)", k64)
-			retval.Sessions = append(retval.Sessions, &types.SessionWrapper{})
-		}
-		return nil // Still want to move on to the next.
-	})
+	sessions, pageRes, err := query.CollectionPaginate(ctx, k.sessionCollections, getPageRequest(req),
+		func(_ []byte, session types.Session) (*types.SessionWrapper, error) {
+			return types.WrapSession(&session, incInfo), nil
+		})
 	if err != nil {
 		return &retval, sdkerrors.ErrInvalidRequest.Wrap(err.Error())
 	}
+	retval.Sessions = sessions
 	retval.Pagination = pageRes
 	return &retval, nil
 }
@@ -535,36 +494,15 @@ func (k Keeper) RecordsAll(c context.Context, req *types.RecordsAllRequest) (*ty
 		incInfo = !req.ExcludeIdInfo
 	}
 
-	pageRequest := getPageRequest(req)
-
 	ctx := sdk.UnwrapSDKContext(c)
-	kvStore := ctx.KVStore(k.storeKey)
-	prefixStore := prefix.NewStore(kvStore, types.RecordKeyPrefix)
-
-	pageRes, err := query.Paginate(prefixStore, pageRequest, func(key, value []byte) error {
-		var record types.Record
-		vErr := record.Unmarshal(value)
-		if vErr == nil {
-			retval.Records = append(retval.Records, types.WrapRecord(&record, incInfo))
-			return nil
-		}
-		// Something's wrong. Let's do what we can to give indications of it.
-		var addr types.MetadataAddress
-		kErr := addr.Unmarshal(key)
-		if kErr == nil {
-			k.Logger(ctx).Error("failed to unmarshal record", "address", addr, "error", vErr)
-			retval.Records = append(retval.Records, types.WrapRecordNotFound(addr))
-		} else {
-			k64 := b64.StdEncoding.EncodeToString(key)
-			k.Logger(ctx).Error("failed to unmarshal record key and value",
-				"key error", kErr, "value error", vErr, "key (base64)", k64)
-			retval.Records = append(retval.Records, &types.RecordWrapper{})
-		}
-		return nil // Still want to move on to the next.
-	})
+	records, pageRes, err := query.CollectionPaginate(ctx, k.recordCollections, getPageRequest(req),
+		func(_ []byte, record types.Record) (*types.RecordWrapper, error) {
+			return types.WrapRecord(&record, incInfo), nil
+		})
 	if err != nil {
 		return &retval, sdkerrors.ErrInvalidRequest.Wrap(err.Error())
 	}
+	retval.Records = records
 	retval.Pagination = pageRes
 	return &retval, nil
 }
@@ -591,24 +529,29 @@ func (k Keeper) Ownership(c context.Context, req *types.OwnershipRequest) (*type
 	}
 
 	ctx := sdk.UnwrapSDKContext(c)
-	store := ctx.KVStore(k.storeKey)
-	scopeStore := prefix.NewStore(store, types.GetAddressScopeCacheIteratorPrefix(addr))
+	addrPrefix := address.MustLengthPrefix(addr)
 
-	pageRes, err := query.Paginate(scopeStore, req.Pagination, func(key, _ []byte) error {
-		var ma types.MetadataAddress
-		if mErr := ma.Unmarshal(key); mErr != nil {
-			return mErr
-		}
-		scopeUUID, sErr := ma.ScopeUUID()
-		if sErr != nil {
-			return sErr
-		}
-		retval.ScopeUuids = append(retval.ScopeUuids, scopeUUID.String())
-		return nil
-	})
+	uuids, pageRes, err := query.CollectionPaginate(ctx, k.addressScopeIndex, req.Pagination,
+		func(key []byte, _ []byte) (string, error) {
+			scopeIDBytes := key[len(addrPrefix):]
+			var ma types.MetadataAddress
+			if mErr := ma.Unmarshal(scopeIDBytes); mErr != nil {
+				return "", mErr
+			}
+			scopeUUID, sErr := ma.ScopeUUID()
+			if sErr != nil {
+				return "", sErr
+			}
+			return scopeUUID.String(), nil
+		},
+		func(o *query.CollectionsPaginateOptions[[]byte]) {
+			o.Prefix = &addrPrefix
+		},
+	)
 	if err != nil {
 		return &retval, sdkerrors.ErrInvalidRequest.Wrapf("paginate: %v", err)
 	}
+	retval.ScopeUuids = uuids
 	retval.Pagination = pageRes
 
 	return &retval, nil
@@ -721,36 +664,15 @@ func (k Keeper) ScopeSpecificationsAll(c context.Context, req *types.ScopeSpecif
 		incInfo = !req.ExcludeIdInfo
 	}
 
-	pageRequest := getPageRequest(req)
-
 	ctx := sdk.UnwrapSDKContext(c)
-	kvStore := ctx.KVStore(k.storeKey)
-	prefixStore := prefix.NewStore(kvStore, types.ScopeSpecificationKeyPrefix)
-
-	pageRes, err := query.Paginate(prefixStore, pageRequest, func(key, value []byte) error {
-		var scopeSpec types.ScopeSpecification
-		vErr := scopeSpec.Unmarshal(value)
-		if vErr == nil {
-			retval.ScopeSpecifications = append(retval.ScopeSpecifications, types.WrapScopeSpec(&scopeSpec, incInfo))
-			return nil
-		}
-		// Something's wrong. Let's do what we can to give indications of it.
-		var addr types.MetadataAddress
-		kErr := addr.Unmarshal(key)
-		if kErr == nil {
-			k.Logger(ctx).Error("failed to unmarshal scope spec", "address", addr, "error", vErr)
-			retval.ScopeSpecifications = append(retval.ScopeSpecifications, types.WrapScopeSpecNotFound(addr))
-		} else {
-			k64 := b64.StdEncoding.EncodeToString(key)
-			k.Logger(ctx).Error("failed to unmarshal scope spec key and value",
-				"key error", kErr, "value error", vErr, "key (base64)", k64)
-			retval.ScopeSpecifications = append(retval.ScopeSpecifications, &types.ScopeSpecificationWrapper{})
-		}
-		return nil // Still want to move on to the next.
-	})
+	specs, pageRes, err := query.CollectionPaginate(ctx, k.scopeSpecs, getPageRequest(req),
+		func(_ []byte, spec types.ScopeSpecification) (*types.ScopeSpecificationWrapper, error) {
+			return types.WrapScopeSpec(&spec, incInfo), nil
+		})
 	if err != nil {
 		return &retval, sdkerrors.ErrInvalidRequest.Wrap(err.Error())
 	}
+	retval.ScopeSpecifications = specs
 	retval.Pagination = pageRes
 	return &retval, nil
 }
@@ -808,36 +730,15 @@ func (k Keeper) ContractSpecificationsAll(c context.Context, req *types.Contract
 		incInfo = !req.ExcludeIdInfo
 	}
 
-	pageRequest := getPageRequest(req)
-
 	ctx := sdk.UnwrapSDKContext(c)
-	kvStore := ctx.KVStore(k.storeKey)
-	prefixStore := prefix.NewStore(kvStore, types.ContractSpecificationKeyPrefix)
-
-	pageRes, err := query.Paginate(prefixStore, pageRequest, func(key, value []byte) error {
-		var contractSpec types.ContractSpecification
-		vErr := contractSpec.Unmarshal(value)
-		if vErr == nil {
-			retval.ContractSpecifications = append(retval.ContractSpecifications, types.WrapContractSpec(&contractSpec, incInfo))
-			return nil
-		}
-		// Something's wrong. Let's do what we can to give indications of it.
-		var addr types.MetadataAddress
-		kErr := addr.Unmarshal(key)
-		if kErr == nil {
-			k.Logger(ctx).Error("failed to unmarshal contract spec", "address", addr, "error", vErr)
-			retval.ContractSpecifications = append(retval.ContractSpecifications, types.WrapContractSpecNotFound(addr))
-		} else {
-			k64 := b64.StdEncoding.EncodeToString(key)
-			k.Logger(ctx).Error("failed to unmarshal contract spec key and value",
-				"key error", kErr, "value error", vErr, "key (base64)", k64)
-			retval.ContractSpecifications = append(retval.ContractSpecifications, &types.ContractSpecificationWrapper{})
-		}
-		return nil // Still want to move on to the next.
-	})
+	specs, pageRes, err := query.CollectionPaginate(ctx, k.contractSpecCollection, getPageRequest(req),
+		func(_ []byte, spec types.ContractSpecification) (*types.ContractSpecificationWrapper, error) {
+			return types.WrapContractSpec(&spec, incInfo), nil
+		})
 	if err != nil {
 		return &retval, sdkerrors.ErrInvalidRequest.Wrap(err.Error())
 	}
+	retval.ContractSpecifications = specs
 	retval.Pagination = pageRes
 	return &retval, nil
 }
@@ -927,37 +828,15 @@ func (k Keeper) RecordSpecificationsAll(c context.Context, req *types.RecordSpec
 		}
 		incInfo = !req.ExcludeIdInfo
 	}
-
-	pageRequest := getPageRequest(req)
-
 	ctx := sdk.UnwrapSDKContext(c)
-	kvStore := ctx.KVStore(k.storeKey)
-	prefixStore := prefix.NewStore(kvStore, types.RecordSpecificationKeyPrefix)
-
-	pageRes, err := query.Paginate(prefixStore, pageRequest, func(key, value []byte) error {
-		var recordSpec types.RecordSpecification
-		vErr := recordSpec.Unmarshal(value)
-		if vErr == nil {
-			retval.RecordSpecifications = append(retval.RecordSpecifications, types.WrapRecordSpec(&recordSpec, incInfo))
-			return nil
-		}
-		// Something's wrong. Let's do what we can to give indications of it.
-		var addr types.MetadataAddress
-		kErr := addr.Unmarshal(key)
-		if kErr == nil {
-			k.Logger(ctx).Error("failed to unmarshal record spec", "address", addr, "error", vErr)
-			retval.RecordSpecifications = append(retval.RecordSpecifications, types.WrapRecordSpecNotFound(addr))
-		} else {
-			k64 := b64.StdEncoding.EncodeToString(key)
-			k.Logger(ctx).Error("failed to unmarshal record spec key and value",
-				"key error", kErr, "value error", vErr, "key (base64)", k64)
-			retval.RecordSpecifications = append(retval.RecordSpecifications, &types.RecordSpecificationWrapper{})
-		}
-		return nil // Still want to move on to the next.
-	})
+	specs, pageRes, err := query.CollectionPaginate(ctx, k.recordSpecs, getPageRequest(req),
+		func(_ []byte, spec types.RecordSpecification) (*types.RecordSpecificationWrapper, error) {
+			return types.WrapRecordSpec(&spec, incInfo), nil
+		})
 	if err != nil {
 		return &retval, sdkerrors.ErrInvalidRequest.Wrap(err.Error())
 	}
+	retval.RecordSpecifications = specs
 	retval.Pagination = pageRes
 	return &retval, nil
 }
@@ -1076,7 +955,6 @@ func (k Keeper) OSLocatorsByURI(ctx context.Context, request *types.OSLocatorsBy
 	}
 
 	var sDec []byte
-	// rest request send in base64 encoded uri, using a URL-compatible base64 format.
 	if IsBase64(request.Uri) {
 		sDec, _ = b64.StdEncoding.DecodeString(request.Uri)
 	} else {
@@ -1088,23 +966,22 @@ func (k Keeper) OSLocatorsByURI(ctx context.Context, request *types.OSLocatorsBy
 	}
 	uriStr := uri.String()
 
-	osLocatorStore := prefix.NewStore(sdk.UnwrapSDKContext(ctx).KVStore(k.storeKey), types.OSLocatorAddressKeyPrefix)
-	retval.Pagination, err = query.FilteredPaginate(osLocatorStore, request.Pagination, func(_ []byte, value []byte, accumulate bool) (bool, error) {
-		record := types.ObjectStoreLocator{}
-		if rerr := k.cdc.Unmarshal(value, &record); rerr != nil {
-			return false, rerr
-		}
-		if record.LocatorUri != uriStr {
-			return false, nil
-		}
-		if accumulate {
-			retval.Locators = append(retval.Locators, record)
-		}
-		return true, nil
-	})
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	locators, pageRes, err := query.CollectionFilteredPaginate(sdkCtx, k.osLocators, request.Pagination,
+		// predicate: keep only matching URIs
+		func(_ []byte, locator types.ObjectStoreLocator) (bool, error) {
+			return locator.LocatorUri == uriStr, nil
+		},
+		// transform: return the locator as-is
+		func(_ []byte, locator types.ObjectStoreLocator) (types.ObjectStoreLocator, error) {
+			return locator, nil
+		},
+	)
 	if err != nil {
 		return &retval, err
 	}
+	retval.Locators = locators
+	retval.Pagination = pageRes
 	if len(retval.Locators) == 0 {
 		return &retval, types.ErrNoRecordsFound
 	}
@@ -1146,20 +1023,16 @@ func (k Keeper) OSAllLocators(ctx context.Context, request *types.OSAllLocatorsR
 		retval.Request = request
 	}
 
-	osLocatorStore := prefix.NewStore(sdk.UnwrapSDKContext(ctx).KVStore(k.storeKey), types.OSLocatorAddressKeyPrefix)
-	var err error
-	retval.Pagination, err = query.Paginate(osLocatorStore, request.Pagination, func(_ []byte, value []byte) error {
-		record := types.ObjectStoreLocator{}
-		if rerr := k.cdc.Unmarshal(value, &record); rerr != nil {
-			return rerr
-		}
-		retval.Locators = append(retval.Locators, record)
-		return nil
-	})
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	locators, pageRes, err := query.CollectionPaginate(sdkCtx, k.osLocators, request.Pagination,
+		func(_ []byte, locator types.ObjectStoreLocator) (types.ObjectStoreLocator, error) {
+			return locator, nil
+		})
 	if err != nil {
 		return &retval, err
 	}
-
+	retval.Locators = locators
+	retval.Pagination = pageRes
 	return &retval, nil
 }
 

--- a/x/metadata/keeper/record.go
+++ b/x/metadata/keeper/record.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	storetypes "cosmossdk.io/store/types"
+	"cosmossdk.io/collections"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/gogoproto/proto"
@@ -21,13 +21,11 @@ func (k Keeper) GetRecord(ctx sdk.Context, id types.MetadataAddress) (record typ
 	if !id.IsRecordAddress() {
 		return record, false
 	}
-	store := ctx.KVStore(k.storeKey)
-	b := store.Get(id)
-	if b == nil {
+	val, err := k.recordCollections.Get(ctx, mdKey(id))
+	if err != nil {
 		return types.Record{}, false
 	}
-	k.cdc.MustUnmarshal(b, &record)
-	return record, true
+	return val, true
 }
 
 // GetRecords returns records for a scope optionally limited to a name.
@@ -58,17 +56,16 @@ func (k Keeper) GetRecords(ctx sdk.Context, scopeAddress types.MetadataAddress, 
 
 // SetRecord stores a record in the module kv store.
 func (k Keeper) SetRecord(ctx sdk.Context, record types.Record) {
-	store := ctx.KVStore(k.storeKey)
-	b := k.cdc.MustMarshal(&record)
-
 	recordID := record.SessionId.MustGetAsRecordAddress(record.Name)
 
 	var event proto.Message = types.NewEventRecordCreated(recordID, record.SessionId)
-	if store.Has(recordID) {
+	if has, _ := k.recordCollections.Has(ctx, mdKey(recordID)); has {
 		event = types.NewEventRecordUpdated(recordID, record.SessionId)
 	}
 
-	store.Set(recordID, b)
+	if err := k.recordCollections.Set(ctx, mdKey(recordID), record); err != nil {
+		panic(err)
+	}
 	k.EmitEvent(ctx, event)
 }
 
@@ -81,10 +78,10 @@ func (k Keeper) RemoveRecord(ctx sdk.Context, id types.MetadataAddress) {
 	if !found {
 		return
 	}
-	store := ctx.KVStore(k.storeKey)
-	store.Delete(id)
+	if err := k.recordCollections.Remove(ctx, mdKey(id)); err != nil {
+		panic(err)
+	}
 	k.EmitEvent(ctx, types.NewEventRecordDeleted(id))
-
 	// Remove the session too if there are no more records in it.
 	k.RemoveSession(ctx, record.SessionId)
 }
@@ -93,24 +90,14 @@ func (k Keeper) RemoveRecord(ctx sdk.Context, id types.MetadataAddress) {
 // If the scopeID is an empty MetadataAddress, all records will be processed.
 // Otherwise, just the records for the given scopeID will be processed.
 func (k Keeper) IterateRecords(ctx sdk.Context, scopeID types.MetadataAddress, handler func(types.Record) (stop bool)) error {
-	store := ctx.KVStore(k.storeKey)
-	prefix, err := scopeID.ScopeRecordIteratorPrefix()
-	if err != nil {
-		return err
+	walkFn := func(_ []byte, record types.Record) (stop bool, err error) {
+		return handler(record), nil
 	}
-	it := storetypes.KVStorePrefixIterator(store, prefix)
-	defer it.Close() //nolint:errcheck // close error safe to ignore in this context.
-
-	for ; it.Valid(); it.Next() {
-		var record types.Record
-		err = k.cdc.Unmarshal(it.Value(), &record)
-		if err != nil {
-			k.Logger(ctx).Error("could not unmarshal record", "address", it.Key(), "error", err)
-		} else if handler(record) {
-			break
-		}
+	if len(scopeID) > 1 {
+		rng := new(collections.Range[[]byte]).Prefix(scopeID[1:]) // 16-byte scope UUID
+		return k.recordCollections.Walk(ctx, rng, walkFn)
 	}
-	return nil
+	return k.recordCollections.Walk(ctx, nil, walkFn) // literal nil → whole collection
 }
 
 // ValidateWriteRecord checks the current record and the proposed record to determine if the proposed changes are valid

--- a/x/metadata/keeper/scope.go
+++ b/x/metadata/keeper/scope.go
@@ -4,9 +4,10 @@ import (
 	"errors"
 	"fmt"
 
-	storetypes "cosmossdk.io/store/types"
+	"cosmossdk.io/collections"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/address"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/gogoproto/proto"
 
@@ -16,57 +17,50 @@ import (
 
 // IterateScopes processes all stored scopes with the given handler.
 func (k Keeper) IterateScopes(ctx sdk.Context, handler func(types.Scope) (stop bool)) error {
-	store := ctx.KVStore(k.storeKey)
-	it := storetypes.KVStorePrefixIterator(store, types.ScopeKeyPrefix)
-	defer it.Close() //nolint:errcheck // close error safe to ignore in this context.
-	for ; it.Valid(); it.Next() {
-		scope := k.mustReadScopeBz(it.Value())
+	return k.scopeCollections.Walk(ctx, nil, func(_ []byte, scope types.Scope) (stop bool, err error) {
+		// Clear ValueOwnerAddress — historical state may have it set; it is not trusted.
+		// See original readScopeBz comment.
+		scope.ValueOwnerAddress = ""
 		k.PopulateScopeValueOwner(ctx, &scope)
-		if handler(scope) {
-			break
-		}
-	}
-	return nil
+		return handler(scope), nil
+	})
 }
 
 // IterateScopesForAddress processes scopes associated with the provided address with the given handler.
-func (k Keeper) IterateScopesForAddress(ctx sdk.Context, address sdk.AccAddress, handler func(scopeID types.MetadataAddress) (stop bool)) error {
-	store := ctx.KVStore(k.storeKey)
-	prefix := types.GetAddressScopeCacheIteratorPrefix(address)
-	it := storetypes.KVStorePrefixIterator(store, prefix)
-	defer it.Close() //nolint:errcheck // close error safe to ignore in this context.
-
-	for ; it.Valid(); it.Next() {
-		var scopeID types.MetadataAddress
-		if err := scopeID.Unmarshal(it.Key()[len(prefix):]); err != nil {
-			return err
-		}
-		if handler(scopeID) {
-			break
-		}
-	}
-	return nil
+func (k Keeper) IterateScopesForAddress(ctx sdk.Context, addr sdk.AccAddress, handler func(scopeID types.MetadataAddress) (stop bool)) error {
+	// Index key format: length_prefix(addr) + scopeID_17bytes
+	// Use length_prefix(addr) as the prefix to iterate all scopes for this address.
+	addrPrefix := address.MustLengthPrefix(addr)
+	return k.addressScopeIndex.Walk(ctx,
+		new(collections.Range[[]byte]).Prefix(addrPrefix),
+		func(key []byte, _ []byte) (stop bool, err error) {
+			// key = length_prefix(addr) + scopeID_17bytes
+			// Strip the address prefix to get the scopeID bytes (full 17-byte MetadataAddress).
+			scopeIDBytes := key[len(addrPrefix):]
+			var scopeID types.MetadataAddress
+			if err := scopeID.Unmarshal(scopeIDBytes); err != nil {
+				return false, err
+			}
+			return handler(scopeID), nil
+		})
 }
 
 // IterateScopesForScopeSpec processes scopes associated with the provided scope specification id with the given handler.
 func (k Keeper) IterateScopesForScopeSpec(ctx sdk.Context, scopeSpecID types.MetadataAddress,
 	handler func(scopeID types.MetadataAddress) (stop bool),
 ) error {
-	store := ctx.KVStore(k.storeKey)
-	prefix := types.GetScopeSpecScopeCacheIteratorPrefix(scopeSpecID)
-	it := storetypes.KVStorePrefixIterator(store, prefix)
-	defer it.Close() //nolint:errcheck // close error safe to ignore in this context.
-
-	for ; it.Valid(); it.Next() {
-		var scopeID types.MetadataAddress
-		if err := scopeID.Unmarshal(it.Key()[len(prefix):]); err != nil {
-			return err
-		}
-		if handler(scopeID) {
-			break
-		}
-	}
-	return nil
+	// Index key format: scopeSpecID_17bytes + scopeID_17bytes
+	specPrefix := scopeSpecID.Bytes() // full 17 bytes including type prefix byte
+	return k.scopeSpecScopeIndex.Walk(ctx,
+		new(collections.Range[[]byte]).Prefix(specPrefix),
+		func(key []byte, _ []byte) (stop bool, err error) {
+			scopeIDBytes := key[len(specPrefix):]
+			var scopeID types.MetadataAddress
+			if err := scopeID.Unmarshal(scopeIDBytes); err != nil {
+				return false, err
+			}
+			return handler(scopeID), nil
+		})
 }
 
 // GetScope returns the scope with the given id. The ValueOwnerAddress field will always be empty from this method.
@@ -75,34 +69,13 @@ func (k Keeper) GetScope(ctx sdk.Context, id types.MetadataAddress) (types.Scope
 	if !id.IsScopeAddress() {
 		return types.Scope{}, false
 	}
-	store := ctx.KVStore(k.storeKey)
-	b := store.Get(id.Bytes())
-	if b == nil {
+	val, err := k.scopeCollections.Get(ctx, mdKey(id))
+	if err != nil {
 		return types.Scope{}, false
 	}
-	return k.mustReadScopeBz(b), true
-}
-
-// readScopeBz will unmarshal the given bytes into a Scope.
-// The ValueOwnerAddress will always be empty. See also: GetScopeValueOwner, PopulateScopeValueOwner.
-func (k Keeper) readScopeBz(bz []byte) (types.Scope, error) {
-	var scope types.Scope
-	err := k.cdc.Unmarshal(bz, &scope)
-	// In the viridian upgrade, we switched to using the bank module to track the ValueOwnerAddress,
-	// but we didn't update all the scopes to remove the data from that field. Any value in that field
-	// in state is therefore not to be trusted (probably out of date), so we clear it out here.
-	scope.ValueOwnerAddress = ""
-	return scope, err
-}
-
-// mustReadScopeBz will unmarshal the given bytes into a Scope, panicking if there's an error.
-// The ValueOwnerAddress will always be empty. See also: GetScopeValueOwner, PopulateScopeValueOwner.
-func (k Keeper) mustReadScopeBz(bz []byte) types.Scope {
-	scope, err := k.readScopeBz(bz)
-	if err != nil {
-		panic(err)
-	}
-	return scope
+	// Clear ValueOwnerAddress — not trusted from state (managed by bank module).
+	val.ValueOwnerAddress = ""
+	return val, true
 }
 
 // GetScopeWithValueOwner will get a scope from state and also look up and set its value owner field.
@@ -144,26 +117,21 @@ func (k Keeper) SetScope(ctx sdk.Context, scope types.Scope) error {
 // writeScopeToState writes the given scope to state, updates the related indexes, and emits the appropriate events.
 // It's split out from SetScope only so that unit tests can write scopes that have something in the value owner field.
 func (k Keeper) writeScopeToState(ctx sdk.Context, scope types.Scope) {
-	store := ctx.KVStore(k.storeKey)
-	b := k.cdc.MustMarshal(&scope)
-
 	var oldScope *types.Scope
 	var event proto.Message = types.NewEventScopeCreated(scope.ScopeId)
-	if store.Has(scope.ScopeId) {
+
+	if has, _ := k.scopeCollections.Has(ctx, mdKey(scope.ScopeId)); has {
 		event = types.NewEventScopeUpdated(scope.ScopeId)
-		if oldScopeBytes := store.Get(scope.ScopeId); len(oldScopeBytes) > 0 {
-			os, err := k.readScopeBz(oldScopeBytes)
-			if err != nil {
-				k.Logger(ctx).Error("could not unmarshal old scope", "err", err,
-					"scopeId", scope.ScopeId.String(), "oldScopeBytes", oldScopeBytes)
-			} else {
-				oldScope = &os
-			}
+		if existing, err := k.scopeCollections.Get(ctx, mdKey(scope.ScopeId)); err == nil {
+			existing.ValueOwnerAddress = "" // clear before using for index comparison
+			oldScope = &existing
 		}
 	}
 
-	store.Set(scope.ScopeId, b)
-	k.indexScope(store, &scope, oldScope)
+	if err := k.scopeCollections.Set(ctx, mdKey(scope.ScopeId), scope); err != nil {
+		panic(err)
+	}
+	k.indexScope(ctx, &scope, oldScope)
 	k.EmitEvent(ctx, event)
 }
 
@@ -185,20 +153,24 @@ func (k Keeper) RemoveScope(ctx sdk.Context, id types.MetadataAddress) error {
 	}
 
 	// Remove all records. The sessions are deleted by RemoveRecord as the last record in each is deleted.
-	store := ctx.KVStore(k.storeKey)
-	prefix, _ := id.ScopeRecordIteratorPrefix() // Can't return an error because we know it's a valid scope id.
-	iter := storetypes.KVStorePrefixIterator(store, prefix)
-	defer func() {
-		if err := iter.Close(); err != nil {
-			k.Logger(ctx).Error("Failed to close RemoveScope", "error", err)
-		}
-	}()
-	for ; iter.Valid(); iter.Next() {
-		k.RemoveRecord(ctx, iter.Key())
+	// Collect all record IDs first, then remove them.
+	// (Each RemoveRecord may also remove its session once the last record is gone.)
+	var recordIDs []types.MetadataAddress
+	if err := k.IterateRecords(ctx, id, func(r types.Record) (stop bool) {
+		recordID := r.SessionId.MustGetAsRecordAddress(r.Name)
+		recordIDs = append(recordIDs, recordID)
+		return false
+	}); err != nil {
+		return err
+	}
+	for _, recordID := range recordIDs {
+		k.RemoveRecord(ctx, recordID)
 	}
 
-	k.indexScope(store, nil, &scope)
-	store.Delete(id)
+	k.indexScope(ctx, nil, &scope)
+	if err := k.scopeCollections.Remove(ctx, mdKey(id)); err != nil {
+		return err
+	}
 	k.EmitEvent(ctx, types.NewEventScopeDeleted(scope.ScopeId))
 	return nil
 }
@@ -406,22 +378,41 @@ func (v scopeIndexValues) IndexKeys() [][]byte {
 //
 // If both newScope and oldScope are not nil, it is assumed that they have the same ScopeId.
 // Failure to meet this assumption will result in strange and bad behavior.
-func (k Keeper) indexScope(store storetypes.KVStore, newScope, oldScope *types.Scope) {
+func (k Keeper) indexScope(ctx sdk.Context, newScope, oldScope *types.Scope) {
 	if newScope == nil && oldScope == nil {
 		return
 	}
 
-	newScopeIndexValues := getScopeIndexValues(newScope)
-	oldScopeIndexValues := getScopeIndexValues(oldScope)
+	toAdd := getMissingScopeIndexValues(getScopeIndexValues(newScope), getScopeIndexValues(oldScope))
+	toRemove := getMissingScopeIndexValues(getScopeIndexValues(oldScope), getScopeIndexValues(newScope))
 
-	toAdd := getMissingScopeIndexValues(newScopeIndexValues, oldScopeIndexValues)
-	toRemove := getMissingScopeIndexValues(oldScopeIndexValues, newScopeIndexValues)
+	applyKey := func(indexKey []byte, set bool) {
+		if len(indexKey) == 0 {
+			return
+		}
+		// indexKey[0] is the collection prefix byte; indexKey[1:] is the collection key.
+		subKey := indexKey[1:]
+		switch indexKey[0] {
+		case types.AddressScopeCacheKeyPrefix[0]: // 0x17 → AddressScopeIndex
+			if set {
+				_ = k.addressScopeIndex.Set(ctx, subKey, indexPresent)
+			} else {
+				_ = k.addressScopeIndex.Remove(ctx, subKey)
+			}
+		case types.ScopeSpecScopeCacheKeyPrefix[0]: // 0x11 → ScopeSpecScopeIndex
+			if set {
+				_ = k.scopeSpecScopeIndex.Set(ctx, subKey, indexPresent)
+			} else {
+				_ = k.scopeSpecScopeIndex.Remove(ctx, subKey)
+			}
+		}
+	}
 
 	for _, indexKey := range toAdd.IndexKeys() {
-		store.Set(indexKey, []byte{0x01})
+		applyKey(indexKey, true)
 	}
 	for _, indexKey := range toRemove.IndexKeys() {
-		store.Delete(indexKey)
+		applyKey(indexKey, false)
 	}
 }
 
@@ -849,25 +840,18 @@ func (k Keeper) GetNetAssetValue(ctx sdk.Context, metadataDenom, priceDenom stri
 		return nil, fmt.Errorf("could not get metadata address: %w", err)
 	}
 
-	store := ctx.KVStore(k.storeKey)
-	key := types.NetAssetValueKey(scopeID, priceDenom)
-	value := store.Get(key)
-	if len(value) == 0 {
-		return nil, nil
-	}
-
-	var scopeNAV types.NetAssetValue
-	err = k.cdc.Unmarshal(value, &scopeNAV)
+	navKey := append(address.MustLengthPrefix(scopeID.Bytes()), []byte(priceDenom)...)
+	val, err := k.netAssetValues.Get(ctx, navKey)
 	if err != nil {
+		if errors.Is(err, collections.ErrNotFound) {
+			return nil, nil // genuinely not found
+		}
 		return nil, fmt.Errorf("could not read nav for %q with price denom %q: %w", scopeID, priceDenom, err)
 	}
-	// The Volume will be zero for NAVs written before that field was added. So if it's still 0,
-	// we switch it to 1 since that's what it was assumed to be before the Volume field was added.
-	if scopeNAV.Volume < 1 {
-		scopeNAV.Volume = 1
+	if val.Volume < 1 {
+		val.Volume = 1
 	}
-
-	return &scopeNAV, nil
+	return &val, nil
 }
 
 // SetNetAssetValue adds/updates a net asset value to scope
@@ -887,48 +871,35 @@ func (k Keeper) SetNetAssetValue(ctx sdk.Context, scopeID types.MetadataAddress,
 		return err
 	}
 
-	key := types.NetAssetValueKey(scopeID, netAssetValue.Price.Denom)
-	store := ctx.KVStore(k.storeKey)
-
-	bz, err := k.cdc.Marshal(&netAssetValue)
-	if err != nil {
-		return err
-	}
-	store.Set(key, bz)
-
-	return nil
+	navKey := append(address.MustLengthPrefix(scopeID.Bytes()), []byte(netAssetValue.Price.Denom)...)
+	return k.netAssetValues.Set(ctx, navKey, netAssetValue)
 }
 
 // IterateNetAssetValues iterates net asset values for scope
 func (k Keeper) IterateNetAssetValues(ctx sdk.Context, scopeID types.MetadataAddress, handler func(state types.NetAssetValue) (stop bool)) error {
-	store := ctx.KVStore(k.storeKey)
-	it := storetypes.KVStorePrefixIterator(store, types.NetAssetValueKeyPrefix(scopeID))
-	defer it.Close() //nolint:errcheck // close error safe to ignore in this context.
-
-	for ; it.Valid(); it.Next() {
-		var scopeNav types.NetAssetValue
-		err := k.cdc.Unmarshal(it.Value(), &scopeNav)
-		if err != nil {
-			return err
-		} else if handler(scopeNav) {
-			break
-		}
-	}
-	return nil
+	// NAV key = length_prefix(scopeAddr) + denom
+	navPrefix := address.MustLengthPrefix(scopeID.Bytes())
+	return k.netAssetValues.Walk(ctx,
+		new(collections.Range[[]byte]).Prefix(navPrefix),
+		func(_ []byte, nav types.NetAssetValue) (stop bool, err error) {
+			return handler(nav), nil
+		})
 }
 
 // RemoveNetAssetValues removes all net asset values for a scope
 func (k Keeper) RemoveNetAssetValues(ctx sdk.Context, scopeID types.MetadataAddress) {
-	store := ctx.KVStore(k.storeKey)
-	it := storetypes.KVStorePrefixIterator(store, types.NetAssetValueKeyPrefix(scopeID))
-	var keys [][]byte
-	for ; it.Valid(); it.Next() {
-		keys = append(keys, it.Key())
-	}
-	defer it.Close() //nolint:errcheck // close error safe to ignore in this context.
+	navPrefix := address.MustLengthPrefix(scopeID.Bytes())
 
+	// Collect all keys first, then delete (cannot mutate while iterating).
+	var keys [][]byte
+	_ = k.netAssetValues.Walk(ctx,
+		new(collections.Range[[]byte]).Prefix(navPrefix),
+		func(key []byte, _ types.NetAssetValue) (stop bool, err error) {
+			keys = append(keys, key)
+			return false, nil
+		})
 	for _, key := range keys {
-		store.Delete(key)
+		_ = k.netAssetValues.Remove(ctx, key)
 	}
 }
 
@@ -944,13 +915,6 @@ func (k Keeper) SetNetAssetValueWithBlockHeight(ctx sdk.Context, scopeID types.M
 		return err
 	}
 
-	key := types.NetAssetValueKey(scopeID, netAssetValue.Price.Denom)
-	bz, err := k.cdc.Marshal(&netAssetValue)
-	if err != nil {
-		return err
-	}
-	store := ctx.KVStore(k.storeKey)
-	store.Set(key, bz)
-
-	return nil
+	navKey := append(address.MustLengthPrefix(scopeID.Bytes()), []byte(netAssetValue.Price.Denom)...)
+	return k.netAssetValues.Set(ctx, navKey, netAssetValue)
 }

--- a/x/metadata/keeper/scope_test.go
+++ b/x/metadata/keeper/scope_test.go
@@ -3331,7 +3331,7 @@ func (s *ScopeKeeperTestSuite) TestGetNetAssetValue() {
 		err := s.app.MetadataKeeper.SetNetAssetValue(ctx, scopeIDOK, okNAV, "testing")
 		s.Require().NoError(err)
 
-		store := ctx.KVStore(s.app.MetadataKeeper.GetStoreKey())
+		store := s.app.MetadataKeeper.GetStoreService().OpenKVStore(ctx)
 		badKey := types.NetAssetValueKey(scopeIDBad, priceDenomBad)
 		badVal := []byte{0, 0, 0}
 		store.Set(badKey, badVal)
@@ -3367,7 +3367,7 @@ func (s *ScopeKeeperTestSuite) TestGetNetAssetValue() {
 			name:    "invalid nav data in state",
 			mdDenom: scopeIDBad.Denom(),
 			pDenom:  priceDenomBad,
-			expErr:  "could not read nav for \"" + scopeIDBad.String() + "\" with price denom \"" + priceDenomBad + "\": proto: NetAssetValue: illegal tag 0 (wire type 0)",
+			expErr:  "could not read nav for \"" + scopeIDBad.String() + "\" with price denom \"" + priceDenomBad + "\": collections: encoding error: value decode: proto: NetAssetValue: illegal tag 0 (wire type 0)",
 		},
 		{
 			name:    "okay",

--- a/x/metadata/keeper/session.go
+++ b/x/metadata/keeper/session.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	storetypes "cosmossdk.io/store/types"
+	"cosmossdk.io/collections"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/gogoproto/proto"
@@ -17,26 +17,22 @@ func (k Keeper) GetSession(ctx sdk.Context, id types.MetadataAddress) (session t
 	if !id.IsSessionAddress() {
 		return session, false
 	}
-	store := ctx.KVStore(k.storeKey)
-	b := store.Get(id.Bytes())
-	if b == nil {
+	val, err := k.sessionCollections.Get(ctx, mdKey(id))
+	if err != nil {
 		return types.Session{}, false
 	}
-	k.cdc.MustUnmarshal(b, &session)
-	return session, true
+	return val, true
 }
 
 // SetSession stores a session in the module kv store.
 func (k Keeper) SetSession(ctx sdk.Context, session types.Session) {
-	store := ctx.KVStore(k.storeKey)
-	b := k.cdc.MustMarshal(&session)
-
 	var event proto.Message = types.NewEventSessionCreated(session.SessionId)
-	if store.Has(session.SessionId) {
+	if has, _ := k.sessionCollections.Has(ctx, mdKey(session.SessionId)); has {
 		event = types.NewEventSessionUpdated(session.SessionId)
 	}
-
-	store.Set(session.SessionId, b)
+	if err := k.sessionCollections.Set(ctx, mdKey(session.SessionId), session); err != nil {
+		panic(err)
+	}
 	k.EmitEvent(ctx, event)
 }
 
@@ -45,13 +41,13 @@ func (k Keeper) RemoveSession(ctx sdk.Context, id types.MetadataAddress) {
 	if !id.IsSessionAddress() {
 		panic(fmt.Errorf("invalid address, address must be for a session"))
 	}
-	store := ctx.KVStore(k.storeKey)
-
-	if !store.Has(id) || k.sessionHasRecords(ctx, id) {
+	has, _ := k.sessionCollections.Has(ctx, mdKey(id))
+	if !has || k.sessionHasRecords(ctx, id) {
 		return
 	}
-
-	store.Delete(id)
+	if err := k.sessionCollections.Remove(ctx, mdKey(id)); err != nil {
+		panic(err)
+	}
 	k.EmitEvent(ctx, types.NewEventSessionDeleted(id))
 }
 
@@ -81,24 +77,14 @@ func (k Keeper) sessionHasRecords(ctx sdk.Context, id types.MetadataAddress) boo
 // If the scopeID is an empty MetadataAddress, all sessions will be processed.
 // Otherwise, just the sessions for the given scopeID will be processed.
 func (k Keeper) IterateSessions(ctx sdk.Context, scopeID types.MetadataAddress, handler func(types.Session) (stop bool)) error {
-	store := ctx.KVStore(k.storeKey)
-	prefix, err := scopeID.ScopeSessionIteratorPrefix()
-	if err != nil {
-		return err
+	walkFn := func(_ []byte, session types.Session) (stop bool, err error) {
+		return handler(session), nil
 	}
-	it := storetypes.KVStorePrefixIterator(store, prefix)
-	defer it.Close() //nolint:errcheck // close error safe to ignore in this context.
-
-	for ; it.Valid(); it.Next() {
-		var session types.Session
-		err = k.cdc.Unmarshal(it.Value(), &session)
-		if err != nil {
-			k.Logger(ctx).Error("could not unmarshal session", "address", it.Key(), "error", err)
-		} else if handler(session) {
-			break
-		}
+	if len(scopeID) > 1 {
+		rng := new(collections.Range[[]byte]).Prefix(scopeID[1:]) // 16-byte scope UUID
+		return k.sessionCollections.Walk(ctx, rng, walkFn)
 	}
-	return nil
+	return k.sessionCollections.Walk(ctx, nil, walkFn) // literal nil → whole collection
 }
 
 // ValidateWriteSession checks the current session and the proposed session to determine if the proposed changes are valid

--- a/x/metadata/keeper/specification.go
+++ b/x/metadata/keeper/specification.go
@@ -3,9 +3,10 @@ package keeper
 import (
 	"fmt"
 
-	storetypes "cosmossdk.io/store/types"
+	"cosmossdk.io/collections"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/address"
 	"github.com/cosmos/gogoproto/proto"
 
 	"github.com/provenance-io/provenance/internal/provutils"
@@ -14,21 +15,9 @@ import (
 
 // IterateRecordSpecs processes all record specs using a given handler.
 func (k Keeper) IterateRecordSpecs(ctx sdk.Context, handler func(specification types.RecordSpecification) (stop bool)) error {
-	store := ctx.KVStore(k.storeKey)
-	it := storetypes.KVStorePrefixIterator(store, types.RecordSpecificationKeyPrefix)
-	defer it.Close() //nolint:errcheck // close error safe to ignore in this context.
-
-	for ; it.Valid(); it.Next() {
-		var recordSpec types.RecordSpecification
-		err := k.cdc.Unmarshal(it.Value(), &recordSpec)
-		if err != nil {
-			return err
-		}
-		if handler(recordSpec) {
-			break
-		}
-	}
-	return nil
+	return k.recordSpecs.Walk(ctx, nil, func(_ []byte, spec types.RecordSpecification) (stop bool, err error) {
+		return handler(spec), nil
+	})
 }
 
 // IterateRecordSpecsForOwner processes all record specs owned by an address using a given handler.
@@ -56,24 +45,15 @@ func (k Keeper) IterateRecordSpecsForOwner(ctx sdk.Context, ownerAddress sdk.Acc
 
 // IterateRecordSpecsForContractSpec processes all record specs for a contract spec using a given handler.
 func (k Keeper) IterateRecordSpecsForContractSpec(ctx sdk.Context, contractSpecID types.MetadataAddress, handler func(recordSpecID types.MetadataAddress) (stop bool)) error {
-	store := ctx.KVStore(k.storeKey)
-	prefix, err := contractSpecID.ContractSpecRecordSpecIteratorPrefix()
-	if err != nil {
-		return err
-	}
-	it := storetypes.KVStorePrefixIterator(store, prefix)
-	defer it.Close() //nolint:errcheck // close error safe to ignore in this context.
-
-	for ; it.Valid(); it.Next() {
-		var recordSpecID types.MetadataAddress
-		if err := recordSpecID.Unmarshal(it.Key()); err != nil {
-			return err
-		}
-		if handler(recordSpecID) {
-			break
-		}
-	}
-	return nil
+	prefix := contractSpecID[1:] // 16-byte contract spec UUID
+	return k.recordSpecs.Walk(ctx,
+		new(collections.Range[[]byte]).Prefix(prefix),
+		func(key []byte, _ types.RecordSpecification) (stop bool, err error) {
+			recordSpecID := make(types.MetadataAddress, 33)
+			recordSpecID[0] = types.RecordSpecificationKeyPrefix[0] // 0x05
+			copy(recordSpecID[1:], key)
+			return handler(recordSpecID), nil
+		})
 }
 
 // GetRecordSpecificationsForContractSpecificationID returns all the record specifications associated with given contractSpecID
@@ -96,26 +76,22 @@ func (k Keeper) GetRecordSpecification(ctx sdk.Context, recordSpecID types.Metad
 	if !recordSpecID.IsRecordSpecificationAddress() {
 		return spec, false
 	}
-	store := ctx.KVStore(k.storeKey)
-	b := store.Get(recordSpecID)
-	if b == nil {
+	val, err := k.recordSpecs.Get(ctx, mdKey(recordSpecID))
+	if err != nil {
 		return types.RecordSpecification{}, false
 	}
-	k.cdc.MustUnmarshal(b, &spec)
-	return spec, true
+	return val, true
 }
 
 // SetRecordSpecification stores a record specification in the module kv store.
 func (k Keeper) SetRecordSpecification(ctx sdk.Context, spec types.RecordSpecification) {
-	store := ctx.KVStore(k.storeKey)
-	b := k.cdc.MustMarshal(&spec)
-
 	var event proto.Message = types.NewEventRecordSpecificationCreated(spec.SpecificationId)
-	if store.Has(spec.SpecificationId) {
+	if has, _ := k.recordSpecs.Has(ctx, mdKey(spec.SpecificationId)); has {
 		event = types.NewEventRecordSpecificationUpdated(spec.SpecificationId)
 	}
-
-	store.Set(spec.SpecificationId, b)
+	if err := k.recordSpecs.Set(ctx, mdKey(spec.SpecificationId), spec); err != nil {
+		panic(err)
+	}
 	k.EmitEvent(ctx, event)
 }
 
@@ -125,13 +101,12 @@ func (k Keeper) RemoveRecordSpecification(ctx sdk.Context, recordSpecID types.Me
 		return fmt.Errorf("record specification with id %s still in use", recordSpecID)
 	}
 
-	store := ctx.KVStore(k.storeKey)
-
-	if !store.Has(recordSpecID) {
+	if has, _ := k.recordSpecs.Has(ctx, mdKey(recordSpecID)); !has {
 		return fmt.Errorf("record specification with id %s not found", recordSpecID)
 	}
-
-	store.Delete(recordSpecID)
+	if err := k.recordSpecs.Remove(ctx, mdKey(recordSpecID)); err != nil {
+		return err
+	}
 	k.EmitEvent(ctx, types.NewEventRecordSpecificationDeleted(recordSpecID))
 	return nil
 }
@@ -162,40 +137,24 @@ func (k Keeper) isRecordSpecUsed(_ sdk.Context, _ types.MetadataAddress) bool {
 
 // IterateContractSpecs processes all contract specs using a given handler.
 func (k Keeper) IterateContractSpecs(ctx sdk.Context, handler func(specification types.ContractSpecification) (stop bool)) error {
-	store := ctx.KVStore(k.storeKey)
-	it := storetypes.KVStorePrefixIterator(store, types.ContractSpecificationKeyPrefix)
-	defer it.Close() //nolint:errcheck // close error safe to ignore in this context.
-
-	for ; it.Valid(); it.Next() {
-		var contractSpec types.ContractSpecification
-		err := k.cdc.Unmarshal(it.Value(), &contractSpec)
-		if err != nil {
-			return err
-		}
-		if handler(contractSpec) {
-			break
-		}
-	}
-	return nil
+	return k.contractSpecCollection.Walk(ctx, nil, func(_ []byte, spec types.ContractSpecification) (stop bool, err error) {
+		return handler(spec), nil
+	})
 }
 
 // IterateContractSpecsForOwner processes all contract specs owned by an address using a given handler.
 func (k Keeper) IterateContractSpecsForOwner(ctx sdk.Context, ownerAddress sdk.AccAddress, handler func(contractSpecID types.MetadataAddress) (stop bool)) error {
-	store := ctx.KVStore(k.storeKey)
-	prefix := types.GetAddressContractSpecCacheIteratorPrefix(ownerAddress)
-	it := storetypes.KVStorePrefixIterator(store, prefix)
-	defer it.Close() //nolint:errcheck // close error safe to ignore in this context.
-
-	for ; it.Valid(); it.Next() {
-		var contractSpecID types.MetadataAddress
-		if err := contractSpecID.Unmarshal(it.Key()[len(prefix):]); err != nil {
-			return err
-		}
-		if handler(contractSpecID) {
-			break
-		}
-	}
-	return nil
+	addrPrefix := address.MustLengthPrefix(ownerAddress)
+	return k.addressContractSpecIndex.Walk(ctx,
+		new(collections.Range[[]byte]).Prefix(addrPrefix),
+		func(key []byte, _ []byte) (stop bool, err error) {
+			contractSpecIDBytes := key[len(addrPrefix):]
+			var contractSpecID types.MetadataAddress
+			if err := contractSpecID.Unmarshal(contractSpecIDBytes); err != nil {
+				return false, err
+			}
+			return handler(contractSpecID), nil
+		})
 }
 
 // GetContractSpecification returns the contract specification with the given id.
@@ -203,34 +162,26 @@ func (k Keeper) GetContractSpecification(ctx sdk.Context, contractSpecID types.M
 	if !contractSpecID.IsContractSpecificationAddress() {
 		return spec, false
 	}
-	store := ctx.KVStore(k.storeKey)
-	b := store.Get(contractSpecID)
-	if b == nil {
+	val, err := k.contractSpecCollection.Get(ctx, mdKey(contractSpecID))
+	if err != nil {
 		return types.ContractSpecification{}, false
 	}
-	k.cdc.MustUnmarshal(b, &spec)
-	return spec, true
+	return val, true
 }
 
 // SetContractSpecification stores a contract specification in the module kv store.
 func (k Keeper) SetContractSpecification(ctx sdk.Context, spec types.ContractSpecification) {
-	store := ctx.KVStore(k.storeKey)
-	b := k.cdc.MustMarshal(&spec)
-
 	var oldSpec *types.ContractSpecification
 	var event proto.Message = types.NewEventContractSpecificationCreated(spec.SpecificationId)
-	if store.Has(spec.SpecificationId) {
+	if has, _ := k.contractSpecCollection.Has(ctx, mdKey(spec.SpecificationId)); has {
 		event = types.NewEventContractSpecificationUpdated(spec.SpecificationId)
-		if oldBytes := store.Get(spec.SpecificationId); oldBytes != nil {
-			oldSpec = &types.ContractSpecification{}
-			if err := k.cdc.Unmarshal(oldBytes, oldSpec); err != nil {
-				k.Logger(ctx).Error("could not unmarshal old contract spec", "err", err, "specId", spec.SpecificationId.String(), "oldBytes", oldBytes)
-				oldSpec = nil
-			}
+		if existing, err := k.contractSpecCollection.Get(ctx, mdKey(spec.SpecificationId)); err == nil {
+			oldSpec = &existing
 		}
 	}
-
-	store.Set(spec.SpecificationId, b)
+	if err := k.contractSpecCollection.Set(ctx, mdKey(spec.SpecificationId), spec); err != nil {
+		panic(err)
+	}
 	k.indexContractSpecification(ctx, &spec, oldSpec)
 	k.EmitEvent(ctx, event)
 }
@@ -240,16 +191,15 @@ func (k Keeper) RemoveContractSpecification(ctx sdk.Context, contractSpecID type
 	if k.isContractSpecUsed(ctx, contractSpecID) {
 		return fmt.Errorf("contract specification with id %s still in use", contractSpecID)
 	}
-
-	store := ctx.KVStore(k.storeKey)
-
 	contractSpec, found := k.GetContractSpecification(ctx, contractSpecID)
 	if !found {
 		return fmt.Errorf("contract specification with id %s not found", contractSpecID)
 	}
 
 	k.indexContractSpecification(ctx, nil, &contractSpec)
-	store.Delete(contractSpecID)
+	if err := k.contractSpecCollection.Remove(ctx, mdKey(contractSpecID)); err != nil {
+		return err
+	}
 	k.EmitEvent(ctx, types.NewEventContractSpecificationDeleted(contractSpecID))
 	return nil
 }
@@ -314,18 +264,14 @@ func (k Keeper) indexContractSpecification(ctx sdk.Context, newSpec, oldSpec *ty
 		return
 	}
 
-	newSpecIndexValues := getContractSpecIndexValues(newSpec)
-	oldSpecIndexValues := getContractSpecIndexValues(oldSpec)
+	toAdd := getMissingContractSpecIndexValues(getContractSpecIndexValues(newSpec), getContractSpecIndexValues(oldSpec))
+	toRemove := getMissingContractSpecIndexValues(getContractSpecIndexValues(oldSpec), getContractSpecIndexValues(newSpec))
 
-	toAdd := getMissingContractSpecIndexValues(newSpecIndexValues, oldSpecIndexValues)
-	toRemove := getMissingContractSpecIndexValues(oldSpecIndexValues, newSpecIndexValues)
-
-	store := ctx.KVStore(k.storeKey)
 	for _, indexKey := range toAdd.IndexKeys() {
-		store.Set(indexKey, []byte{0x01})
+		_ = k.addressContractSpecIndex.Set(ctx, indexKey[1:], indexPresent)
 	}
 	for _, indexKey := range toRemove.IndexKeys() {
-		store.Delete(indexKey)
+		_ = k.addressContractSpecIndex.Remove(ctx, indexKey[1:])
 	}
 }
 
@@ -368,59 +314,39 @@ func (k Keeper) ValidateWriteContractSpecification(_ sdk.Context, existing *type
 
 // IterateScopeSpecs processes all scope specs using a given handler.
 func (k Keeper) IterateScopeSpecs(ctx sdk.Context, handler func(specification types.ScopeSpecification) (stop bool)) error {
-	store := ctx.KVStore(k.storeKey)
-	it := storetypes.KVStorePrefixIterator(store, types.ScopeSpecificationKeyPrefix)
-	defer it.Close() //nolint:errcheck // close error safe to ignore in this context.
-
-	for ; it.Valid(); it.Next() {
-		var scopeSpec types.ScopeSpecification
-		err := k.cdc.Unmarshal(it.Value(), &scopeSpec)
-		if err != nil {
-			return err
-		}
-		if handler(scopeSpec) {
-			break
-		}
-	}
-	return nil
+	return k.scopeSpecs.Walk(ctx, nil, func(_ []byte, spec types.ScopeSpecification) (stop bool, err error) {
+		return handler(spec), nil
+	})
 }
 
 // IterateScopeSpecsForOwner processes all scope specs owned by an address using a given handler.
 func (k Keeper) IterateScopeSpecsForOwner(ctx sdk.Context, ownerAddress sdk.AccAddress, handler func(scopeSpecID types.MetadataAddress) (stop bool)) error {
-	store := ctx.KVStore(k.storeKey)
-	prefix := types.GetAddressScopeSpecCacheIteratorPrefix(ownerAddress)
-	it := storetypes.KVStorePrefixIterator(store, prefix)
-	defer it.Close() //nolint:errcheck // close error safe to ignore in this context.
-
-	for ; it.Valid(); it.Next() {
-		var scopeSpecID types.MetadataAddress
-		if err := scopeSpecID.Unmarshal(it.Key()[len(prefix):]); err != nil {
-			return err
-		}
-		if handler(scopeSpecID) {
-			break
-		}
-	}
-	return nil
+	addrPrefix := address.MustLengthPrefix(ownerAddress)
+	return k.addressScopeSpecIndex.Walk(ctx,
+		new(collections.Range[[]byte]).Prefix(addrPrefix),
+		func(key []byte, _ []byte) (stop bool, err error) {
+			scopeSpecIDBytes := key[len(addrPrefix):]
+			var scopeSpecID types.MetadataAddress
+			if err := scopeSpecID.Unmarshal(scopeSpecIDBytes); err != nil {
+				return false, err
+			}
+			return handler(scopeSpecID), nil
+		})
 }
 
 // IterateScopeSpecsForContractSpec processes all scope specs associated with a contract spec id using a given handler.
 func (k Keeper) IterateScopeSpecsForContractSpec(ctx sdk.Context, contractSpecID types.MetadataAddress, handler func(scopeSpecID types.MetadataAddress) (stop bool)) error {
-	store := ctx.KVStore(k.storeKey)
-	prefix := types.GetContractSpecScopeSpecCacheIteratorPrefix(contractSpecID)
-	it := storetypes.KVStorePrefixIterator(store, prefix)
-	defer it.Close() //nolint:errcheck // close error safe to ignore in this context.
-
-	for ; it.Valid(); it.Next() {
-		var scopeSpecID types.MetadataAddress
-		if err := scopeSpecID.Unmarshal(it.Key()[len(prefix):]); err != nil {
-			return err
-		}
-		if handler(scopeSpecID) {
-			break
-		}
-	}
-	return nil
+	specPrefix := contractSpecID.Bytes()
+	return k.contractSpecScopeSpecIndex.Walk(ctx,
+		new(collections.Range[[]byte]).Prefix(specPrefix),
+		func(key []byte, _ []byte) (stop bool, err error) {
+			scopeSpecIDBytes := key[len(specPrefix):]
+			var scopeSpecID types.MetadataAddress
+			if err := scopeSpecID.Unmarshal(scopeSpecIDBytes); err != nil {
+				return false, err
+			}
+			return handler(scopeSpecID), nil
+		})
 }
 
 // GetScopeSpecification returns the scope specification with the given id.
@@ -428,34 +354,26 @@ func (k Keeper) GetScopeSpecification(ctx sdk.Context, scopeSpecID types.Metadat
 	if !scopeSpecID.IsScopeSpecificationAddress() {
 		return spec, false
 	}
-	store := ctx.KVStore(k.storeKey)
-	b := store.Get(scopeSpecID)
-	if b == nil {
+	val, err := k.scopeSpecs.Get(ctx, mdKey(scopeSpecID))
+	if err != nil {
 		return types.ScopeSpecification{}, false
 	}
-	k.cdc.MustUnmarshal(b, &spec)
-	return spec, true
+	return val, true
 }
 
 // SetScopeSpecification stores a scope specification in the module kv store.
 func (k Keeper) SetScopeSpecification(ctx sdk.Context, spec types.ScopeSpecification) {
-	store := ctx.KVStore(k.storeKey)
-	b := k.cdc.MustMarshal(&spec)
-
 	var oldSpec *types.ScopeSpecification
 	var event proto.Message = types.NewEventScopeSpecificationCreated(spec.SpecificationId)
-	if store.Has(spec.SpecificationId) {
+	if has, _ := k.scopeSpecs.Has(ctx, mdKey(spec.SpecificationId)); has {
 		event = types.NewEventScopeSpecificationUpdated(spec.SpecificationId)
-		if oldBytes := store.Get(spec.SpecificationId); oldBytes != nil {
-			oldSpec = &types.ScopeSpecification{}
-			if err := k.cdc.Unmarshal(oldBytes, oldSpec); err != nil {
-				k.Logger(ctx).Error("could not unmarshal old scope spec", "err", err, "specId", spec.SpecificationId.String(), "oldBytes", oldBytes)
-				oldSpec = nil
-			}
+		if existing, err := k.scopeSpecs.Get(ctx, mdKey(spec.SpecificationId)); err == nil {
+			oldSpec = &existing
 		}
 	}
-
-	store.Set(spec.SpecificationId, b)
+	if err := k.scopeSpecs.Set(ctx, mdKey(spec.SpecificationId), spec); err != nil {
+		panic(err)
+	}
 	k.indexScopeSpecification(ctx, &spec, oldSpec)
 	k.EmitEvent(ctx, event)
 }
@@ -466,15 +384,15 @@ func (k Keeper) RemoveScopeSpecification(ctx sdk.Context, scopeSpecID types.Meta
 		return fmt.Errorf("scope specification with id %s still in use", scopeSpecID)
 	}
 
-	store := ctx.KVStore(k.storeKey)
-
 	scopeSpec, found := k.GetScopeSpecification(ctx, scopeSpecID)
 	if !found {
 		return fmt.Errorf("scope specification with id %s not found", scopeSpecID)
 	}
 
 	k.indexScopeSpecification(ctx, nil, &scopeSpec)
-	store.Delete(scopeSpecID)
+	if err := k.scopeSpecs.Remove(ctx, mdKey(scopeSpecID)); err != nil {
+		return err
+	}
 	k.EmitEvent(ctx, types.NewEventScopeSpecificationDeleted(scopeSpecID))
 	return nil
 }
@@ -564,18 +482,35 @@ func (k Keeper) indexScopeSpecification(ctx sdk.Context, newSpec, oldSpec *types
 		return
 	}
 
-	newSpecIndexValues := getScopeSpecIndexValues(newSpec)
-	oldSpecIndexValues := getScopeSpecIndexValues(oldSpec)
+	toAdd := getMissingScopeSpecIndexValues(getScopeSpecIndexValues(newSpec), getScopeSpecIndexValues(oldSpec))
+	toRemove := getMissingScopeSpecIndexValues(getScopeSpecIndexValues(oldSpec), getScopeSpecIndexValues(newSpec))
 
-	toAdd := getMissingScopeSpecIndexValues(newSpecIndexValues, oldSpecIndexValues)
-	toRemove := getMissingScopeSpecIndexValues(oldSpecIndexValues, newSpecIndexValues)
+	applyKey := func(indexKey []byte, set bool) {
+		if len(indexKey) == 0 {
+			return
+		}
+		subKey := indexKey[1:]
+		switch indexKey[0] {
+		case types.AddressScopeSpecCacheKeyPrefix[0]: // 0x19
+			if set {
+				_ = k.addressScopeSpecIndex.Set(ctx, subKey, indexPresent)
+			} else {
+				_ = k.addressScopeSpecIndex.Remove(ctx, subKey)
+			}
+		case types.ContractSpecScopeSpecCacheKeyPrefix[0]: // 0x14
+			if set {
+				_ = k.contractSpecScopeSpecIndex.Set(ctx, subKey, indexPresent)
+			} else {
+				_ = k.contractSpecScopeSpecIndex.Remove(ctx, subKey)
+			}
+		}
+	}
 
-	store := ctx.KVStore(k.storeKey)
 	for _, indexKey := range toAdd.IndexKeys() {
-		store.Set(indexKey, []byte{0x01})
+		applyKey(indexKey, true)
 	}
 	for _, indexKey := range toRemove.IndexKeys() {
-		store.Delete(indexKey)
+		applyKey(indexKey, false)
 	}
 }
 
@@ -604,13 +539,12 @@ func (k Keeper) ValidateWriteScopeSpecification(ctx sdk.Context, existing *types
 	// If the spec is new, gotta check all of the contract spec ids.
 	// Otherwise, we only need to check contract spec ids that are being added.
 	// If they're being removed or were already in the list, we allow them to not exist.
-	store := ctx.KVStore(k.storeKey)
 	for _, contractSpecID := range getNewContractSpecIDs(&proposed, existing) {
-		if !store.Has(contractSpecID) {
+		has, _ := k.contractSpecCollection.Has(ctx, mdKey(contractSpecID))
+		if !has {
 			return fmt.Errorf("no contract spec exists with id %s", contractSpecID)
 		}
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
* Switch to collections in the metadata module.
closes: #2495 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized metadata module's internal storage infrastructure, replacing legacy patterns with collections-based architecture for improved maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->