### PR TITLE
Key name records on a hash of the full name so different names can't share a record

### DIFF
--- a/.changelog/unreleased/bug-fixes/2683-name-record-key-collisions.md
+++ b/.changelog/unreleased/bug-fixes/2683-name-record-key-collisions.md
@@ -1,0 +1,1 @@
+* Key name records on a hash of the full name so that names made up of the same letters split into different segments, e.g. `midleaf.pb` and `leaf.mid.pb`, no longer share a record [#2683](https://github.com/provenance-io/provenance/issues/2683).

--- a/x/name/client/cli/cli_test.go
+++ b/x/name/client/cli/cli_test.go
@@ -270,12 +270,12 @@ func (s *IntegrationTestSuite) TestReverseLookupCommand() {
 		{
 			"query name, json output",
 			[]string{s.accountAddr.String(), fmt.Sprintf("--%s=json", cmtcli.OutputFlag)},
-			"{\"name\":[\"example.attribute\",\"attribute\"],\"pagination\":{\"next_key\":null,\"total\":\"0\"}}",
+			"{\"name\":[\"attribute\",\"example.attribute\"],\"pagination\":{\"next_key\":null,\"total\":\"0\"}}",
 		},
 		{
 			"query name, text output",
 			[]string{s.accountAddr.String(), fmt.Sprintf("--%s=text", cmtcli.OutputFlag)},
-			"name:\n- example.attribute\n- attribute\npagination:\n  next_key: null\n  total: \"0\"",
+			"name:\n- attribute\n- example.attribute\npagination:\n  next_key: null\n  total: \"0\"",
 		},
 		{
 			"query name that does not exist, text output",

--- a/x/name/keeper/keeper_test.go
+++ b/x/name/keeper/keeper_test.go
@@ -96,10 +96,10 @@ func (s *KeeperTestSuite) TestSetup() {
   name: test.root
   restricted: false
 - address: %[1]s
-  name: name
+  name: example.name
   restricted: false
 - address: %[1]s
-  name: example.name
+  name: name
   restricted: false
 - address: %[3]s
   name: %[2]s
@@ -259,6 +259,32 @@ func (s *KeeperTestSuite) TestGetName() {
 	})
 }
 
+func (s *KeeperTestSuite) TestNamesWithDifferentSegmentsDoNotShareARecord() {
+	// "midleaf.name" and "leaf.mid.name" are different names made up of the same letters,
+	// so they must each get their own record and resolve only to their own owner.
+	s.Require().NoError(s.app.NameKeeper.SetNameRecord(s.ctx, "midleaf.name", s.user2Addr, false),
+		"SetNameRecord(midleaf.name)")
+	s.Require().NoError(s.app.NameKeeper.SetNameRecord(s.ctx, "leaf.mid.name", s.user1Addr, false),
+		"SetNameRecord(leaf.mid.name)")
+
+	r, err := s.app.NameKeeper.GetRecordByName(s.ctx, "leaf.mid.name")
+	s.Require().NoError(err, "GetRecordByName(leaf.mid.name)")
+	s.Assert().Equal("leaf.mid.name", r.Name, "record name")
+	s.Assert().Equal(s.user1Addr.String(), r.Address, "record address")
+
+	r, err = s.app.NameKeeper.GetRecordByName(s.ctx, "midleaf.name")
+	s.Require().NoError(err, "GetRecordByName(midleaf.name)")
+	s.Assert().Equal("midleaf.name", r.Name, "record name")
+	s.Assert().Equal(s.user2Addr.String(), r.Address, "record address")
+
+	s.Assert().True(s.app.NameKeeper.ResolvesTo(s.ctx, "leaf.mid.name", s.user1Addr), "leaf.mid.name resolves to its owner")
+	s.Assert().False(s.app.NameKeeper.ResolvesTo(s.ctx, "leaf.mid.name", s.user2Addr), "leaf.mid.name resolves to the owner of midleaf.name")
+	s.Assert().False(s.app.NameKeeper.NameExists(s.ctx, "af.midle.name"), "NameExists(af.midle.name)")
+
+	s.Require().NoError(s.app.NameKeeper.DeleteRecord(s.ctx, "midleaf.name"), "DeleteRecord(midleaf.name)")
+	s.Assert().True(s.app.NameKeeper.NameExists(s.ctx, "leaf.mid.name"), "leaf.mid.name still exists after midleaf.name was deleted")
+}
+
 func (s *KeeperTestSuite) TestGetAddress() {
 	s.Run("get names by address", func() {
 		r, err := s.app.NameKeeper.GetRecordsByAddress(s.ctx, s.user1Addr)
@@ -309,10 +335,10 @@ func (s *KeeperTestSuite) TestModifyRecord() {
 		s.Assert().False(isUser2, "ResolvesTo(%q, user2)", jackthecat)
 
 		expUser1Recs := nametypes.NameRecords{
-			{Name: jackthecat, Address: s.user1Addr.String(), Restricted: true},
 			{Name: "test.root", Address: s.user1Addr.String(), Restricted: false},
-			{Name: "name", Address: s.user1Addr.String(), Restricted: false},
+			{Name: jackthecat, Address: s.user1Addr.String(), Restricted: true},
 			{Name: "example.name", Address: s.user1Addr.String(), Restricted: false},
+			{Name: "name", Address: s.user1Addr.String(), Restricted: false},
 		}
 		addr1Recs, err := s.app.NameKeeper.GetRecordsByAddress(s.ctx, s.user1Addr)
 		s.Require().NoError(err, "GetRecordsByAddress(user1)")
@@ -359,8 +385,8 @@ func (s *KeeperTestSuite) TestIterateRecord() {
 	s.Run("iterate name's", func() {
 		expRecords := nametypes.NameRecords{
 			nametypes.NewNameRecord("test.root", s.user1Addr, false),
-			nametypes.NewNameRecord("name", s.user1Addr, false),
 			nametypes.NewNameRecord("example.name", s.user1Addr, false),
+			nametypes.NewNameRecord("name", s.user1Addr, false),
 			nametypes.NewNameRecord(attrtypes.AccountDataName, authtypes.NewModuleAddress(attrtypes.ModuleName), true),
 		}
 		records := nametypes.NameRecords{}

--- a/x/name/keeper/migrations.go
+++ b/x/name/keeper/migrations.go
@@ -1,5 +1,17 @@
 package keeper
 
+import (
+	"bytes"
+	"fmt"
+	"slices"
+
+	storetypes "cosmossdk.io/store/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/provenance-io/provenance/x/name/types"
+)
+
 // Migrator is a struct for handling in-place store migrations.
 type Migrator struct {
 	keeper Keeper
@@ -8,4 +20,90 @@ type Migrator struct {
 // NewMigrator returns a new Migrator.
 func NewMigrator(keeper Keeper) Migrator {
 	return Migrator{keeper: keeper}
+}
+
+// rekeyedEntry is a store entry that needs to move from oldKey to newKey.
+type rekeyedEntry struct {
+	oldKey []byte
+	newKey []byte
+	value  []byte
+}
+
+// Migrate2to3 rewrites the name records and the address -> name index entries using keys that
+// are a hash of the full name instead of a hash of just the name segments.
+func (m Migrator) Migrate2to3(ctx sdk.Context) error {
+	logger := m.keeper.Logger(ctx)
+	logger.Info("Migrating name records to keys based on the full name.")
+
+	store := ctx.KVStore(m.keeper.storeKey)
+
+	entries, err := m.rekeyedNameEntries(store)
+	if err != nil {
+		return err
+	}
+	indexEntries, err := m.rekeyedAddressIndexEntries(store)
+	if err != nil {
+		return err
+	}
+	entries = append(entries, indexEntries...)
+
+	// All of the deletes are done before any of the writes so that an entry keeping its
+	// key (any single-segment name) can't be deleted after it has been written again.
+	for _, entry := range entries {
+		store.Delete(entry.oldKey)
+	}
+	for _, entry := range entries {
+		store.Set(entry.newKey, entry.value)
+	}
+
+	logger.Info(fmt.Sprintf("Done migrating name records. Rewrote %d entries.", len(entries)))
+	return nil
+}
+
+// rekeyedNameEntries returns the name records, [NameKeyPrefix] :: [name key], that need a new key.
+func (m Migrator) rekeyedNameEntries(store storetypes.KVStore) ([]rekeyedEntry, error) {
+	return m.rekeyedEntries(store, types.NameKeyPrefix, func(_ []byte, nameKey []byte) []byte {
+		return nameKey
+	})
+}
+
+// rekeyedAddressIndexEntries returns the address index entries,
+// [AddressKeyPrefix] :: [address length] :: [address] :: [name key], that need a new key.
+func (m Migrator) rekeyedAddressIndexEntries(store storetypes.KVStore) ([]rekeyedEntry, error) {
+	return m.rekeyedEntries(store, types.AddressKeyPrefix, func(oldKey []byte, nameKey []byte) []byte {
+		// The 2nd byte is the length of the address that follows it, and the name key is the rest.
+		addrEnd := int(oldKey[1]) + 2
+		return append(slices.Clone(oldKey[:addrEnd]), nameKey...)
+	})
+}
+
+// rekeyedEntries returns each entry under the given prefix whose key changes, using newKey to
+// build the new key from the entry's existing key and the new key of the name it holds.
+func (m Migrator) rekeyedEntries(store storetypes.KVStore, prefix []byte, newKey func(oldKey []byte, nameKey []byte) []byte) ([]rekeyedEntry, error) {
+	var entries []rekeyedEntry
+
+	iter := storetypes.KVStorePrefixIterator(store, prefix)
+	defer iter.Close() //nolint:errcheck // close error safe to ignore in this context.
+
+	for ; iter.Valid(); iter.Next() {
+		record := types.NameRecord{}
+		if err := m.keeper.cdc.Unmarshal(iter.Value(), &record); err != nil {
+			return nil, err
+		}
+		nameKey, err := types.GetNameKeyPrefix(record.Name)
+		if err != nil {
+			return nil, err
+		}
+		entry := rekeyedEntry{
+			oldKey: slices.Clone(iter.Key()),
+			newKey: newKey(iter.Key(), nameKey),
+			value:  slices.Clone(iter.Value()),
+		}
+		if bytes.Equal(entry.oldKey, entry.newKey) {
+			continue
+		}
+		entries = append(entries, entry)
+	}
+
+	return entries, nil
 }

--- a/x/name/keeper/migrations_test.go
+++ b/x/name/keeper/migrations_test.go
@@ -1,0 +1,131 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	storetypes "cosmossdk.io/store/types"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/provenance-io/provenance/app"
+	namekeeper "github.com/provenance-io/provenance/x/name/keeper"
+	nametypes "github.com/provenance-io/provenance/x/name/types"
+)
+
+type MigrationsTestSuite struct {
+	suite.Suite
+
+	app *app.App
+	ctx sdk.Context
+	cdc *codec.ProtoCodec
+
+	user1Addr sdk.AccAddress
+	user2Addr sdk.AccAddress
+}
+
+func TestMigrationsTestSuite(t *testing.T) {
+	suite.Run(t, new(MigrationsTestSuite))
+}
+
+func (s *MigrationsTestSuite) SetupTest() {
+	s.app = app.Setup(s.T())
+	s.cdc = codec.NewProtoCodec(s.app.GetEncodingConfig().InterfaceRegistry)
+	s.ctx = s.app.BaseApp.NewContext(false)
+	s.user1Addr = sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
+	s.user2Addr = sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
+}
+
+func (s *MigrationsTestSuite) store() storetypes.KVStore {
+	return s.ctx.KVStore(s.app.GetKey(nametypes.StoreKey))
+}
+
+// setLegacyNameRecord writes a name record and its address index entry using the keys
+// that the name module used before version 3.
+func (s *MigrationsTestSuite) setLegacyNameRecord(name string, addr sdk.AccAddress, restricted bool) {
+	record := nametypes.NewNameRecord(name, addr, restricted)
+	bz, err := s.cdc.Marshal(&record)
+	s.Require().NoError(err, "Marshal(%q)", name)
+
+	nameKey, err := nametypes.GetLegacyNameKeyPrefix(name)
+	s.Require().NoError(err, "GetLegacyNameKeyPrefix(%q)", name)
+	addrKey, err := nametypes.GetAddressKeyPrefix(addr)
+	s.Require().NoError(err, "GetAddressKeyPrefix(%q)", addr)
+
+	store := s.store()
+	store.Set(nameKey, bz)
+	store.Set(append(addrKey, nameKey...), bz)
+}
+
+func (s *MigrationsTestSuite) TestMigrate2to3() {
+	multiSegment := []string{"leaf.mid.root", "example.name", "test.root"}
+	singleSegment := []string{"root", "name"}
+	allNames := append(append([]string{}, multiSegment...), singleSegment...)
+
+	for _, name := range allNames {
+		s.setLegacyNameRecord(name, s.user1Addr, false)
+	}
+	s.setLegacyNameRecord("other.root", s.user2Addr, true)
+
+	// The multi-segment records are only reachable by their legacy key until they're migrated.
+	for _, name := range multiSegment {
+		_, err := s.app.NameKeeper.GetRecordByName(s.ctx, name)
+		s.Assert().ErrorIs(err, nametypes.ErrNameNotBound, "GetRecordByName(%q) before the migration", name)
+	}
+
+	err := namekeeper.NewMigrator(s.app.NameKeeper).Migrate2to3(s.ctx)
+	s.Require().NoError(err, "Migrate2to3")
+
+	store := s.store()
+	for _, name := range allNames {
+		record, err := s.app.NameKeeper.GetRecordByName(s.ctx, name)
+		if s.Assert().NoError(err, "GetRecordByName(%q) after the migration", name) {
+			s.Assert().Equal(name, record.Name, "record name")
+			s.Assert().Equal(s.user1Addr.String(), record.Address, "record address")
+		}
+
+		addrKey, err := nametypes.GetAddressKeyPrefix(s.user1Addr)
+		s.Require().NoError(err, "GetAddressKeyPrefix")
+		nameKey, err := nametypes.GetNameKeyPrefix(name)
+		s.Require().NoError(err, "GetNameKeyPrefix(%q)", name)
+		s.Assert().True(store.Has(append(addrKey, nameKey...)), "address index entry exists for %q", name)
+	}
+
+	for _, name := range multiSegment {
+		legacyKey, err := nametypes.GetLegacyNameKeyPrefix(name)
+		s.Require().NoError(err, "GetLegacyNameKeyPrefix(%q)", name)
+		s.Assert().False(store.Has(legacyKey), "legacy record still exists for %q", name)
+
+		addrKey, err := nametypes.GetAddressKeyPrefix(s.user1Addr)
+		s.Require().NoError(err, "GetAddressKeyPrefix")
+		s.Assert().False(store.Has(append(addrKey, legacyKey...)), "legacy address index entry still exists for %q", name)
+	}
+
+	records, err := s.app.NameKeeper.GetRecordsByAddress(s.ctx, s.user1Addr)
+	s.Require().NoError(err, "GetRecordsByAddress")
+	names := make([]string, 0, len(records))
+	for _, record := range records {
+		names = append(names, record.Name)
+	}
+	s.Assert().ElementsMatch(allNames, names, "names bound to the address")
+
+	record, err := s.app.NameKeeper.GetRecordByName(s.ctx, "other.root")
+	s.Require().NoError(err, `GetRecordByName("other.root")`)
+	s.Assert().Equal(s.user2Addr.String(), record.Address, "record address")
+	s.Assert().True(record.Restricted, "record restricted")
+}
+
+func (s *MigrationsTestSuite) TestMigrate2to3IsRepeatable() {
+	s.setLegacyNameRecord("leaf.mid.root", s.user1Addr, false)
+
+	migrator := namekeeper.NewMigrator(s.app.NameKeeper)
+	s.Require().NoError(migrator.Migrate2to3(s.ctx), "Migrate2to3 first run")
+	s.Require().NoError(migrator.Migrate2to3(s.ctx), "Migrate2to3 second run")
+
+	record, err := s.app.NameKeeper.GetRecordByName(s.ctx, "leaf.mid.root")
+	s.Require().NoError(err, `GetRecordByName("leaf.mid.root")`)
+	s.Assert().Equal(s.user1Addr.String(), record.Address, "record address")
+}

--- a/x/name/module.go
+++ b/x/name/module.go
@@ -122,6 +122,11 @@ func (AppModule) Name() string {
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
 	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
+
+	m := keeper.NewMigrator(am.keeper)
+	if err := cfg.RegisterMigration(types.ModuleName, 2, m.Migrate2to3); err != nil {
+		panic(fmt.Errorf("failed to register name migration: %w", err))
+	}
 }
 
 // InitGenesis performs genesis initialization for the name module. It returns
@@ -165,4 +170,4 @@ func (am AppModule) WeightedOperations(simState module.SimulationState) []simtyp
 }
 
 // ConsensusVersion implements AppModule/ConsensusVersion.
-func (AppModule) ConsensusVersion() uint64 { return 2 }
+func (AppModule) ConsensusVersion() uint64 { return 3 }

--- a/x/name/spec/02_state.md
+++ b/x/name/spec/02_state.md
@@ -5,29 +5,30 @@ The name module holds a very simple state collection.
 
 
 ## Name Record KV Values
-Name records are stored using a key based upon a concatenated
-list of hashes based on each label within the name.  This approach allows all of the names in the tree under a given
-name to be quickly queried and iterated over.
+Name records are stored using a key made up of the name record type byte, `0x03`, followed by a SHA-256 hash of the
+normalized name.  Hashing the whole name, dots included, keeps each name in its own record: names made up of the same
+letters split into different segments, e.g. `bar.foo` and `foo` with the segment `bar`, get different keys.
 
 ```
 Name: foo
-key = 2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae
+key = 03 || 2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae
 
 Name: foo.bar
-key = 2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae.fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9
+key = 03 || 2595d08ad22c733f7a1ce713e767563e13a8dfa35baa74919c28e0f586cb424b
 
 Name:  foo.bar.baz
-key = 2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae.fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9.baa5a0964d3320fbc0c6a922140453c8513ea24ab8fd0577034804a967248096
+key = 03 || 31f52e7760a01e3ff5b6b395411d1dbace56483562480570bec00e03237b9373
 
 ```
 
 ## Address Record KV Index
 In addition to the records stored by name an address cache is maintained for the addresses associated with each name
-record.  This allows simple and fast reverse lookup queries to be performed.
+record.  This allows simple and fast reverse lookup queries to be performed.  Those keys are made up of the address
+index type byte, `0x05`, the length of the address, the address itself, and then the name record key.
 
 ```
 Address: pb1tg3ktger9ttlscehl3r5j4pqw7qzmvs4qr9vpm
-key = 5A2365A3232AD7F86337FC4749542077802DB215.2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae.fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9
+key = 05 || 14 || 5A2365A3232AD7F86337FC4749542077802DB215 || 03 || 2595d08ad22c733f7a1ce713e767563e13a8dfa35baa74919c28e0f586cb424b
 value = foo.bar
 ```
 

--- a/x/name/types/keys.go
+++ b/x/name/types/keys.go
@@ -31,32 +31,46 @@ var (
 
 // GetNameKeyPrefix converts a name into key format.
 func GetNameKeyPrefix(name string) (key []byte, err error) {
-	key = NameKeyPrefix
-	return getNamePrefixByType(name, key)
-}
-
-// internal common code for legacy and current way.
-func getNamePrefixByType(name string, key []byte) ([]byte, error) {
-	var err error
-	if strings.TrimSpace(name) == "" {
-		err = fmt.Errorf("name can not be empty: %w", ErrNameInvalid)
+	comps, err := getNameSegments(name)
+	if err != nil {
 		return nil, err
 	}
-	comps := strings.Split(name, ".")
+	sum := sha256.Sum256([]byte(strings.Join(comps, ".")))
+	key = NameKeyPrefix
+	return append(key, sum[:]...), nil
+}
+
+// GetLegacyNameKeyPrefix converts a name into the key format used by the name module before version 3.
+// Those keys are a hash of just the name segments, so names with different segments, e.g. "leaf.mid.root"
+// and "midleaf.root", can end up sharing a key. It is only still around so that the migration can find them.
+func GetLegacyNameKeyPrefix(name string) (key []byte, err error) {
+	comps, err := getNameSegments(name)
+	if err != nil {
+		return nil, err
+	}
 	hsh := sha256.New()
 	for i := len(comps) - 1; i >= 0; i-- {
-		comp := strings.TrimSpace(comps[i])
-		if len(comp) == 0 {
-			err = fmt.Errorf("name segment cannot be empty: %w", ErrNameInvalid)
-			return nil, err
-		}
-		if _, err = hsh.Write([]byte(comp)); err != nil {
+		if _, err = hsh.Write([]byte(comps[i])); err != nil {
 			return nil, err
 		}
 	}
-	sum := hsh.Sum(nil)
-	key = append(key, sum...)
-	return key, nil
+	key = NameKeyPrefix
+	return append(key, hsh.Sum(nil)...), nil
+}
+
+// getNameSegments splits a name into its space-trimmed segments, returning an error if any of them are empty.
+func getNameSegments(name string) ([]string, error) {
+	if strings.TrimSpace(name) == "" {
+		return nil, fmt.Errorf("name can not be empty: %w", ErrNameInvalid)
+	}
+	comps := strings.Split(name, ".")
+	for i, comp := range comps {
+		comps[i] = strings.TrimSpace(comp)
+		if len(comps[i]) == 0 {
+			return nil, fmt.Errorf("name segment cannot be empty: %w", ErrNameInvalid)
+		}
+	}
+	return comps, nil
 }
 
 // GetAddressKeyPrefix returns a store key for a name record address

--- a/x/name/types/keys_test.go
+++ b/x/name/types/keys_test.go
@@ -34,7 +34,7 @@ func (s *NameKeyTestSuite) TestNameKeyPrefix() {
 	}{
 		"valid two-part": {
 			"name.domain",
-			mustHexDecode("0369e54bac206cf0d1dc5a11c9ae404c5f15a1b75456327e2dba1a8182e507e23a"),
+			mustHexDecode("03e27733edfa985bcd3fdcfe8544741d602a379fd28464b3c15f483b7350e2dd20"),
 			false,
 			"",
 		},
@@ -46,7 +46,13 @@ func (s *NameKeyTestSuite) TestNameKeyPrefix() {
 		},
 		"valid multi-part": {
 			"first.second.third.fourth.fifth.sixth.seventh.eighth.ninth.tenth",
-			mustHexDecode("0319f8e4495c302135434642f853698172ef1f167400d04c12864f9cdf539fbaba"),
+			mustHexDecode("031cccba52f948b1d9e2123bb38988a08d733a040e78ecb516c608e7454960bf01"),
+			false,
+			"",
+		},
+		"valid two-part with segment spacing": {
+			" name . domain ",
+			mustHexDecode("03e27733edfa985bcd3fdcfe8544741d602a379fd28464b3c15f483b7350e2dd20"),
 			false,
 			"",
 		},
@@ -88,6 +94,93 @@ func (s *NameKeyTestSuite) TestNameKeyPrefix() {
 				s.NoError(err)
 			}
 			s.Equal(tc.key, key)
+		})
+	}
+}
+
+func (s *NameKeyTestSuite) TestLegacyNameKeyPrefix() {
+	cases := map[string]struct {
+		name      string
+		key       []byte
+		expectErr bool
+		errValue  string
+	}{
+		"valid two-part": {
+			"name.domain",
+			mustHexDecode("0369e54bac206cf0d1dc5a11c9ae404c5f15a1b75456327e2dba1a8182e507e23a"),
+			false,
+			"",
+		},
+		"valid single": {
+			"domain",
+			mustHexDecode("03f2ff83860a4dc203988ed1a22ba1f21237f04abdbd0c4c951103cfbed121de78"),
+			false,
+			"",
+		},
+		"valid multi-part": {
+			"first.second.third.fourth.fifth.sixth.seventh.eighth.ninth.tenth",
+			mustHexDecode("0319f8e4495c302135434642f853698172ef1f167400d04c12864f9cdf539fbaba"),
+			false,
+			"",
+		},
+		"invalid empty name": {
+			"",
+			[]byte(nil),
+			true,
+			fmt.Errorf("name can not be empty: %w", ErrNameInvalid).Error(),
+		},
+		"invalid empty name segment": {
+			"name..empty.segment",
+			[]byte(nil),
+			true,
+			fmt.Errorf("name segment cannot be empty: %w", ErrNameInvalid).Error(),
+		},
+	}
+	for n, tc := range cases {
+		s.Run(n, func() {
+			key, err := GetLegacyNameKeyPrefix(tc.name)
+			if tc.expectErr {
+				s.Error(err)
+				s.Equal(tc.errValue, err.Error())
+			} else {
+				s.NoError(err)
+			}
+			s.Equal(tc.key, key)
+		})
+	}
+}
+
+func (s *NameKeyTestSuite) TestNameKeyPrefixSegmentCollisions() {
+	cases := []struct {
+		name  string
+		name1 string
+		name2 string
+	}{
+		{
+			name:  "extra segment in the middle",
+			name1: "leaf.mid.pb",
+			name2: "midleaf.pb",
+		},
+		{
+			name:  "extra segment at the front",
+			name1: "kyc.identity.pb",
+			name2: "identitykyc.pb",
+		},
+		{
+			name:  "two segments vs one",
+			name1: "aa.bb",
+			name2: "bbaa",
+		},
+	}
+
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			key1, err := GetNameKeyPrefix(tc.name1)
+			s.Require().NoError(err, "GetNameKeyPrefix(%q)", tc.name1)
+			key2, err := GetNameKeyPrefix(tc.name2)
+			s.Require().NoError(err, "GetNameKeyPrefix(%q)", tc.name2)
+			s.Assert().NotEqual(hex.EncodeToString(key1), hex.EncodeToString(key2),
+				"%q and %q are different names and must not share a store key", tc.name1, tc.name2)
 		})
 	}
 }


### PR DESCRIPTION
This PR proposes keying `x/name` records on a hash of the full name, so that two names made up of the same letters split into different segments can no longer land on one record — Fixes #2683. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/238. You can sign in with your GitHub ID to claim ownership of the project.

## The defect

`GetNameKeyPrefix` hashed the name's segments concatenated back to front with nothing between them, so `leaf.mid.pb` hashes `"pb" + "mid" + "leaf"` and `midleaf.pb` hashes `"pb" + "midleaf"` — the same bytes, and therefore the same store key. Three such pairs, run against `main` at 8d92467:

```
$ go test ./x/name/types/ -run 'TestNameKeySuite/TestNameKeyPrefixSegmentCollisions' -count=1 -v
--- FAIL: TestNameKeySuite/TestNameKeyPrefixSegmentCollisions/extra_segment_in_the_middle
    Error:    Should not be: "03def7306f705fc6861d1f0979f06ec9b62d2ad26be5a1461109218fad7d57014e"
    Messages: "leaf.mid.pb" and "midleaf.pb" are different names and must not share a store key
--- FAIL: TestNameKeySuite/TestNameKeyPrefixSegmentCollisions/extra_segment_at_the_front
    Messages: "kyc.identity.pb" and "identitykyc.pb" are different names and must not share a store key
--- FAIL: TestNameKeySuite/TestNameKeyPrefixSegmentCollisions/two_segments_vs_one
    Messages: "aa.bb" and "bbaa" are different names and must not share a store key
```

One key means one record, and the first name bound owns it. With `midleaf.name` bound to one account, the keeper answers for `leaf.mid.name` — a name nobody bound — with that account's record and no error:

```
GetRecordByName("leaf.mid.name") -> record=midleaf.name: cosmos1dmz82cgdj5ck2aslm4xcgw2u85q843zr2yfmnx, err=<nil>
NameExists("leaf.mid.name")      -> true
ResolvesTo("leaf.mid.name", owner-of-midleaf.name) -> true
```

`ResolvesTo` is the permission check behind every attribute write and delete (`x/attribute/keeper/keeper.go` lines 168, 259, 327, 394 and 457) and behind `DeleteName` (`x/name/keeper/msg_server.go:124`), so whoever binds one name of a colliding pair holds the other name's permissions. The other half is a denial: binding the second name returns `name is already bound to an address` even though it was never bound. Both names in a pair need only a shared unrestricted parent, so the pairs are reachable by ordinary `MsgBindNameRequest` calls rather than only by governance.

## The change

* `GetNameKeyPrefix` hashes the full normalized name, dots included, which is what `x/attribute` already does for its own name keys (`GetNameKeyBytes`). Segment trimming and both `ErrNameInvalid` cases are unchanged, so `" name . domain "` still keys the same as `name.domain`.
* `GetLegacyNameKeyPrefix` keeps the old derivation, only so the migration can find the existing entries.
* `Migrate2to3` rewrites the name records and the address index entries under their new keys, and the module's consensus version goes 2 → 3. Single-segment names hash to the same key as before, so only multi-segment records move. All deletes happen before any writes, and re-running the migration is a no-op.
* `x/name/spec/02_state.md` described a dot-joined list of per-label hashes, which is not what the code stored either before or after; it now matches the code.

## Verification

Baseline first on a clean `main`, then again with the change, same command each time:

```
$ go test ./x/name/... ./x/attribute/... ./internal/... -count=1
ok  github.com/provenance-io/provenance/x/name/client/cli     14.389s
ok  github.com/provenance-io/provenance/x/name/keeper         10.627s
ok  github.com/provenance-io/provenance/x/name/simulation     13.754s
ok  github.com/provenance-io/provenance/x/name/types           4.458s
ok  github.com/provenance-io/provenance/x/attribute/keeper    13.994s
... (attribute cli/rest/simulation/types and internal/... all ok)
```

Both runs are green — nothing that passed before fails now. `go build ./...` and `golangci-lint run ./x/name/...` (v2.4.0, your `.golangci.yml`) are also clean. New coverage: the collision cases above, a keeper test that binds `midleaf.name` and `leaf.mid.name` to different accounts and checks each resolves only to its own owner, a round-trip migration test that writes records under legacy keys and reads them back through the keeper afterwards, and a repeat-run test. Each of them fails against the old derivation — the keeper one with `SetNameRecord(leaf.mid.name): name is already bound to an address`.

Three existing expectations moved: `TestSetup`'s exported genesis, `TestIterateRecord`, and the reverse-lookup CLI output all pin the order records come back in, which is store-key order and necessarily changes with the key. Only the order in those expectations changed.

Worth flagging: #2411 moves this module to collections and carries the segment hash over unchanged in `HashedStringKeyCodec.ComputeHash`, so whichever lands first, the other needs the same one-line hashing change. I kept to the approach described in #2683 (hash the full name, re-key in a module migration) rather than the un-hashed key alternative, since it keeps the fixed-length keys.

## How this was managed

This work was tracked on a live board built from this repository's own issues, pull requests and milestones — 2313 stories and 46 labels: the story is [Use hashed name for key instead of just the segments](https://eastagiletracker.com/projects/238/stories/116895) and the board it lives on is at https://eastagiletracker.com/projects/238.

![board](https://raw.githubusercontent.com/eastagiletracker/provenance/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented collisions between names with identical labels arranged in different segments.
  * Improved name lookups so each distinct name resolves only to its correct owner.
  * Preserved independent records when one of multiple similarly structured names is deleted.
  * Normalized name handling by ignoring surrounding whitespace.

* **Migrations**
  * Added automatic migration support for existing name records and address indexes, preserving lookup behavior during upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->