### PR TITLE
Remove all-supply permissions bypass.

### DIFF
--- a/.changelog/unreleased/improvements/2807-rm-all-supply-bypass.md
+++ b/.changelog/unreleased/improvements/2807-rm-all-supply-bypass.md
@@ -1,0 +1,1 @@
+* Remove the marker all-supply permissions bypass [PR 2807](https://github.com/provenance-io/provenance/pull/2807).

--- a/x/marker/keeper/keeper_test.go
+++ b/x/marker/keeper/keeper_test.go
@@ -12,12 +12,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	abci "github.com/cometbft/cometbft/abci/types"
+
 	"cosmossdk.io/collections"
 	sdkmath "cosmossdk.io/math"
 	storetypes "cosmossdk.io/store/types"
 	"cosmossdk.io/x/feegrant"
 	feegrantkeeper "cosmossdk.io/x/feegrant/keeper"
-	abci "github.com/cometbft/cometbft/abci/types"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	"github.com/cosmos/cosmos-sdk/runtime"
@@ -933,14 +934,52 @@ func TestImplictControl(t *testing.T) {
 	require.NoError(t, app.MarkerKeeper.WithdrawCoins(ctx, user, user2, "testcoin",
 		sdk.NewCoins(sdk.NewInt64Coin("testcoin", 1000))))
 
-	// Succeeds now because user2 is holding all of the testcoin supply.
-	require.NoError(t, app.MarkerKeeper.AddAccess(ctx, user2, "testcoin",
-		types.NewAccessGrant(user2, []types.Access{types.Access_Mint, types.Access_Delete, types.Access_Transfer})))
+	// fails now even though user2 is holding all of the testcoin supply.
+	err := app.MarkerKeeper.AddAccess(ctx, user2, "testcoin",
+		types.NewAccessGrant(user2, []types.Access{types.Access_Mint, types.Access_Delete, types.Access_Transfer}))
+	require.EqualError(t, err, user2.String()+" is not authorized to make access list changes against finalized/active testcoin marker")
 
-	// succeeds for a user with transfer rights
-	require.NoError(t, app.MarkerKeeper.TransferCoin(ctx, user2, user, user2, sdk.NewInt64Coin("testcoin", 10)))
+	// fails for user2 that doesn't have transfer authority
+	require.Error(t, app.MarkerKeeper.TransferCoin(ctx, user2, user, user2, sdk.NewInt64Coin("testcoin", 10)))
 	// fails if the admin user does not have transfer authority
 	require.Error(t, app.MarkerKeeper.TransferCoin(ctx, user, user2, user, sdk.NewInt64Coin("testcoin", 10)))
+}
+
+func TestAuthzControl(t *testing.T) {
+	app := simapp.Setup(t)
+	ctx := app.BaseApp.NewContext(false)
+
+	setAcc := func(addr sdk.AccAddress, sequence uint64) {
+		acc := app.AccountKeeper.NewAccountWithAddress(ctx, addr)
+		require.NoError(t, acc.SetSequence(sequence), "%s.SetSequence(%d)", string(addr), sequence)
+		app.AccountKeeper.SetAccount(ctx, acc)
+	}
+
+	user := testUserAddress("test")
+	user2 := testUserAddress("test2")
+	setAcc(user, 1)
+	setAcc(user2, 1)
+
+	// create account and check default values
+	mac := types.NewEmptyMarkerAccount("testcoin", user.String(), []types.AccessGrant{
+		*types.NewAccessGrant(user, []types.Access{types.Access_Mint, types.Access_Burn, types.Access_Withdraw, types.Access_Delete, types.Access_Transfer}),
+		*types.NewAccessGrant(user2, []types.Access{types.Access_Mint, types.Access_Delete, types.Access_Transfer}),
+	})
+
+	mac.MarkerType = types.MarkerType_RestrictedCoin
+	require.NoError(t, mac.SetManager(user))
+	require.NoError(t, mac.SetSupply(sdk.NewInt64Coin("testcoin", 1000)))
+
+	require.NoError(t, app.MarkerKeeper.AddMarkerAccount(ctx, mac))
+	require.NoError(t, app.MarkerKeeper.SetNetAssetValue(ctx, mac, types.NewNetAssetValue(sdk.NewInt64Coin(types.UsdDenom, 1), 1), "test"))
+
+	// Moves to finalized, mints required supply, moves to active status.
+	require.NoError(t, app.MarkerKeeper.FinalizeMarker(ctx, user, "testcoin"))
+	require.NoError(t, app.MarkerKeeper.ActivateMarker(ctx, user, "testcoin"))
+
+	// Move some of the supply into user and user2.
+	require.NoError(t, app.MarkerKeeper.WithdrawCoins(ctx, user, user, "testcoin", sdk.NewCoins(sdk.NewInt64Coin("testcoin", 100))))
+	require.NoError(t, app.MarkerKeeper.WithdrawCoins(ctx, user, user2, "testcoin", sdk.NewCoins(sdk.NewInt64Coin("testcoin", 200))))
 
 	// validate authz when 'from' is different from 'admin'
 	granter := user

--- a/x/marker/keeper/marker.go
+++ b/x/marker/keeper/marker.go
@@ -98,8 +98,7 @@ func (k Keeper) AddAccess(
 	// marker is fixed/active, assert permission to make changes by checking for Grant Permission
 	case types.StatusFinalized, types.StatusActive:
 		if (!caller.Equals(m.GetManager()) || m.GetStatus() != types.StatusFinalized) &&
-			!m.AddressHasAccess(caller, types.Access_Admin) &&
-			!k.accountControlsAllSupply(ctx, caller, m) {
+			!m.AddressHasAccess(caller, types.Access_Admin) {
 			return fmt.Errorf("%s is not authorized to make access list changes against finalized/active %s marker",
 				caller, m.GetDenom())
 		}
@@ -142,8 +141,7 @@ func (k Keeper) RemoveAccess(ctx sdk.Context, caller sdk.AccAddress, denom strin
 	// marker is fixed/active, assert permission to make changes by checking for Grant Permission
 	case types.StatusFinalized, types.StatusActive:
 		if (!caller.Equals(m.GetManager()) || m.GetStatus() != types.StatusFinalized) &&
-			!m.AddressHasAccess(caller, types.Access_Admin) &&
-			!k.accountControlsAllSupply(ctx, caller, m) {
+			!m.AddressHasAccess(caller, types.Access_Admin) {
 			return fmt.Errorf("%s is not authorized to make access list changes against finalized/active %s marker",
 				caller, m.GetDenom())
 		}
@@ -894,21 +892,6 @@ func (k Keeper) AddFinalizeAndActivateMarker(ctx sdk.Context, marker types.Marke
 	}
 
 	return k.ActivateMarker(ctx, marker.GetManager(), marker.GetDenom())
-}
-
-// accountControlsAllSupply return true if the caller account address possess 100% of the total supply of a marker.
-// This check is used to determine if an account should be allowed to perform defacto admin operations on a marker.
-func (k Keeper) accountControlsAllSupply(ctx sdk.Context, caller sdk.AccAddress, m types.MarkerAccountI) bool {
-	// If the given account is currently holding 100% of the supply of a marker then it should be able to invoke
-	// the operations as an admin on the marker.
-	// Use the live circulating supply from the bank keeper instead of m.GetSupply().
-	// m.GetSupply() can become outdated after minting.
-	supply := k.bankKeeper.GetSupply(ctx, m.GetDenom())
-	if supply.Amount.IsNil() || supply.Amount.IsZero() {
-		return false
-	}
-	balance := k.bankKeeper.GetBalance(ctx, caller, m.GetDenom())
-	return supply.Equal(sdk.NewCoin(m.GetDenom(), balance.Amount))
 }
 
 // validateSendToMarker returns an error if the toAddr is a restricted marker but the admin doesn't have deposit access on it.


### PR DESCRIPTION
## Description

Remove the marker permissions bypass for account holding the entire supply of a coin.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved marker access controls so full token-supply ownership alone no longer grants permission to modify access lists.
  * Restricted changes to finalized and active markers to authorized managers or explicitly approved administrators.
  * Improved authorization handling for marker transfers, balance movements, and transfer permissions.
  * Added coverage for access-control and authorization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->