### PR TITLE
Prevent the sims runners from running out of memory.

### DIFF
--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -7,7 +7,8 @@ on:
     branches:
       - main
 
-# GOGC=50 makes the go garbage collector kick in at 50% of the heap (default is 100%).
+# GOGC=50 sets the go garbage collector's target heap growth to 50% above the live heap,
+# so it collects once the heap grows to 1.5x the live set (default is 100%, i.e. 2x).
 # It should help prevent these sims from using all the runner's memory (and getting killed).
 env:
   LD_LIBRARY_PATH: /usr/local/lib:/usr/local/lib/x86_64-linux-gnu

--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -7,8 +7,12 @@ on:
     branches:
       - main
 
+# GOGC=50 makes the go garbage collector kick in at 50% of the heap (default is 100%).
+# It should help prevent these sims from using all the runner's memory (and getting killed).
 env:
   LD_LIBRARY_PATH: /usr/local/lib:/usr/local/lib/x86_64-linux-gnu
+  GOMEMLIMIT: 6GiB
+  GOGC: 50
 
 # Set concurrency for this workflow to cancel in-progress jobs if retriggered.
 # The github.ref is only available when triggered by a PR so fall back to github.run_id for other cases.


### PR DESCRIPTION
## Description

Prevent the sims runners from running out of memory.

The `make test-sim-simple` action recently started failing with this at the end of the logs:
```
make: *** [sims.mk:75: test-sim-simple] Terminated
Error: Process completed with exit code 143.
```

That indicates that it's running out of memory and getting killed for it.

This PR adds two env vars to the sims actions:
* `GOMEMLIMIT: 6GiB` - This limits go to using 6 gigs of memory.
* `GOGC: 50` - This makes the garbage collector kick in once the heap is 50% full (default is 100%).

Together, this should let the sims run and finish.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved simulation job stability by adjusting runtime memory settings to reduce the risk of runner memory exhaustion.
  * Added explicit environment tuning for garbage collection and Go memory limits, while keeping the workflow’s existing steps and behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->