### PR TITLE
Fix heighliner Github action and speed up docker actions.

### DIFF
--- a/.changelog/unreleased/bug-fixes/2833-faster-docker-action.md
+++ b/.changelog/unreleased/bug-fixes/2833-faster-docker-action.md
@@ -1,0 +1,1 @@
+* Fix the heighliner docker build GitHub action [PR 2833](https://github.com/provenance-io/provenance/pull/2833).

--- a/.changelog/unreleased/improvements/2833-faster-docker-action.md
+++ b/.changelog/unreleased/improvements/2833-faster-docker-action.md
@@ -1,0 +1,1 @@
+* Use an arm runner to build the arm docker images [PR 2833](https://github.com/provenance-io/provenance/pull/2833).

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,8 +73,14 @@ jobs:
             - "GO_VERSION=1.25"
           skip: ${{ github.event_name == 'pull_request' }}
 
-  docker:
-    runs-on: ubuntu-latest
+  docker-build:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+    runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v7
 
@@ -85,8 +91,6 @@ jobs:
       - run: go mod vendor
 
       - uses: docker/setup-buildx-action@v4
-
-      - uses: docker/setup-qemu-action@v4
 
       - uses: docker/metadata-action@v6
         id: meta
@@ -102,19 +106,84 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Set platform pair
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+
       - uses: docker/build-push-action@v7
+        id: build
         with:
           context: .
           target: run
           build-args: |
             VERSION=${{ steps.meta.outputs.version }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           file: docker/blockchain/Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          outputs: ${{ github.event_name == 'pull_request' && 'type=cacheonly' || format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', env.DOCKER_IMAGE) }}
 
-  ghcr-publish:
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  docker:
+    needs: docker-build
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: docker-digests-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/metadata-action@v6
+        id: meta
+        with:
+          images: ${{ env.DOCKER_IMAGE }}
+          tags: |
+            type=edge
+            type=ref,event=pr
+            type=ref,event=tag
+
+      - uses: docker/login-action@v4.6.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.DOCKER_IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: docker buildx imagetools inspect ${{ env.DOCKER_IMAGE }}:${{ steps.meta.outputs.version }}
+
+  ghcr-build:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+    runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     permissions:
       contents: read
       packages: write
@@ -128,8 +197,6 @@ jobs:
       - run: go mod vendor
 
       - uses: docker/setup-buildx-action@v4
-
-      - uses: docker/setup-qemu-action@v4
 
       - uses: docker/metadata-action@v6
         id: meta
@@ -150,14 +217,81 @@ jobs:
           username: 129784868+provenanceio-bot@users.noreply.github.com
           password: ${{ secrets.BOT_GHCR_PAT }}
 
+      - name: Set platform pair
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+
       - uses: docker/build-push-action@v7
+        id: build
         with:
           context: .
           target: run
           build-args: |
             VERSION=${{ steps.meta.outputs.version }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           file: docker/blockchain/Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          outputs: ${{ github.event_name == 'pull_request' && 'type=cacheonly' || format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', env.GHCR_IMAGE) }}
+
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ghcr-digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  ghcr-publish:
+    needs: ghcr-build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: ghcr-digests-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/metadata-action@v6
+        id: meta
+        with:
+          images: ${{ env.GHCR_IMAGE }}
+          tags: |
+            type=edge
+            type=ref,event=pr
+            type=ref,event=tag
+          labels: |
+            org.opencontainers.image.source=https://github.com/provenance-io/provenance
+            org.opencontainers.image.description=Provenance Blockchain Node
+            org.opencontainers.image.licenses=Apache-2.0
+
+      - uses: docker/login-action@v4.6.0
+        with:
+          registry: ghcr.io
+          username: 129784868+provenanceio-bot@users.noreply.github.com
+          password: ${{ secrets.BOT_GHCR_PAT }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.GHCR_IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: docker buildx imagetools inspect ${{ env.GHCR_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -120,17 +120,17 @@ jobs:
             VERSION=${{ steps.meta.outputs.version }}
           platforms: ${{ matrix.platform }}
           file: docker/blockchain/Dockerfile
-          outputs: ${{ format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', env.DOCKER_IMAGE) }} # TEMP-TEST: force push-by-digest on PR, revert before merge
+          outputs: ${{ github.event_name == 'pull_request' && 'type=cacheonly' || format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', env.DOCKER_IMAGE) }}
 
       - name: Export digest
-        if: true # TEMP-TEST: force run on PR, revert before merge
+        if: github.event_name != 'pull_request'
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        if: true # TEMP-TEST: force run on PR, revert before merge
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: docker-digests-${{ env.PLATFORM_PAIR }}
@@ -140,7 +140,7 @@ jobs:
 
   docker:
     needs: docker-build
-    if: true # TEMP-TEST: force run on PR, revert before merge
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Download digests
@@ -232,17 +232,17 @@ jobs:
           platforms: ${{ matrix.platform }}
           file: docker/blockchain/Dockerfile
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: ${{ format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', env.GHCR_IMAGE) }} # TEMP-TEST: force push-by-digest on PR, revert before merge
+          outputs: ${{ github.event_name == 'pull_request' && 'type=cacheonly' || format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', env.GHCR_IMAGE) }}
 
       - name: Export digest
-        if: true # TEMP-TEST: force run on PR, revert before merge
+        if: github.event_name != 'pull_request'
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        if: true # TEMP-TEST: force run on PR, revert before merge
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: ghcr-digests-${{ env.PLATFORM_PAIR }}
@@ -252,7 +252,7 @@ jobs:
 
   ghcr-publish:
     needs: ghcr-build
-    if: true # TEMP-TEST: force run on PR, revert before merge
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -120,17 +120,17 @@ jobs:
             VERSION=${{ steps.meta.outputs.version }}
           platforms: ${{ matrix.platform }}
           file: docker/blockchain/Dockerfile
-          outputs: ${{ github.event_name == 'pull_request' && 'type=cacheonly' || format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', env.DOCKER_IMAGE) }}
+          outputs: ${{ format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', env.DOCKER_IMAGE) }} # TEMP-TEST: force push-by-digest on PR, revert before merge
 
       - name: Export digest
-        if: github.event_name != 'pull_request'
+        if: true # TEMP-TEST: force run on PR, revert before merge
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        if: github.event_name != 'pull_request'
+        if: true # TEMP-TEST: force run on PR, revert before merge
         uses: actions/upload-artifact@v4
         with:
           name: docker-digests-${{ env.PLATFORM_PAIR }}
@@ -140,7 +140,7 @@ jobs:
 
   docker:
     needs: docker-build
-    if: github.event_name != 'pull_request'
+    if: true # TEMP-TEST: force run on PR, revert before merge
     runs-on: ubuntu-latest
     steps:
       - name: Download digests
@@ -232,17 +232,17 @@ jobs:
           platforms: ${{ matrix.platform }}
           file: docker/blockchain/Dockerfile
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: ${{ github.event_name == 'pull_request' && 'type=cacheonly' || format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', env.GHCR_IMAGE) }}
+          outputs: ${{ format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', env.GHCR_IMAGE) }} # TEMP-TEST: force push-by-digest on PR, revert before merge
 
       - name: Export digest
-        if: github.event_name != 'pull_request'
+        if: true # TEMP-TEST: force run on PR, revert before merge
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        if: github.event_name != 'pull_request'
+        if: true # TEMP-TEST: force run on PR, revert before merge
         uses: actions/upload-artifact@v4
         with:
           name: ghcr-digests-${{ env.PLATFORM_PAIR }}
@@ -252,7 +252,7 @@ jobs:
 
   ghcr-publish:
     needs: ghcr-build
-    if: github.event_name != 'pull_request'
+    if: true # TEMP-TEST: force run on PR, revert before merge
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,6 +49,7 @@ jobs:
             type=ref,event=tag
 
       - uses: docker/login-action@v4.6.0
+        if: github.event_name != 'pull_request'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,7 +56,8 @@ jobs:
       # lock to "linux/amd64" only for now since cross compilation is throwing errors
       - uses: amygdala-labs/heighliner-build-action@main
         with:
-          heighliner-tag: v1.7.5
+          heighliner-owner: amygdala-labs
+          heighliner-tag: v1.7.6
           chain: provenance
           local: true
           tag: ${{ steps.meta.outputs.version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,7 +54,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # lock to "linux/amd64" only for now since cross compilation is throwing errors
-      - uses: strangelove-ventures/heighliner-build-action@main
+      - uses: amygdala-labs/heighliner-build-action@main
         with:
           heighliner-tag: v1.7.5
           chain: provenance

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,8 +56,7 @@ jobs:
       # lock to "linux/amd64" only for now since cross compilation is throwing errors
       - uses: amygdala-labs/heighliner-build-action@main
         with:
-          heighliner-owner: amygdala-labs
-          heighliner-tag: v1.7.6
+          heighliner-tag: v1.7.5
           chain: provenance
           local: true
           tag: ${{ steps.meta.outputs.version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -138,6 +138,7 @@ jobs:
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
+          overwrite: true
 
   docker:
     needs: docker-build
@@ -251,6 +252,7 @@ jobs:
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
+          overwrite: true
 
   ghcr-publish:
     needs: ghcr-build

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -102,6 +102,7 @@ jobs:
             type=ref,event=tag
 
       - uses: docker/login-action@v4.6.0
+        if: github.event_name != 'pull_request'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -212,6 +213,7 @@ jobs:
             org.opencontainers.image.licenses=Apache-2.0
 
       - uses: docker/login-action@v4.6.0
+        if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io
           username: 129784868+provenanceio-bot@users.noreply.github.com
@@ -275,10 +277,6 @@ jobs:
             type=edge
             type=ref,event=pr
             type=ref,event=tag
-          labels: |
-            org.opencontainers.image.source=https://github.com/provenance-io/provenance
-            org.opencontainers.image.description=Provenance Blockchain Node
-            org.opencontainers.image.licenses=Apache-2.0
 
       - uses: docker/login-action@v4.6.0
         with:

--- a/dockerfile/cosmos/localcross.Dockerfile
+++ b/dockerfile/cosmos/localcross.Dockerfile
@@ -1,0 +1,235 @@
+# This file exists to override Heighliner's embedded "cosmos/localcross.Dockerfile"
+# template, which hardcodes `FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.1.12`.
+# That image now 403s on an anonymous pull because the strangelove-ventures GitHub
+# org (and its ghcr.io packages) moved to amygdala-labs; the package now lives at
+# ghcr.io/amygdala-labs/infra-toolkit:v0.1.12. Heighliner's released template hasn't
+# been updated to point at the new location, so the embedded copy fails every build.
+# This is otherwise a verbatim copy of heighliner v1.7.6's embedded template with
+# only that one FROM line changed. Once upstream fixes it, this override (and its
+# directory) can be deleted.
+#
+# It must live at exactly this path: heighliner looks for a local override at
+# "<repo-root>/dockerfile/<type>/<name>.Dockerfile" (see dockerfileEmbeddedOrLocal
+# in github.com/amygdala-labs/heighliner's builder/builder.go) before falling back
+# to its embedded copy. The "dockerfile" directory name is hardcoded in heighliner
+# itself, not configurable via the action's inputs, so it can't be moved or renamed.
+ARG BASE_VERSION
+FROM --platform=$BUILDPLATFORM golang:${BASE_VERSION} AS build-env
+
+RUN apk add --update --no-cache curl make git libc-dev bash gcc linux-headers eudev-dev
+
+ARG TARGETARCH
+ARG BUILDARCH
+
+RUN if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then\
+        wget -c https://storage.googleapis.com/strangelove-public/musl/aarch64-linux-musl-cross.tgz -O - | tar -xzvv --strip-components 1 -C /usr;\
+    elif [ "${TARGETARCH}" = "amd64" ] && [ "${BUILDARCH}" != "amd64" ]; then\
+        wget -c https://storage.googleapis.com/strangelove-public/musl/x86_64-linux-musl-cross.tgz -O - | tar -xzvv --strip-components 1 -C /usr;\
+    fi
+
+ARG GITHUB_ORGANIZATION
+ARG REPO_HOST
+
+WORKDIR /go/src/${REPO_HOST}/${GITHUB_ORGANIZATION}/${GITHUB_REPO}
+
+ARG GITHUB_REPO
+ARG VERSION
+ARG BUILD_TIMESTAMP
+
+ADD . .
+
+ARG BUILD_TARGET
+ARG BUILD_ENV
+ARG BUILD_TAGS
+ARG PRE_BUILD
+ARG BUILD_DIR
+ARG WASMVM_VERSION
+
+ARG CLONE_KEY
+
+RUN if [ ! -z "${CLONE_KEY}" ]; then\
+  mkdir -p ~/.ssh;\
+  echo "${CLONE_KEY}" | base64 -d > ~/.ssh/id_ed25519;\
+  chmod 600 ~/.ssh/id_ed25519;\
+  apk add openssh;\
+  git config --global --add url."ssh://git@github.com/".insteadOf "https://github.com/";\
+  ssh-keyscan github.com >> ~/.ssh/known_hosts;\
+  fi
+
+RUN set -eux;\
+    LIBDIR=/lib;\
+    if [ "${TARGETARCH}" = "arm64" ]; then\
+      export ARCH=aarch64;\
+      if [ "${BUILDARCH}" != "arm64" ]; then\
+        LIBDIR=/usr/aarch64-linux-musl/lib;\
+        mkdir -p $LIBDIR;\
+        export CC=aarch64-linux-musl-gcc CXX=aarch64-linux-musl-g++;\
+      fi;\
+    elif [ "${TARGETARCH}" = "amd64" ]; then\
+      export ARCH=x86_64;\
+      if [ "${BUILDARCH}" != "amd64" ]; then\
+        LIBDIR=/usr/x86_64-linux-musl/lib;\
+        mkdir -p $LIBDIR;\
+        export CC=x86_64-linux-musl-gcc CXX=x86_64-linux-musl-g++;\
+      fi;\
+    fi;\
+    if [ ! -z "${WASMVM_VERSION}" ]; then\
+      WASMVM_REPO=$(echo $WASMVM_VERSION | awk '{print $1}');\
+      WASMVM_VERS=$(echo $WASMVM_VERSION | awk '{print $2}');\
+      wget -O $LIBDIR/libwasmvm_muslc.a https://${WASMVM_REPO}/releases/download/${WASMVM_VERS}/libwasmvm_muslc.${ARCH}.a;\
+      ln $LIBDIR/libwasmvm_muslc.a $LIBDIR/libwasmvm_muslc.$(uname -m).a;\
+    fi;\
+    export GOOS=linux GOARCH=$TARGETARCH CGO_ENABLED=1 LDFLAGS='-linkmode external -extldflags "-static"';\
+    if [ ! -z "$PRE_BUILD" ]; then sh -c "${PRE_BUILD}"; fi;\
+    if [ ! -z "$BUILD_TARGET" ]; then\
+      if [ ! -z "$BUILD_ENV" ]; then export ${BUILD_ENV}; fi;\
+      if [ ! -z "$BUILD_TAGS" ]; then export "${BUILD_TAGS}"; fi;\
+      if [ ! -z "$BUILD_DIR" ]; then cd "${BUILD_DIR}"; fi;\
+      sh -c "${BUILD_TARGET}";\
+    fi
+
+RUN if [ -d "/go/bin/linux_${TARGETARCH}" ]; then mv /go/bin/linux_${TARGETARCH}/* /go/bin/; fi
+
+# Copy all binaries to /root/bin, for a single place to copy into final image.
+# If a colon (:) delimiter is present, binary will be renamed to the text after the delimiter.
+RUN mkdir /root/bin
+ARG RACE
+ARG BINARIES
+ENV BINARIES_ENV ${BINARIES}
+RUN bash -c 'set -eux;\
+  BINARIES_ARR=();\
+  IFS=, read -ra BINARIES_ARR <<< "$BINARIES_ENV";\
+  for BINARY in "${BINARIES_ARR[@]}"; do\
+    BINSPLIT=();\
+    IFS=: read -ra BINSPLIT <<< "$BINARY";\
+    BINPATH=${BINSPLIT[1]+"${BINSPLIT[1]}"};\
+    BIN="$(eval "echo "${BINSPLIT[0]+"${BINSPLIT[0]}"}"")";\
+    if [ ! -z "$RACE" ] && GOVERSIONOUT=$(go version -m $BIN); then\
+      if echo $GOVERSIONOUT | grep build | grep "-race=true"; then\
+        echo "Race detection is enabled in binary";\
+      else\
+        echo "Race detection not enabled in binary!";\
+        exit 1;\
+      fi;\
+    fi;\
+    if [ ! -z "$BINPATH" ]; then\
+      if [[ $BINPATH == *"/"* ]]; then\
+        mkdir -p "$(dirname "${BINPATH}")";\
+        cp "$BIN" "${BINPATH}";\
+      else\
+        cp "$BIN" "/root/bin/${BINPATH}";\
+      fi;\
+    else\
+      cp "$BIN" /root/bin/;\
+    fi;\
+  done'
+
+RUN mkdir -p /root/lib
+ARG LIBRARIES
+ENV LIBRARIES_ENV ${LIBRARIES}
+RUN bash -c 'set -eux;\
+  LIBRARIES_ARR=($LIBRARIES_ENV); for LIBRARY in "${LIBRARIES_ARR[@]}"; do cp $LIBRARY /root/lib/; done'
+
+# Copy over directories
+RUN mkdir -p /root/dir_abs && touch /root/dir_abs.list
+ARG DIRECTORIES
+ENV DIRECTORIES_ENV ${DIRECTORIES}
+RUN bash -c 'set -eux;\
+  DIRECTORIES_ARR=($DIRECTORIES_ENV);\
+  i=0;\
+  for DIRECTORY in "${DIRECTORIES_ARR[@]}"; do \
+    cp -R $DIRECTORY /root/dir_abs/$i;\
+    echo $DIRECTORY >> /root/dir_abs.list;\
+    ((i = i + 1));\
+  done'
+
+# Use minimal busybox from infra-toolkit image for final scratch image
+# NOTE: repointed from ghcr.io/strangelove-ventures/infra-toolkit (403s anonymously
+# since the org moved) to the same image under its new home, ghcr.io/amygdala-labs.
+FROM ghcr.io/amygdala-labs/infra-toolkit:v0.1.12 AS infra-toolkit
+RUN addgroup --gid 1025 -S heighliner && adduser --uid 1025 -S heighliner -G heighliner
+
+# Use alpine to source the latest CA certificates
+FROM alpine:3 as alpine-3
+
+# Build final image from scratch
+FROM scratch
+
+LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/heighliner"
+
+WORKDIR /bin
+
+# Install minimal busybox as `sh` and `ln` binaries
+# sh allows using `RUN` commands
+COPY --from=infra-toolkit /busybox/busybox /bin/sh
+# ln creates hardlinks for exposed binaries from infra-toolkit min config
+COPY --from=infra-toolkit /busybox/busybox /bin/ln
+
+# Install jq
+COPY --from=infra-toolkit /usr/local/bin/jq /bin/
+
+# Add hard links for utils
+# Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode
+RUN for b in \
+  cat \
+  date \
+  df \
+  dirname \
+  du \
+  env \
+  grep \
+  head \
+  less \
+  ls \
+  md5sum \
+  mkdir \
+  mv \
+  pwd \
+  rm \
+  sed \
+  sha1sum \
+  sha256sum \
+  sha3sum \
+  sha512sum \
+  sleep \
+  stty \
+  tail \
+  tar \
+  tee \
+  tr \
+  vi \
+  watch \
+  which \
+  ; do ln ln $b; done; \
+  rm -rf sh; \
+  ln ln sh;
+
+# Copy over absolute path directories
+COPY --from=build-env /root/dir_abs /root/dir_abs
+COPY --from=build-env /root/dir_abs.list /root/dir_abs.list
+
+# Move absolute path directories to their absolute locations.
+RUN sh -c 'i=0; while read DIR; do\
+      echo "$i: $DIR";\
+      PLACEDIR="$(dirname "$DIR")";\
+      mkdir -p "$PLACEDIR";\
+      mv /root/dir_abs/$i $DIR;\
+      i=$((i+1));\
+    done < /root/dir_abs.list'
+
+# Install chain binaries
+COPY --from=build-env /root/bin /bin
+
+# Install libraries
+COPY --from=build-env /root/lib /lib
+
+# Install trusted CA certificates
+COPY --from=alpine-3 /etc/ssl/cert.pem /etc/ssl/cert.pem
+
+# Install heighliner user
+COPY --from=infra-toolkit /etc/passwd /etc/passwd
+COPY --from=infra-toolkit --chown=1025:1025 /home/heighliner /home/heighliner
+COPY --from=infra-toolkit --chown=1025:1025 /tmp /tmp
+
+WORKDIR /home/heighliner
+USER heighliner

--- a/dockerfile/cosmos/localcross.Dockerfile
+++ b/dockerfile/cosmos/localcross.Dockerfile
@@ -13,6 +13,8 @@
 # in github.com/amygdala-labs/heighliner's builder/builder.go) before falling back
 # to its embedded copy. The "dockerfile" directory name is hardcoded in heighliner
 # itself, not configurable via the action's inputs, so it can't be moved or renamed.
+#
+# TODO: https://github.com/provenance-io/provenance/issues/2835 Check if this file can be deleted.
 ARG BASE_VERSION
 FROM --platform=$BUILDPLATFORM golang:${BASE_VERSION} AS build-env
 


### PR DESCRIPTION
## Description

Update the docker Github actions to make them all finish faster. Also, fix the heighliner docker build job that broke due to upstream reorganization.

Before this PR, we were using QEMU to build the arm docker image on an amd runner. That was what was taking so long. With this PR, the builds are split into a matrix so that we build amd on an amd runner, and arm on an arm runner. Once those are done, the manifest is updated using another job.

The `docker` job was split into a `build-docker` matrix job and `docker` finishing job.
The `ghcr-publish` job was also split into a `ghcr-build` matrix job and `ghcr-publish finishing job.
The `heighliner-docker` job was not changed.

A run now takes about 6 minutes (used to take 55).

One change to call it is that the new `docker` and `ghcr-publish` jobs no longer run for PRs; they'll show as skipped. Previously, since those jobs did all parts, they'd still run, they just wouldn't upload anything. But now each PR will have two `docker-build` entries (one for arm, one for amd), and two similar `ghcr-build` entries.

---

This PR also fixes the heighliner docker build job. It broke because the organization changed to `amygdala-labs` (from `strangelove-ventures`). As part of the heighliner build step, it was trying to dowload an old `strangelove-ventures` set of utils which has moved to the `amygdala-labs` organization. Trying to get it from the old location was resulting in a 403 error. The fix was to create our own `dockerfile/cosmos/localcross.Dockerfile` file with the fixed utils location. The file had to go in that location and be named that way in order for the action to recognize it (there's no option/field for defining it). Hopefully, we only have this file temporarily, and we can remove it once Amygdala Labs fixes it on their side.

With this PR, I also created issue #2835 to clean up the heighliner docker file once we don't need it in this repo anymore.

I also created a PR with Amygdala Labs to fix the action:
* https://github.com/amygdala-labs/heighliner/issues/346

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores

- Docker images are now built independently for Linux AMD64 and ARM64 platforms.
- ARM images are built using ARM runners for faster image creation.
- Multi-architecture image manifests are automatically assembled and published to Docker Hub and GitHub Container Registry.
- Pull request builds use cache-only workflows, while release builds publish and verify platform-specific images.
- Registry authentication and image metadata handling have been streamlined.
- Docker build tooling has been updated to support the latest image-building workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->