### PR TITLE
Bump Cosmos-sdk to v0.53.8-pio-2 (from v0.53.8-pio-1).

### DIFF
--- a/.changelog/unreleased/dependencies/2839-bump-sdk.md
+++ b/.changelog/unreleased/dependencies/2839-bump-sdk.md
@@ -1,0 +1,1 @@
+* `github.com/cosmos/cosmos-sdk` bumped to v0.53.8-pio-2 of `github.com/provenance-io/cosmos-sdk` (from v0.53.8-pio-1 of `github.com/provenance-io/cosmos-sdk`) [PR 2839](https://github.com/provenance-io/provenance/pull/2839).

--- a/go.mod
+++ b/go.mod
@@ -428,7 +428,7 @@ replace (
 	// This is required for https://github.com/provenance-io/provenance/issues/1414
 	github.com/CosmWasm/wasmd => github.com/provenance-io/wasmd v0.61.10-pio-2
 
-	github.com/cosmos/cosmos-sdk => github.com/provenance-io/cosmos-sdk v0.53.8-pio-1
+	github.com/cosmos/cosmos-sdk => github.com/provenance-io/cosmos-sdk v0.53.8-pio-2
 
 	// Replace iavl to fix the prune command. This can be removed once upstream is off v1.2.2
 	github.com/cosmos/iavl => github.com/cosmos/iavl v1.2.6

--- a/go.sum
+++ b/go.sum
@@ -1011,8 +1011,8 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.3.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.21.1 h1:GljZCt+zSTS+NZq88cyQ1LjZ+RCHp3uVuabBWA5+OJI=
 github.com/prometheus/procfs v0.21.1/go.mod h1:aB55Cww9pdSJVHk0hUf0inxWyyjPogFIjmHKYgMKmtY=
-github.com/provenance-io/cosmos-sdk v0.53.8-pio-1 h1:5dKqG4Utb6s79uafWi62185PA2Faj/xRX3kbQaVJsSA=
-github.com/provenance-io/cosmos-sdk v0.53.8-pio-1/go.mod h1:b/De6uhCfooGEy4kE5G4C0A+MxK9aPr0nZNMyR+PmY0=
+github.com/provenance-io/cosmos-sdk v0.53.8-pio-2 h1:H10JaP6Ys62dwafm7uGAtKzhu9PHWe8b90ivK/0dW3Q=
+github.com/provenance-io/cosmos-sdk v0.53.8-pio-2/go.mod h1:b/De6uhCfooGEy4kE5G4C0A+MxK9aPr0nZNMyR+PmY0=
 github.com/provenance-io/wasmd v0.61.10-pio-2 h1:uc0gDj31d2S4010dIy+rtI6RawUzsZ60i0BXcUT2gEk=
 github.com/provenance-io/wasmd v0.61.10-pio-2/go.mod h1:GMPqtsb1T8FvaKpQGJmGuj/JMPXBauk4ZhUErgmtEus=
 github.com/provlabs/vault v1.2.4 h1:EdcSfMy6uql2mMDv0VpCy5xfpHsUAATB1OH8Gq5wLo0=


### PR DESCRIPTION
## Description

This PR bumps the Cosmos-SDK to `v0.53.8-pio-2` (from `v0.53.8-pio-1`). This fixes the feegrant revoke endpoint so that it properly deletes the deletion queue entry.


---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#pr-targeting)).
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration [tests](https://github.com/provenance-io/provenance/blob/main/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`).
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added relevant changelog entries under `.changelog/unreleased` (see [Adding Changes](https://github.com/provenance-io/provenance/blob/main/.changelog/README.md#adding-changes)).
- [x] Re-reviewed `Files changed` in the Github PR explorer.
- [ ] Review `Codecov Report` in the comment section below once CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the Cosmos SDK integration to Provenance fork release v0.53.8-pio-2.
  - This update keeps the application aligned with the latest supported SDK fork version.
  - Added a changelog entry documenting the SDK update and associated release reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->