### PR TITLE
Add forsythia upgrade and remove previous upgrades

### DIFF
--- a/.changelog/unreleased/improvements/2780-add-forsythia.md
+++ b/.changelog/unreleased/improvements/2780-add-forsythia.md
@@ -1,0 +1,1 @@
+* Add the forsythia upgrade and remove older upgrades [PR 2780](https://github.com/provenance-io/provenance/pull/2780).

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	vaulttypes "github.com/provlabs/vault/types"
-
 	storetypes "cosmossdk.io/store/types"
 	circuittypes "cosmossdk.io/x/circuit/types"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
@@ -15,8 +13,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	vesting "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 	ibctmmigrations "github.com/cosmos/ibc-go/v10/modules/light-clients/07-tendermint/migrations"
-
-	flatfeestypes "github.com/provenance-io/provenance/x/flatfees/types"
 )
 
 // appUpgrade is an internal structure for defining all things for an upgrade.
@@ -43,139 +39,6 @@ type appUpgrade struct {
 // Entries should be in chronological/alphabetical order, earliest first.
 // I.e. Brand-new flowers should be added to the bottom with the rcs first, then the non-rc.
 var upgrades = map[string]appUpgrade{
-	"daisy-rc1": {
-		Deleted: []string{"interchainquery", "oracle", "capability"},
-		Handler: func(ctx sdk.Context, app *App, vm module.VersionMap) (module.VersionMap, error) {
-			var err error
-			if vm, err = runModuleMigrations(ctx, app, vm); err != nil {
-				return nil, err
-			}
-
-			foundation, team := getTestnetCircuitBreakerAddrs()
-			setupCircuitBreakerPermissions(ctx, app, foundation, team)
-
-			if err = pruneIBCExpiredConsensusStates(ctx, app); err != nil {
-				return nil, err
-			}
-			if err = setupMsgStoreCodeFee(ctx, app); err != nil {
-				return nil, err
-			}
-			removeInactiveValidatorDelegations(ctx, app)
-			if err = convertFinishedVestingAccountsToBase(ctx, app); err != nil {
-				return nil, err
-			}
-
-			if err = app.VaultKeeper.MigrateVaultAccountPaymentDenomDefaults(ctx); err != nil {
-				return nil, err
-			}
-
-			if err = updateMsgFees(ctx, app); err != nil {
-				return nil, err
-			}
-			return vm, nil
-		},
-	},
-	"daisy": {
-		Deleted: []string{"interchainquery", "oracle", "capability"},
-		Handler: func(ctx sdk.Context, app *App, vm module.VersionMap) (module.VersionMap, error) {
-			var err error
-			if vm, err = runModuleMigrations(ctx, app, vm); err != nil {
-				return nil, err
-			}
-
-			foundation, team := getMainnetCircuitBreakerAddrs()
-			setupCircuitBreakerPermissions(ctx, app, foundation, team)
-
-			if err = pruneIBCExpiredConsensusStates(ctx, app); err != nil {
-				return nil, err
-			}
-			if err = setupMsgStoreCodeFee(ctx, app); err != nil {
-				return nil, err
-			}
-			removeInactiveValidatorDelegations(ctx, app)
-			if err = convertFinishedVestingAccountsToBase(ctx, app); err != nil {
-				return nil, err
-			}
-
-			if err = app.VaultKeeper.MigrateVaultAccountPaymentDenomDefaults(ctx); err != nil {
-				return nil, err
-			}
-
-			if err = updateMsgFees(ctx, app); err != nil {
-				return nil, err
-			}
-			return vm, nil
-		},
-	},
-	"edelweiss-rc1": { // v1.29.0-rc1
-		Handler: func(ctx sdk.Context, app *App, vm module.VersionMap) (module.VersionMap, error) {
-			var err error
-			if vm, err = runModuleMigrations(ctx, app, vm); err != nil {
-				return nil, err
-			}
-
-			if err = pruneIBCExpiredConsensusStates(ctx, app); err != nil {
-				return nil, err
-			}
-
-			removeInactiveValidatorDelegations(ctx, app)
-
-			if err = convertFinishedVestingAccountsToBase(ctx, app); err != nil {
-				return nil, err
-			}
-
-			return vm, nil
-		},
-	},
-	"edelweiss-rc2": {}, // Empty upgrade for v1.29.0-rc2
-	"edelweiss-rc3": { // Upgrade for v1.29.0-rc3
-		Handler: func(ctx sdk.Context, app *App, vm module.VersionMap) (module.VersionMap, error) {
-			var err error
-			if vm, err = runModuleMigrations(ctx, app, vm); err != nil {
-				return nil, err
-			}
-
-			if err = pruneIBCExpiredConsensusStates(ctx, app); err != nil {
-				return nil, err
-			}
-
-			removeInactiveValidatorDelegations(ctx, app)
-
-			if err = convertFinishedVestingAccountsToBase(ctx, app); err != nil {
-				return nil, err
-			}
-
-			if err = setupVaultParams(ctx, app); err != nil {
-				return nil, err
-			}
-
-			return vm, nil
-		},
-	},
-	"edelweiss": { // v1.29.0
-		Handler: func(ctx sdk.Context, app *App, vm module.VersionMap) (module.VersionMap, error) {
-			var err error
-			if vm, err = runModuleMigrations(ctx, app, vm); err != nil {
-				return nil, err
-			}
-
-			if err = pruneIBCExpiredConsensusStates(ctx, app); err != nil {
-				return nil, err
-			}
-
-			removeInactiveValidatorDelegations(ctx, app)
-
-			if err = convertFinishedVestingAccountsToBase(ctx, app); err != nil {
-				return nil, err
-			}
-
-			if err = setupVaultParams(ctx, app); err != nil {
-				return nil, err
-			}
-
-			return vm, nil
-		},
-	},
 	"forsythia-rc1": { // Upgrade for v1.30.0-rc1
 		Handler: func(ctx sdk.Context, app *App, vm module.VersionMap) (module.VersionMap, error) {
 			var err error
@@ -441,134 +304,6 @@ var (
 	_ = unlockVestingAccounts
 )
 
-// setupMsgStoreCodeFee sets the flat fee for MsgStoreCode to $100 (100,000 musd).
-// This allows smart contracts to be stored directly without governance proposals.
-func setupMsgStoreCodeFee(ctx sdk.Context, app *App) error {
-	ctx.Logger().Info("Setting up MsgStoreCode flat fee.")
-
-	msgFee := flatfeestypes.MsgFee{
-		MsgTypeUrl: "/cosmwasm.wasm.v1.MsgStoreCode",
-		Cost:       sdk.NewCoins(sdk.NewInt64Coin("musd", 100000)),
-	}
-
-	if err := msgFee.Validate(); err != nil {
-		return fmt.Errorf("invalid MsgStoreCode fee: %w", err)
-	}
-
-	if err := app.FlatFeesKeeper.SetMsgFee(ctx, msgFee); err != nil {
-		return fmt.Errorf("failed to set MsgStoreCode fee: %w", err)
-	}
-
-	ctx.Logger().Info("MsgStoreCode flat fee set successfully.", "msg_type", msgFee.MsgTypeUrl, "fee_musd", "100000", "fee_usd", "$100")
-
-	return nil
-}
-
-// updateMsgFees updates the flat fees for multiple message types.
-// Metadata operations (record/session writes): Lower fees to encourage usage
-// IBC client updates: Minimal fee for relayer operations
-func updateMsgFees(ctx sdk.Context, app *App) error {
-	ctx.Logger().Info("Updating message fees.")
-
-	// Define all fee updates
-	feeUpdates := []flatfeestypes.MsgFee{
-		{
-			MsgTypeUrl: "/provenance.metadata.v1.MsgWriteRecordRequest",
-			Cost:       sdk.NewCoins(sdk.NewInt64Coin("musd", 10)), // $0.01
-		},
-		{
-			MsgTypeUrl: "/provenance.metadata.v1.MsgWriteSessionRequest",
-			Cost:       sdk.NewCoins(sdk.NewInt64Coin("musd", 50)), // $0.05
-		},
-		{
-			MsgTypeUrl: "/ibc.core.client.v1.MsgUpdateClient",
-			Cost:       sdk.NewCoins(sdk.NewInt64Coin("musd", 10)), // $0.01
-		},
-		{
-			MsgTypeUrl: "/ibc.core.channel.v2.MsgAcknowledgement",
-			Cost:       sdk.NewCoins(sdk.NewInt64Coin("musd", 50)), // $0.05
-		},
-		{
-			MsgTypeUrl: "/ibc.core.channel.v2.MsgRecvPacket",
-			Cost:       sdk.NewCoins(sdk.NewInt64Coin("musd", 50)), // $0.05
-		},
-		{
-			MsgTypeUrl: "/ibc.core.channel.v2.MsgSendPacket",
-			Cost:       sdk.NewCoins(sdk.NewInt64Coin("musd", 50)), // $0.05
-		},
-		{
-			MsgTypeUrl: "/provenance.flatfees.v1.MsgAddOracleAddressRequest",
-			Cost:       sdk.NewCoins(sdk.NewInt64Coin("musd", 0)), // free (gov prop msg)
-		},
-		{
-			MsgTypeUrl: "/provenance.flatfees.v1.MsgRemoveOracleAddressRequest",
-			Cost:       sdk.NewCoins(sdk.NewInt64Coin("musd", 0)), // free (gov prop msg)
-		},
-		{
-			MsgTypeUrl: "/provenance.exchange.v1.MsgMarketCommitmentSettleRequest",
-			Cost:       sdk.NewCoins(sdk.NewInt64Coin("musd", 50)), // $0.05
-		},
-	}
-
-	for _, msgFee := range feeUpdates {
-		if err := msgFee.Validate(); err != nil {
-			return fmt.Errorf("invalid msg fee for %q: %w", msgFee.MsgTypeUrl, err)
-		}
-
-		if err := app.FlatFeesKeeper.SetMsgFee(ctx, msgFee); err != nil {
-			return fmt.Errorf("failed to set msg fee for %q: %w", msgFee.MsgTypeUrl, err)
-		}
-	}
-
-	feeDeletes := []string{
-		"/ibc.core.channel.v1.MsgUpdateParams",
-		"/icq.v1.MsgUpdateParams",
-		"/provenance.oracle.v1.MsgSendQueryOracleRequest",
-		"/provenance.oracle.v1.MsgUpdateOracleRequest",
-	}
-
-	for _, msgTypeURL := range feeDeletes {
-		if err := app.FlatFeesKeeper.RemoveMsgFee(ctx, msgTypeURL); err != nil {
-			ctx.Logger().Info("Could not remove flat-fee entry.", "msg_type_url", msgTypeURL, "error", err)
-		}
-	}
-
-	ctx.Logger().Info("All message fees updated successfully.", "total_updated", len(feeUpdates))
-	return nil
-}
-
-// setupVaultParams initializes the vault module parameters with chain-appropriate
-// default values. The vault Params (tech_fee_address and default_aum_fee_bips) were
-// added after the module was first wired into the chain, so existing chains won't
-// have them set. This establishes the defaults during the upgrade. It is idempotent:
-// re-running it simply re-writes the same default values.
-func setupVaultParams(ctx sdk.Context, app *App) error {
-	ctx.Logger().Info("Setting up vault module params.")
-
-	params := vaulttypes.Params{
-		TechFeeAddress:    vaulttypes.GetDefaultTechFeeAddress(ctx.ChainID()).String(),
-		DefaultAumFeeBips: vaulttypes.DefaultAumFeeBips,
-	}
-
-	if err := params.Validate(); err != nil {
-		return fmt.Errorf("invalid vault params: %w", err)
-	}
-
-	if err := app.VaultKeeper.Params.Set(ctx, params); err != nil {
-		return fmt.Errorf("failed to set vault params: %w", err)
-	}
-
-	ctx.Logger().Info("Vault module params set successfully.",
-		"tech_fee_address", params.TechFeeAddress,
-		"default_aum_fee_bips", params.DefaultAumFeeBips,
-	)
-	return nil
-}
-
-// setupCircuitBreakerPermissions grants circuit breaker permissions
-// during an upgrade using the caller-provided address lists.
-// The upgrade handlers are responsible for selecting the correct
-// mainnet/testnet address sets.
 func setupCircuitBreakerPermissions(ctx sdk.Context, app *App, foundationAccounts, teamAccounts []string) {
 	ctx.Logger().Info("Setting up circuit breaker permissions.")
 
@@ -607,28 +342,4 @@ func setupCircuitBreakerPermissions(ctx sdk.Context, app *App, foundationAccount
 	grant(teamAccounts, circuittypes.Permissions_LEVEL_ALL_MSGS)
 
 	ctx.Logger().Info("Circuit breaker setup configured.")
-}
-
-// getTestnetCircuitBreakerAddrs returns the list of accounts for Testnet.
-func getTestnetCircuitBreakerAddrs() (foundation []string, team []string) {
-	foundation = []string{
-		"tp1j3uudcktfm98k4f7e6d8z20laxt7zc690f950s", // Danny Wedul.
-	}
-	team = []string{
-		// TODO: Add REAL Testnet team addresses (tp1...)
-	}
-	return foundation, team
-}
-
-// getMainnetCircuitBreakerAddrs returns the list of accounts for Mainnet.
-func getMainnetCircuitBreakerAddrs() (foundation []string, team []string) {
-	foundation = []string{
-		"pb1yfstpvte3a9yyq57qtw5k2vjydpn58992ydnfz9h7d23uhzej3esvnkqay", // A group account owned by the foundation.
-	}
-	team = []string{
-		"pb1yquakyj3p68ugvwmxrw53uv58rr2lv4xzt6ue2", // Danny Wedul.
-		"pb1ktgsj6ap4cfq45g5dyw5vj47zhcrd6cl9p6z43", // Jason Davidson.
-		"pb1ue08tptk5rlye5aujd2k3astacnmufqtstn82t", // Matt Conroy.
-	}
-	return foundation, team
 }

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -176,6 +176,46 @@ var upgrades = map[string]appUpgrade{
 			return vm, nil
 		},
 	},
+	"forsythia-rc1": { // Upgrade for v1.30.0-rc1
+		Handler: func(ctx sdk.Context, app *App, vm module.VersionMap) (module.VersionMap, error) {
+			var err error
+			if vm, err = runModuleMigrations(ctx, app, vm); err != nil {
+				return nil, err
+			}
+
+			if err = pruneIBCExpiredConsensusStates(ctx, app); err != nil {
+				return nil, err
+			}
+
+			removeInactiveValidatorDelegations(ctx, app)
+
+			if err = convertFinishedVestingAccountsToBase(ctx, app); err != nil {
+				return nil, err
+			}
+
+			return vm, nil
+		},
+	},
+	"forsythia": { // Upgrade for v1.30.0
+		Handler: func(ctx sdk.Context, app *App, vm module.VersionMap) (module.VersionMap, error) {
+			var err error
+			if vm, err = runModuleMigrations(ctx, app, vm); err != nil {
+				return nil, err
+			}
+
+			if err = pruneIBCExpiredConsensusStates(ctx, app); err != nil {
+				return nil, err
+			}
+
+			removeInactiveValidatorDelegations(ctx, app)
+
+			if err = convertFinishedVestingAccountsToBase(ctx, app); err != nil {
+				return nil, err
+			}
+
+			return vm, nil
+		},
+	},
 }
 
 // InstallCustomUpgradeHandlers sets upgrade handlers for all entries in the upgrades map.

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -2,8 +2,6 @@ package app
 
 import (
 	"bytes"
-	"context"
-	"errors"
 	"fmt"
 	"regexp"
 	"slices"
@@ -12,8 +10,6 @@ import (
 	"testing"
 	"time"
 
-	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
-	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	"github.com/stretchr/testify/suite"
 
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
@@ -1037,64 +1033,6 @@ var (
 	LogMsgConvertFinishedVestingAccountsToBase = "INF Converting completed vesting accounts into base accounts. module=baseapp"
 )
 
-func (s *UpgradeTestSuite) TestDaisyRC1() {
-	expInLog := []string{
-		LogMsgRunModuleMigrations,
-		"INF Setting up circuit breaker permissions. module=baseapp",
-		LogMsgPruneIBCExpiredConsensusStates,
-		"INF Setting up MsgStoreCode flat fee. module=baseapp",
-		LogMsgRemoveInactiveValidatorDelegations,
-		LogMsgConvertFinishedVestingAccountsToBase,
-		"INF Updating message fees. module=baseapp",
-	}
-	s.AssertUpgradeHandlerLogs("daisy-rc1", expInLog, nil)
-}
-
-func (s *UpgradeTestSuite) TestDaisy() {
-	expInLog := []string{
-		LogMsgRunModuleMigrations,
-		"INF Setting up circuit breaker permissions. module=baseapp",
-		LogMsgPruneIBCExpiredConsensusStates,
-		"INF Setting up MsgStoreCode flat fee. module=baseapp",
-		LogMsgRemoveInactiveValidatorDelegations,
-		LogMsgConvertFinishedVestingAccountsToBase,
-		"INF Updating message fees. module=baseapp",
-	}
-	s.AssertUpgradeHandlerLogs("daisy", expInLog, nil)
-}
-
-func (s *UpgradeTestSuite) TestEdelweissRC1() {
-	expInLog := []string{
-		LogMsgRunModuleMigrations,
-		LogMsgPruneIBCExpiredConsensusStates,
-		LogMsgRemoveInactiveValidatorDelegations,
-		LogMsgConvertFinishedVestingAccountsToBase,
-	}
-	s.AssertUpgradeHandlerLogs("edelweiss-rc1", expInLog, nil)
-}
-
-func (s *UpgradeTestSuite) TestEdelweissRC3() {
-	expInLog := []string{
-		LogMsgRunModuleMigrations,
-		LogMsgPruneIBCExpiredConsensusStates,
-		LogMsgRemoveInactiveValidatorDelegations,
-		LogMsgConvertFinishedVestingAccountsToBase,
-		"INF Setting up vault module params. module=baseapp",
-	}
-	s.AssertUpgradeHandlerLogs("edelweiss-rc3", expInLog, nil)
-}
-
-func (s *UpgradeTestSuite) TestEdelweiss() {
-	expInLog := []string{
-		LogMsgRunModuleMigrations,
-		LogMsgPruneIBCExpiredConsensusStates,
-		LogMsgRemoveInactiveValidatorDelegations,
-		LogMsgConvertFinishedVestingAccountsToBase,
-		"INF Setting up vault module params. module=baseapp",
-	}
-	s.AssertUpgradeHandlerLogs("edelweiss", expInLog, nil)
-}
-
 func (s *UpgradeTestSuite) TestForsythiaRC1() {
 	expInLog := []string{
 		LogMsgRunModuleMigrations,
@@ -1113,93 +1051,4 @@ func (s *UpgradeTestSuite) TestForsythia() {
 		LogMsgConvertFinishedVestingAccountsToBase,
 	}
 	s.AssertUpgradeHandlerLogs("forsythia", expInLog, nil)
-}
-
-// wrappedWasmMsgSrvr is a wasmtypes.MsgServer that lets us inject an error to return from StoreCode.
-type wrappedWasmMsgSrvr struct {
-	wasmMsgServer wasmtypes.MsgServer
-	storeCodeErr  string
-}
-
-func newWrappedWasmMsgSrvr(wasmKeeper *wasmkeeper.Keeper) *wrappedWasmMsgSrvr {
-	return &wrappedWasmMsgSrvr{wasmMsgServer: wasmkeeper.NewMsgServerImpl(wasmKeeper)}
-}
-
-func (w *wrappedWasmMsgSrvr) WithStoreCodeErr(str string) *wrappedWasmMsgSrvr {
-	w.storeCodeErr = str
-	return w
-}
-
-func (w *wrappedWasmMsgSrvr) StoreCode(ctx context.Context, msg *wasmtypes.MsgStoreCode) (*wasmtypes.MsgStoreCodeResponse, error) {
-	if len(w.storeCodeErr) > 0 {
-		return nil, errors.New(w.storeCodeErr)
-	}
-	return w.wasmMsgServer.StoreCode(ctx, msg)
-}
-
-func (s *UpgradeTestSuite) TestSetupCircuitBreakerPermissions() {
-	type testCase struct {
-		name       string
-		foundAddrs []string
-		teamAddrs  []string
-		expLogs    []string
-	}
-
-	foundAddr := s.CreateAndFundAccount(sdk.NewInt64Coin("hash", 1)).String()
-	teamAddr := s.CreateAndFundAccount(sdk.NewInt64Coin("hash", 1)).String()
-
-	tests := []testCase{
-		{
-			name:       "Success - Mixed Valid Addresses",
-			foundAddrs: []string{foundAddr},
-			teamAddrs:  []string{teamAddr},
-			expLogs: []string{
-				"INF Setting up circuit breaker permissions.",
-				fmt.Sprintf("INF Granted Level LEVEL_SUPER_ADMIN to %s.", foundAddr),
-				fmt.Sprintf("INF Granted Level LEVEL_ALL_MSGS to %s.", teamAddr),
-				"INF Circuit breaker setup configured.",
-				"",
-			},
-		},
-		{
-			name:       "Partial Failure - Invalid Address",
-			foundAddrs: []string{"invalid-bech32-address", foundAddr},
-			teamAddrs:  []string{},
-			expLogs: []string{
-				"INF Setting up circuit breaker permissions.",
-				"ERR Invalid address at index 0 (invalid-bech32-address): decoding bech32 failed. Skipping.",
-				fmt.Sprintf("INF Granted Level LEVEL_SUPER_ADMIN to %s.", foundAddr),
-				"INF Circuit breaker setup configured.",
-				"",
-			},
-		},
-		{
-			name:       "Empty Lists - No Op",
-			foundAddrs: []string{},
-			teamAddrs:  []string{},
-			expLogs: []string{
-				"INF Setting up circuit breaker permissions.",
-				"INF Circuit breaker setup configured.",
-				"",
-			},
-		},
-	}
-
-	for _, tc := range tests {
-		s.Run(tc.name, func() {
-			var buffer bytes.Buffer
-			logger := internal.NewBufferedDebugLogger(&buffer)
-			ctx := s.ctx.WithLogger(logger)
-
-			testFunc := func() {
-				setupCircuitBreakerPermissions(ctx, s.app, tc.foundAddrs, tc.teamAddrs)
-			}
-			s.Require().NotPanics(testFunc, "setupCircuitBreakerPermissions")
-
-			actLog := buffer.String()
-			actLogLines := strings.Split(actLog, "\n")
-
-			s.Assert().Equal(tc.expLogs, actLogLines, "Logged messages.")
-		})
-	}
 }

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -1040,7 +1040,7 @@ func (s *UpgradeTestSuite) TestForsythiaRC1() {
 		LogMsgRemoveInactiveValidatorDelegations,
 		LogMsgConvertFinishedVestingAccountsToBase,
 	}
-	s.AssertUpgradeHandlerLogs("forsythia-rc3", expInLog, nil)
+	s.AssertUpgradeHandlerLogs("forsythia-rc1", expInLog, nil)
 }
 
 func (s *UpgradeTestSuite) TestForsythia() {

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -19,6 +19,7 @@ import (
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 
 	sdkmath "cosmossdk.io/math"
+
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
@@ -1092,6 +1093,26 @@ func (s *UpgradeTestSuite) TestEdelweiss() {
 		"INF Setting up vault module params. module=baseapp",
 	}
 	s.AssertUpgradeHandlerLogs("edelweiss", expInLog, nil)
+}
+
+func (s *UpgradeTestSuite) TestForsythiaRC1() {
+	expInLog := []string{
+		LogMsgRunModuleMigrations,
+		LogMsgPruneIBCExpiredConsensusStates,
+		LogMsgRemoveInactiveValidatorDelegations,
+		LogMsgConvertFinishedVestingAccountsToBase,
+	}
+	s.AssertUpgradeHandlerLogs("forsythia-rc3", expInLog, nil)
+}
+
+func (s *UpgradeTestSuite) TestForsythia() {
+	expInLog := []string{
+		LogMsgRunModuleMigrations,
+		LogMsgPruneIBCExpiredConsensusStates,
+		LogMsgRemoveInactiveValidatorDelegations,
+		LogMsgConvertFinishedVestingAccountsToBase,
+	}
+	s.AssertUpgradeHandlerLogs("forsythia", expInLog, nil)
 }
 
 // wrappedWasmMsgSrvr is a wasmtypes.MsgServer that lets us inject an error to return from StoreCode.


### PR DESCRIPTION
## Description

This PR adds the `forsythia` and `forsythia-rc1` upgrades (doing the standard upgrade processes). It also removes the `daisy` and `edelweiss` upgrades (along with their -`rc`s).

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added upgrade support for Forsythia release candidates and v1.30.0.
  * Upgrade processing now runs module migrations plus routine maintenance (IBC consensus-state pruning, inactive validator delegation cleanup, vesting conversion, vault denom default migration, and message flat-fee updates) and applies circuit-breaker permissions.

* **Bug Fixes**
  * Removed an obsolete vault-parameter initialization step from the upgrade flow.
  * Streamlined circuit-breaker account/permission setup.

* **Tests**
  * Added new upgrade handler tests for Forsythia RC1 and Forsythia.
  * Removed tests for older daisy/edelweiss upgrade paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->