### PR TITLE
Split out the sanction client testutil tests.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,16 +48,23 @@ jobs:
           name: "${{ steps.def-vars.outputs.file-prefix }}-pkgs.txt"
           path: ./pkgs.txt
       - name: Split pkgs into parts
-        # The sanction and quarantine simulation race test takes about 6 minutes.
-        # So we'll split everything else 3 ways, and make those part 03 and 04
+        # The sanction simulation race test takes about 6 minutes.
+        # The sanction client testutil test often gets a dumb "DB closed" error during "db.Close()".
+        # By splitting it out, the rerun takes much less time and I get to merge things faster.
+        # We split everything else up 3 ways into parts 00, 01, and 02.
+        # Sanction simulation is part 03, and sanction client gets to be part 04.
         run: |
           grep -vF \
             -e 'github.com/provenance-io/provenance/x/sanction/simulation' \
+            -e 'github.com/provenance-io/provenance/x/sanction/client/testutil' \
             pkgs.txt > pkgs.txt.tmp
           split -d -n l/3 pkgs.txt.tmp pkgs.txt.part.
           printf '%s\n' \
             'github.com/provenance-io/provenance/x/sanction/simulation' \
             >> pkgs.txt.part.03
+          printf '%s\n' \
+            'github.com/provenance-io/provenance/x/sanction/client/testutil' \
+            >> pkgs.txt.part.04
       - uses: actions/upload-artifact@v7
         with:
           name: "${{ steps.def-vars.outputs.file-prefix }}-pkgs.txt.part.00"
@@ -74,6 +81,10 @@ jobs:
         with:
           name: "${{ steps.def-vars.outputs.file-prefix }}-pkgs.txt.part.03"
           path: ./pkgs.txt.part.03
+      - uses: actions/upload-artifact@v7
+        with:
+          name: "${{ steps.def-vars.outputs.file-prefix }}-pkgs.txt.part.04"
+          path: ./pkgs.txt.part.04
     outputs:
       should-run: ${{ env.GIT_DIFF }}
       file-prefix: ${{ steps.def-vars.outputs.file-prefix }}
@@ -87,7 +98,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        part: ["00", "01", "02", "03"]
+        part: ["00", "01", "02", "03", "04"]
     runs-on: ubuntu-latest
     env:
       LD_LIBRARY_PATH: /usr/local/lib:/usr/local/lib/x86_64-linux-gnu
@@ -144,6 +155,10 @@ jobs:
         if: needs.setup-tests.outputs.should-run
         with:
           name: "${{ needs.setup-tests.outputs.file-prefix }}-03-coverage"
+      - uses: actions/download-artifact@v8
+        if: needs.setup-tests.outputs.should-run
+        with:
+          name: "${{ needs.setup-tests.outputs.file-prefix }}-04-coverage"
       - name: Combine profiles
         if: needs.setup-tests.outputs.should-run
         run: |
@@ -175,7 +190,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        part: ["00", "01", "02", "03"]
+        part: ["00", "01", "02", "03", "04"]
     env:
       LD_LIBRARY_PATH: /usr/local/lib:/usr/local/lib/x86_64-linux-gnu
     steps:


### PR DESCRIPTION
## Description

The sanction client testutil tests often fail due to a panic during cleanup with a message of "DB Closed" that is thrown during `db.Close()`. So we often have to re-run the action with that test before we can merge. This PR splits that test out into its own part so that when it runs as fast as possible. That way, I don't have to wait 10 minutes to see if it fails and another 10 minutes if I need to rerun it.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated test sharding from four to five parts.
  * Added dedicated test coverage and race-test execution for the sanction client test utilities.
  * Updated coverage aggregation to include results from the additional test part.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->